### PR TITLE
feat(remote-browser): pin egress sockets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,40 @@ jobs:
         run: |
           pytest tests/ -v --tb=short -m "not slow and not real_api and not network"
 
+  # The Remote Browser gateway is a security boundary built directly on each
+  # platform's asyncio/TCP implementation. Keep its small focused suite on every
+  # supported Python and OS instead of treating one green Linux socket as proof
+  # for Proactor Windows or Darwin close/shutdown behavior.
+  remote-browser-egress:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run destination policy and native loopback gateway contracts
+        run: |
+          python -m pytest tests/unit/test_remote_browser_destination_policy.py tests/unit/test_remote_browser_egress_gateway.py -v --tb=short
+
   # Validate the native Windows browser IPC (named-pipe daemon transport) — the
   # `co browser` daemon uses Unix sockets on POSIX and Windows named pipes here.
   # These tests use a StubBrowser, so no Chrome/network is needed; they exercise the

--- a/connectonion/network/host/egress_gateway.py
+++ b/connectonion/network/host/egress_gateway.py
@@ -16,7 +16,7 @@ import math
 import re
 import secrets
 import socket
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Iterable, Sequence
 from urllib.parse import urlsplit, urlunsplit
 
@@ -60,6 +60,13 @@ _ERROR_STATUS = {
 }
 
 
+@dataclass
+class _Admission:
+    """Whether this connection has converted a pending slot into a served one."""
+
+    promoted: bool = False
+
+
 class GatewayRefusal(Exception):
     """Stable internal refusal containing no caller-controlled value."""
 
@@ -82,6 +89,11 @@ class GatewayLimits:
     bytes_per_direction: int = 128 * 1024 * 1024
     max_connections: int = 32
     max_dns_answers: int = 32
+    # Sockets waiting to prove they hold the credential are counted separately.
+    # Sharing one budget lets any local process that connects and says nothing
+    # hold slots for the whole header timeout, and the browser's only route to
+    # the internet is this gateway.
+    max_pending_connections: int = 128
 
     def __post_init__(self) -> None:
         integer_values = (
@@ -91,6 +103,7 @@ class GatewayLimits:
             self.bytes_per_direction,
             self.max_connections,
             self.max_dns_answers,
+            self.max_pending_connections,
         )
         durations = (
             self.header_timeout,
@@ -111,6 +124,8 @@ class GatewayLimits:
             raise ValueError("gateway limits must be positive")
         if self.request_line_bytes > self.header_bytes:
             raise ValueError("request line limit exceeds header limit")
+        if self.max_pending_connections < self.max_connections:
+            raise ValueError("pending budget is smaller than the connection limit")
 
 
 @dataclass(frozen=True)
@@ -118,7 +133,10 @@ class ProxyEndpoint:
     host: str
     port: int
     username: str
-    password: str
+    # Kept out of the repr so a traceback, a debug line, or a structured dump of
+    # this object cannot publish the credential. The rule that nothing logs it
+    # is easier to keep when there is nothing to log.
+    password: str = field(repr=False)
 
 
 @dataclass(frozen=True)
@@ -256,6 +274,7 @@ class EgressGateway:
         self._port: int | None = None
         self._closing = False
         self._active = 0
+        self._pending = 0
         self._lifecycle_lock = asyncio.Lock()
         self._state_lock = asyncio.Lock()
         self._client_tasks: set[asyncio.Task] = set()
@@ -324,6 +343,16 @@ class EgressGateway:
     async def __aexit__(self, *_exc) -> None:
         await self.stop()
 
+    async def _promote(self, admission: _Admission) -> None:
+        """Take a served-connection slot, now that the credential is proven."""
+        async with self._state_lock:
+            if self._closing:
+                raise GatewayRefusal(GATEWAY_STOPPING)
+            if self._active >= self.limits.max_connections:
+                raise GatewayRefusal(OVERLOADED)
+            self._active += 1
+            admission.promoted = True
+
     async def _accept(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
@@ -331,10 +360,14 @@ class EgressGateway:
         if task is not None:
             self._client_tasks.add(task)
         admitted = False
+        admission = _Admission()
         try:
             async with self._state_lock:
-                if not self._closing and self._active < self.limits.max_connections:
-                    self._active += 1
+                if (
+                    not self._closing
+                    and self._pending < self.limits.max_pending_connections
+                ):
+                    self._pending += 1
                     admitted = True
             if not admitted:
                 await self._send_error(
@@ -348,7 +381,7 @@ class EgressGateway:
                         reader.read(self.limits.header_bytes + 1), timeout=0.05
                     )
                 return
-            await self._serve_connection(reader, writer)
+            await self._serve_connection(reader, writer, admission)
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -359,7 +392,9 @@ class EgressGateway:
         finally:
             if admitted:
                 async with self._state_lock:
-                    self._active -= 1
+                    self._pending -= 1
+                    if admission.promoted:
+                        self._active -= 1
             writer.close()
             with contextlib.suppress(Exception):
                 await writer.wait_closed()
@@ -367,11 +402,15 @@ class EgressGateway:
                 self._client_tasks.discard(task)
 
     async def _serve_connection(
-        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        admission: _Admission,
     ) -> None:
         try:
             request = await self._read_request(reader)
             self._authenticate(request)
+            await self._promote(admission)
             authority, origin_target, upgrade = self._request_destination(request)
             endpoints = await self._approved_endpoints(authority)
             upstream_reader, upstream_writer = await self._connect(endpoints)
@@ -398,11 +437,10 @@ class EgressGateway:
                 await self._tunnel(reader, writer, upstream_reader, upstream_writer)
                 return
             if content_length:
-                body = await self._read_exactly(reader, content_length)
-                upstream_writer.write(body)
-                await self._drain(upstream_writer)
+                await self._stream_body(reader, upstream_writer, content_length)
             with contextlib.suppress(NotImplementedError, OSError):
                 upstream_writer.write_eof()
+            await self._relay_response_head(upstream_reader, writer)
             await self._copy(upstream_reader, writer)
         except (GatewayRefusal, ConnectionError, OSError):
             # Upstream establishment succeeded, so either side may already have
@@ -495,7 +533,13 @@ class EgressGateway:
             return authority, None, False
 
         split = self._safe_split(request.target)
-        if split.fragment or split.scheme.lower() not in {"http", "ws"}:
+        # A fragment is never sent on the wire, so a target carrying one is a
+        # malformed request rather than a scheme this gateway declines. The
+        # distinction only shows up when someone reads the code and goes looking
+        # at scheme policy for a target whose scheme was fine.
+        if split.fragment:
+            raise GatewayRefusal(INVALID)
+        if split.scheme.lower() not in {"http", "ws"}:
             raise GatewayRefusal(SCHEME_DENIED if split.scheme else INVALID)
         authority = normalize_web_destination(
             request.target, allowed_ports=self.allowed_ports
@@ -582,6 +626,13 @@ class EgressGateway:
             except (asyncio.TimeoutError, OSError):
                 resolution_failed = True
                 answers = ()
+            except Exception:
+                # Resolver is pluggable. Whatever a custom one raises, the
+                # caller gets the same refusal — a resolver failure that closed
+                # the connection with no response at all left the operator
+                # nothing to read and the client nothing to distinguish.
+                resolution_failed = True
+                answers = ()
             if resolution_failed:
                 raise GatewayRefusal(DNS_FAILED)
         if not answers or len(answers) > self.limits.max_dns_answers:
@@ -651,17 +702,79 @@ class EgressGateway:
         lines.append("Connection: Upgrade" if upgrade else "Connection: close")
         return ("\r\n".join(lines) + "\r\n\r\n").encode("ascii")
 
-    async def _read_exactly(self, reader: asyncio.StreamReader, count: int) -> bytes:
-        body = None
+    async def _relay_response_head(
+        self, upstream: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        """Forward the response head with connection reuse taken away.
+
+        The gateway answers exactly one request per connection and then stops
+        reading. An origin that replies `Connection: keep-alive` would leave the
+        client believing otherwise — and a second response queued behind the
+        first would already be in the client's receive buffer, waiting to be
+        matched against whatever it sends next. Rewriting the hop-by-hop
+        headers here is what makes the one-request-per-connection rule visible
+        to the client instead of only true inside the gateway.
+        """
+        head = None
         try:
-            body = await asyncio.wait_for(
-                reader.readexactly(count), timeout=self.limits.idle_timeout
+            head = await asyncio.wait_for(
+                upstream.readuntil(b"\r\n\r\n"), timeout=self.limits.idle_timeout
             )
-        except (asyncio.TimeoutError, asyncio.IncompleteReadError):
+        except (
+            asyncio.TimeoutError,
+            asyncio.IncompleteReadError,
+            asyncio.LimitOverrunError,
+        ):
             pass
-        if body is None:
+        if head is None or len(head) > self.limits.header_bytes:
+            # An unparseable or oversized head cannot be made safe, and passing
+            # it through is what this function exists to prevent.
             raise GatewayRefusal(TRANSFER_LIMIT)
-        return body
+
+        lines = head.decode("latin-1").split("\r\n")
+        rewritten = [lines[0]]
+        for line in lines[1:]:
+            name, separator, _ = line.partition(":")
+            if not separator:
+                continue
+            if name.strip().lower() in {"connection", "keep-alive", "proxy-connection"}:
+                continue
+            rewritten.append(line)
+        rewritten.append("Connection: close")
+        writer.write(("\r\n".join(rewritten) + "\r\n\r\n").encode("latin-1"))
+        await self._drain(writer)
+
+    async def _stream_body(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        count: int,
+    ) -> None:
+        """Forward a declared body in bounded chunks.
+
+        `Content-Length` is caller-controlled, so reading it in one call sizes a
+        resident buffer from a number a stranger chose: one connection declaring
+        the transfer limit holds that many bytes in RAM, times the connection
+        cap. Chunks bound the memory to the chunk size regardless of the
+        declaration; the transfer limit still bounds the total.
+        """
+        if count > self.limits.bytes_per_direction:
+            raise GatewayRefusal(TRANSFER_LIMIT)
+        remaining = count
+        while remaining:
+            chunk = None
+            try:
+                chunk = await asyncio.wait_for(
+                    reader.read(min(remaining, 64 * 1024)),
+                    timeout=self.limits.idle_timeout,
+                )
+            except asyncio.TimeoutError:
+                pass
+            if not chunk:
+                raise GatewayRefusal(TRANSFER_LIMIT)
+            remaining -= len(chunk)
+            writer.write(chunk)
+            await self._drain(writer)
 
     async def _copy(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter

--- a/connectonion/network/host/egress_gateway.py
+++ b/connectonion/network/host/egress_gateway.py
@@ -1,0 +1,736 @@
+"""Bounded loopback egress gateway for future Remote Browser navigation.
+
+The gateway owns hostname resolution and numeric socket selection.  It has no
+Chromium integration and is not reachable through OIP yet; keeping that seam
+closed lets the proxy boundary be tested before a browser can depend on it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import hmac
+import ipaddress
+import math
+import re
+import secrets
+import socket
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Iterable, Sequence
+from urllib.parse import urlsplit, urlunsplit
+
+from .destination_policy import (
+    ADDRESS_DENIED,
+    DNS_FAILED,
+    HOST_DENIED,
+    INVALID,
+    PORT_DENIED,
+    SCHEME_DENIED,
+    DestinationAuthority,
+    DestinationPolicyError,
+    decide_destination,
+    normalize_web_destination,
+)
+
+HEADER_TIMEOUT = "EGRESS_HEADER_TIMEOUT"
+HEADER_TOO_LARGE = "EGRESS_HEADER_TOO_LARGE"
+AUTH_REQUIRED = "EGRESS_AUTH_REQUIRED"
+OVERLOADED = "EGRESS_OVERLOADED"
+CONNECT_FAILED = "EGRESS_CONNECT_FAILED"
+TRANSFER_LIMIT = "EGRESS_TRANSFER_LIMIT"
+GATEWAY_STOPPING = "EGRESS_GATEWAY_STOPPING"
+
+_HEADER_NAME = re.compile(rb"[!#$%&'*+.^_`|~0-9A-Za-z-]+")
+_METHOD = re.compile(rb"[A-Z][A-Z0-9!#$%&'*+.^_`|~-]{0,31}")
+_ERROR_STATUS = {
+    INVALID: (400, "Bad Request"),
+    SCHEME_DENIED: (403, "Forbidden"),
+    PORT_DENIED: (403, "Forbidden"),
+    ADDRESS_DENIED: (403, "Forbidden"),
+    HOST_DENIED: (403, "Forbidden"),
+    DNS_FAILED: (502, "Bad Gateway"),
+    HEADER_TIMEOUT: (408, "Request Timeout"),
+    HEADER_TOO_LARGE: (431, "Request Header Fields Too Large"),
+    AUTH_REQUIRED: (407, "Proxy Authentication Required"),
+    OVERLOADED: (429, "Too Many Requests"),
+    CONNECT_FAILED: (502, "Bad Gateway"),
+    TRANSFER_LIMIT: (413, "Content Too Large"),
+    GATEWAY_STOPPING: (503, "Service Unavailable"),
+}
+
+
+class GatewayRefusal(Exception):
+    """Stable internal refusal containing no caller-controlled value."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class GatewayLimits:
+    """Hard per-instance and per-connection limits."""
+
+    header_bytes: int = 16 * 1024
+    request_line_bytes: int = 4 * 1024
+    header_count: int = 100
+    header_timeout: float = 5.0
+    resolve_timeout: float = 5.0
+    connect_timeout: float = 10.0
+    idle_timeout: float = 60.0
+    bytes_per_direction: int = 128 * 1024 * 1024
+    max_connections: int = 32
+    max_dns_answers: int = 32
+
+    def __post_init__(self) -> None:
+        integer_values = (
+            self.header_bytes,
+            self.request_line_bytes,
+            self.header_count,
+            self.bytes_per_direction,
+            self.max_connections,
+            self.max_dns_answers,
+        )
+        durations = (
+            self.header_timeout,
+            self.resolve_timeout,
+            self.connect_timeout,
+            self.idle_timeout,
+        )
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) or value <= 0
+            for value in integer_values
+        ) or any(
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(value)
+            or value <= 0
+            for value in durations
+        ):
+            raise ValueError("gateway limits must be positive")
+        if self.request_line_bytes > self.header_bytes:
+            raise ValueError("request line limit exceeds header limit")
+
+
+@dataclass(frozen=True)
+class ProxyEndpoint:
+    host: str
+    port: int
+    username: str
+    password: str
+
+
+@dataclass(frozen=True)
+class NumericEndpoint:
+    family: int
+    address: str
+    port: int
+
+    def __post_init__(self) -> None:
+        try:
+            address = ipaddress.ip_address(self.address)
+        except (TypeError, ValueError):
+            raise ValueError("numeric endpoint address is invalid") from None
+        expected = socket.AF_INET if address.version == 4 else socket.AF_INET6
+        if (
+            self.family != expected
+            or str(address) != self.address
+            or isinstance(self.port, bool)
+            or not isinstance(self.port, int)
+            or not 1 <= self.port <= 65535
+        ):
+            raise ValueError("numeric endpoint is not canonical")
+
+    @property
+    def sockaddr(self) -> tuple:
+        if self.family == socket.AF_INET:
+            return (self.address, self.port)
+        return (self.address, self.port, 0, 0)
+
+
+@dataclass(frozen=True)
+class ProxyRequest:
+    method: str
+    target: str
+    headers: tuple[tuple[str, str], ...]
+
+    def values(self, name: str) -> tuple[str, ...]:
+        lowered = name.lower()
+        return tuple(value for key, value in self.headers if key == lowered)
+
+
+Resolver = Callable[[str, int], Awaitable[Sequence[str]]]
+Dialer = Callable[
+    [NumericEndpoint, float],
+    Awaitable[tuple[asyncio.StreamReader, asyncio.StreamWriter]],
+]
+
+
+async def resolve_system(host: str, port: int) -> Sequence[str]:
+    """Resolve one hostname once; callers own timeout and answer bounds."""
+    loop = asyncio.get_running_loop()
+    answers = await loop.getaddrinfo(
+        host,
+        port,
+        family=socket.AF_UNSPEC,
+        type=socket.SOCK_STREAM,
+        proto=socket.IPPROTO_TCP,
+    )
+    return tuple(answer[4][0] for answer in answers)
+
+
+async def dial_numeric(
+    endpoint: NumericEndpoint, timeout: float
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """Connect an already-numeric sockaddr without invoking name resolution."""
+    sock = socket.socket(endpoint.family, socket.SOCK_STREAM, socket.IPPROTO_TCP)
+    sock.setblocking(False)
+    try:
+        await asyncio.wait_for(
+            asyncio.get_running_loop().sock_connect(sock, endpoint.sockaddr),
+            timeout=timeout,
+        )
+        return await asyncio.open_connection(sock=sock)
+    except BaseException:
+        sock.close()
+        raise
+
+
+class EgressGateway:
+    """Authenticated single-destination HTTP/CONNECT proxy on IPv4 loopback."""
+
+    def __init__(
+        self,
+        *,
+        resolver: Resolver = resolve_system,
+        dialer: Dialer = dial_numeric,
+        allowed_ports: Iterable[int] = (80, 443, 8080, 8443),
+        deny_networks: Iterable[str] = (),
+        limits: GatewayLimits | None = None,
+        username: str = "connectonion",
+        password: str | None = None,
+    ):
+        self.resolver = resolver
+        self.dialer = dialer
+        try:
+            self.allowed_ports = frozenset(allowed_ports)
+            self.deny_networks = tuple(deny_networks)
+        except TypeError:
+            raise ValueError("gateway destination policy is invalid") from None
+        self.limits = limits or GatewayLimits()
+        self.username = username
+        self.password = secrets.token_urlsafe(32) if password is None else password
+        if (
+            not isinstance(self.username, str)
+            or not isinstance(self.password, str)
+            or not self.username
+            or not self.password
+            or len(self.username) > 256
+            or len(self.password) > 256
+            or ":" in self.username
+            or any(ord(char) < 0x21 or ord(char) > 0x7E for char in self.username)
+            or any(ord(char) < 0x21 or ord(char) > 0x7E for char in self.password)
+        ):
+            raise ValueError("proxy credentials must be nonempty visible ASCII")
+        raw = f"{self.username}:{self.password}".encode("ascii")
+        self._authorization = b"Basic " + base64.b64encode(raw)
+        if any(
+            isinstance(port, bool)
+            or not isinstance(port, int)
+            or not 1 <= port <= 65535
+            for port in self.allowed_ports
+        ):
+            raise ValueError("gateway destination policy is invalid")
+        # Validate operator CIDRs at construction rather than on a live request.
+        try:
+            decide_destination(
+                DestinationAuthority(
+                    "https", "8.8.8.8", 443, ipaddress.ip_address("8.8.8.8")
+                ),
+                deny_networks=self.deny_networks,
+            )
+        except DestinationPolicyError as exc:
+            raise ValueError("gateway destination policy is invalid") from exc
+        self._server: asyncio.AbstractServer | None = None
+        self._port: int | None = None
+        self._closing = False
+        self._active = 0
+        self._lifecycle_lock = asyncio.Lock()
+        self._state_lock = asyncio.Lock()
+        self._client_tasks: set[asyncio.Task] = set()
+
+    @property
+    def endpoint(self) -> ProxyEndpoint:
+        if self._port is None:
+            raise RuntimeError("egress gateway is not started")
+        return ProxyEndpoint("127.0.0.1", self._port, self.username, self.password)
+
+    async def start(self) -> ProxyEndpoint:
+        async with self._lifecycle_lock:
+            if self._server is not None:
+                return self.endpoint
+            self._closing = False
+            listener = socket.socket(
+                socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP
+            )
+            try:
+                listener.bind(("127.0.0.1", 0))
+                listener.listen()
+                listener.setblocking(False)
+                self._server = await asyncio.start_server(
+                    self._accept,
+                    sock=listener,
+                    limit=self.limits.header_bytes + 1,
+                )
+            except BaseException:
+                listener.close()
+                raise
+            sockets = self._server.sockets or ()
+            host, port = (
+                sockets[0].getsockname()[:2] if len(sockets) == 1 else (None, 0)
+            )
+            if host != "127.0.0.1":
+                self._server.close()
+                await self._server.wait_closed()
+                self._server = None
+                raise RuntimeError("egress gateway escaped IPv4 loopback")
+            self._port = int(port)
+            return self.endpoint
+
+    async def stop(self) -> None:
+        async with self._lifecycle_lock:
+            self._closing = True
+            server, self._server = self._server, None
+            if server is not None:
+                server.close()
+            tasks = tuple(task for task in self._client_tasks if not task.done())
+            for task in tasks:
+                task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            if server is not None:
+                # Python 3.14 wait_closed() waits for accepted connections too.
+                # Cancel owned handlers first so shutdown cannot wait on the very
+                # resolver/tunnel that shutdown is responsible for stopping.
+                await server.wait_closed()
+            self._client_tasks.clear()
+            self._port = None
+
+    async def __aenter__(self) -> EgressGateway:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_exc) -> None:
+        await self.stop()
+
+    async def _accept(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        task = asyncio.current_task()
+        if task is not None:
+            self._client_tasks.add(task)
+        admitted = False
+        try:
+            async with self._state_lock:
+                if not self._closing and self._active < self.limits.max_connections:
+                    self._active += 1
+                    admitted = True
+            if not admitted:
+                await self._send_error(
+                    writer, OVERLOADED if not self._closing else GATEWAY_STOPPING
+                )
+                # macOS resets a TCP close with unread peer bytes, which can erase
+                # the already-written 429/503. Consume at most one bounded request
+                # buffer without parsing, authenticating, resolving, or dialing.
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(
+                        reader.read(self.limits.header_bytes + 1), timeout=0.05
+                    )
+                return
+            await self._serve_connection(reader, writer)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Every expected refusal is translated inside _serve_connection.
+            # An unexpected failure closes silently because a response may have
+            # already started; appending a second response is request smuggling.
+            pass
+        finally:
+            if admitted:
+                async with self._state_lock:
+                    self._active -= 1
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+            if task is not None:
+                self._client_tasks.discard(task)
+
+    async def _serve_connection(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            request = await self._read_request(reader)
+            self._authenticate(request)
+            authority, origin_target, upgrade = self._request_destination(request)
+            endpoints = await self._approved_endpoints(authority)
+            upstream_reader, upstream_writer = await self._connect(endpoints)
+        except GatewayRefusal as refusal:
+            await self._send_error(writer, refusal.code)
+            return
+        except DestinationPolicyError as refusal:
+            await self._send_error(writer, refusal.code)
+            return
+
+        try:
+            if request.method == "CONNECT":
+                writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                await self._drain(writer)
+                await self._tunnel(reader, writer, upstream_reader, upstream_writer)
+                return
+
+            assert origin_target is not None
+            content_length = self._content_length(request)
+            outgoing = self._rewrite_headers(request, authority, origin_target, upgrade)
+            upstream_writer.write(outgoing)
+            await self._drain(upstream_writer)
+            if upgrade:
+                await self._tunnel(reader, writer, upstream_reader, upstream_writer)
+                return
+            if content_length:
+                body = await self._read_exactly(reader, content_length)
+                upstream_writer.write(body)
+                await self._drain(upstream_writer)
+            with contextlib.suppress(NotImplementedError, OSError):
+                upstream_writer.write_eof()
+            await self._copy(upstream_reader, writer)
+        except (GatewayRefusal, ConnectionError, OSError):
+            # Upstream establishment succeeded, so either side may already have
+            # observed bytes. Close instead of appending a second HTTP response.
+            pass
+        finally:
+            upstream_writer.close()
+            with contextlib.suppress(Exception):
+                await upstream_writer.wait_closed()
+
+    async def _read_request(self, reader: asyncio.StreamReader) -> ProxyRequest:
+        refusal_code = None
+        try:
+            block = await asyncio.wait_for(
+                reader.readuntil(b"\r\n\r\n"), timeout=self.limits.header_timeout
+            )
+        except asyncio.TimeoutError:
+            refusal_code = HEADER_TIMEOUT
+        except (asyncio.IncompleteReadError, asyncio.LimitOverrunError):
+            refusal_code = HEADER_TOO_LARGE
+        if refusal_code is not None:
+            raise GatewayRefusal(refusal_code)
+        if len(block) > self.limits.header_bytes:
+            raise GatewayRefusal(HEADER_TOO_LARGE)
+        lines = block[:-4].split(b"\r\n")
+        if not lines or len(lines[0]) > self.limits.request_line_bytes:
+            raise GatewayRefusal(HEADER_TOO_LARGE)
+        parts = lines[0].split(b" ")
+        if (
+            len(parts) != 3
+            or not _METHOD.fullmatch(parts[0])
+            or parts[2] != b"HTTP/1.1"
+        ):
+            raise GatewayRefusal(INVALID)
+        try:
+            method = parts[0].decode("ascii")
+            target = parts[1].decode("ascii")
+        except UnicodeDecodeError:
+            raise GatewayRefusal(INVALID)
+        if not target or len(lines) - 1 > self.limits.header_count:
+            raise GatewayRefusal(INVALID)
+        headers: list[tuple[str, str]] = []
+        for line in lines[1:]:
+            if not line or line[:1] in {b" ", b"\t"} or b":" not in line:
+                raise GatewayRefusal(INVALID)
+            raw_name, raw_value = line.split(b":", 1)
+            if not _HEADER_NAME.fullmatch(raw_name):
+                raise GatewayRefusal(INVALID)
+            value = raw_value.strip(b" ")
+            if any(byte < 0x20 or byte > 0x7E for byte in value):
+                raise GatewayRefusal(INVALID)
+            headers.append((raw_name.decode("ascii").lower(), value.decode("ascii")))
+        return ProxyRequest(method, target, tuple(headers))
+
+    def _authenticate(self, request: ProxyRequest) -> None:
+        values = request.values("proxy-authorization")
+        if len(values) != 1:
+            raise GatewayRefusal(AUTH_REQUIRED)
+        supplied = values[0].encode("ascii")
+        if not hmac.compare_digest(supplied, self._authorization):
+            raise GatewayRefusal(AUTH_REQUIRED)
+
+    def _request_destination(
+        self, request: ProxyRequest
+    ) -> tuple[DestinationAuthority, str | None, bool]:
+        hosts = request.values("host")
+        if len(hosts) > 1:
+            raise GatewayRefusal(INVALID)
+        if request.method == "CONNECT":
+            if any(char in request.target for char in "/?#@"):
+                raise GatewayRefusal(INVALID)
+            split = self._safe_split(f"https://{request.target}/")
+            explicit_port = None
+            port_invalid = False
+            try:
+                explicit_port = split.port
+            except ValueError:
+                port_invalid = True
+            if port_invalid:
+                raise GatewayRefusal(INVALID)
+            if explicit_port is None:
+                raise GatewayRefusal(PORT_DENIED)
+            authority = normalize_web_destination(
+                f"https://{request.target}/", allowed_ports=self.allowed_ports
+            )
+            if hosts:
+                self._require_matching_host(hosts[0], authority)
+            if request.values("content-length") or request.values("transfer-encoding"):
+                raise GatewayRefusal(INVALID)
+            return authority, None, False
+
+        split = self._safe_split(request.target)
+        if split.fragment or split.scheme.lower() not in {"http", "ws"}:
+            raise GatewayRefusal(SCHEME_DENIED if split.scheme else INVALID)
+        authority = normalize_web_destination(
+            request.target, allowed_ports=self.allowed_ports
+        )
+        if len(hosts) != 1:
+            raise GatewayRefusal(INVALID)
+        self._require_matching_host(hosts[0], authority)
+        origin = urlunsplit(("", "", split.path or "/", split.query, ""))
+        connection = request.values("connection")
+        upgrades = request.values("upgrade")
+        if len(connection) > 1 or len(upgrades) > 1:
+            raise GatewayRefusal(INVALID)
+        tokens = {
+            token.strip().lower()
+            for value in connection
+            for token in value.split(",")
+            if token.strip()
+        }
+        if tokens & {
+            "host",
+            "content-length",
+            "transfer-encoding",
+            "proxy-authorization",
+        }:
+            raise GatewayRefusal(INVALID)
+        upgrade = bool(upgrades and "upgrade" in tokens)
+        if bool(upgrades) != ("upgrade" in tokens) or (
+            upgrade and request.method != "GET"
+        ):
+            raise GatewayRefusal(INVALID)
+        self._content_length(request)
+        return authority, origin, upgrade
+
+    @staticmethod
+    def _safe_split(value: str):
+        split = None
+        try:
+            split = urlsplit(value)
+        except ValueError:
+            pass
+        if split is None:
+            raise GatewayRefusal(INVALID)
+        return split
+
+    def _require_matching_host(
+        self, header_value: str, authority: DestinationAuthority
+    ) -> None:
+        if any(character in header_value for character in "/?#@"):
+            raise GatewayRefusal(INVALID)
+        candidate = normalize_web_destination(
+            f"{authority.scheme}://{header_value}/", allowed_ports=self.allowed_ports
+        )
+        if (candidate.host, candidate.port) != (authority.host, authority.port):
+            raise GatewayRefusal(INVALID)
+
+    def _content_length(self, request: ProxyRequest) -> int:
+        lengths = request.values("content-length")
+        transfers = request.values("transfer-encoding")
+        if len(lengths) > 1 or len(transfers) > 0 or request.values("expect"):
+            raise GatewayRefusal(INVALID)
+        if not lengths:
+            return 0
+        if not lengths[0].isascii() or not lengths[0].isdigit() or len(lengths[0]) > 20:
+            raise GatewayRefusal(INVALID)
+        length = int(lengths[0])
+        if length > self.limits.bytes_per_direction:
+            raise GatewayRefusal(TRANSFER_LIMIT)
+        return length
+
+    async def _approved_endpoints(
+        self, authority: DestinationAuthority
+    ) -> tuple[NumericEndpoint, ...]:
+        if authority.literal is not None:
+            answers = (str(authority.literal),)
+        else:
+            resolution_failed = False
+            try:
+                answers = tuple(
+                    await asyncio.wait_for(
+                        self.resolver(authority.host, authority.port),
+                        timeout=self.limits.resolve_timeout,
+                    )
+                )
+            except (asyncio.TimeoutError, OSError):
+                resolution_failed = True
+                answers = ()
+            if resolution_failed:
+                raise GatewayRefusal(DNS_FAILED)
+        if not answers or len(answers) > self.limits.max_dns_answers:
+            raise GatewayRefusal(DNS_FAILED)
+        decision = decide_destination(
+            authority, answers, deny_networks=self.deny_networks
+        )
+        if not decision.ok:
+            raise GatewayRefusal(decision.code)
+        endpoints = []
+        for value in decision.addresses:
+            address = ipaddress.ip_address(value)
+            family = socket.AF_INET if address.version == 4 else socket.AF_INET6
+            endpoints.append(NumericEndpoint(family, str(address), authority.port))
+        return tuple(endpoints)
+
+    async def _connect(
+        self, endpoints: Sequence[NumericEndpoint]
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self.limits.connect_timeout
+        for endpoint in endpoints:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                break
+            try:
+                return await asyncio.wait_for(
+                    self.dialer(endpoint, remaining), timeout=remaining
+                )
+            except (asyncio.TimeoutError, OSError):
+                continue
+        raise GatewayRefusal(CONNECT_FAILED)
+
+    def _rewrite_headers(
+        self,
+        request: ProxyRequest,
+        authority: DestinationAuthority,
+        origin_target: str,
+        upgrade: bool,
+    ) -> bytes:
+        connection_tokens = {
+            token.strip().lower()
+            for value in request.values("connection")
+            for token in value.split(",")
+            if token.strip()
+        }
+        remove = {
+            "host",
+            "proxy-authorization",
+            "proxy-connection",
+            "connection",
+            "keep-alive",
+            "te",
+            "trailer",
+        }
+        remove.update(connection_tokens - ({"upgrade"} if upgrade else set()))
+        lines = [f"{request.method} {origin_target} HTTP/1.1"]
+        host = authority.host
+        if ":" in host:
+            host = f"[{host}]"
+        default_port = 80 if authority.scheme in {"http", "ws"} else 443
+        suffix = "" if authority.port == default_port else f":{authority.port}"
+        lines.append(f"Host: {host}{suffix}")
+        for name, value in request.headers:
+            if name not in remove and (name != "upgrade" or upgrade):
+                lines.append(f"{name}: {value}")
+        lines.append("Connection: Upgrade" if upgrade else "Connection: close")
+        return ("\r\n".join(lines) + "\r\n\r\n").encode("ascii")
+
+    async def _read_exactly(self, reader: asyncio.StreamReader, count: int) -> bytes:
+        body = None
+        try:
+            body = await asyncio.wait_for(
+                reader.readexactly(count), timeout=self.limits.idle_timeout
+            )
+        except (asyncio.TimeoutError, asyncio.IncompleteReadError):
+            pass
+        if body is None:
+            raise GatewayRefusal(TRANSFER_LIMIT)
+        return body
+
+    async def _copy(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        total = 0
+        while True:
+            timed_out = False
+            try:
+                data = await asyncio.wait_for(
+                    reader.read(64 * 1024), timeout=self.limits.idle_timeout
+                )
+            except asyncio.TimeoutError:
+                timed_out = True
+                data = b""
+            if timed_out:
+                raise GatewayRefusal(TRANSFER_LIMIT)
+            if not data:
+                with contextlib.suppress(NotImplementedError, OSError):
+                    writer.write_eof()
+                return
+            total += len(data)
+            if total > self.limits.bytes_per_direction:
+                raise GatewayRefusal(TRANSFER_LIMIT)
+            writer.write(data)
+            await self._drain(writer)
+
+    async def _tunnel(
+        self,
+        client_reader: asyncio.StreamReader,
+        client_writer: asyncio.StreamWriter,
+        upstream_reader: asyncio.StreamReader,
+        upstream_writer: asyncio.StreamWriter,
+    ) -> None:
+        tasks = (
+            asyncio.create_task(self._copy(client_reader, upstream_writer)),
+            asyncio.create_task(self._copy(upstream_reader, client_writer)),
+        )
+        try:
+            await asyncio.gather(*tasks)
+        finally:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _drain(self, writer: asyncio.StreamWriter) -> None:
+        failed = False
+        try:
+            await asyncio.wait_for(writer.drain(), timeout=self.limits.idle_timeout)
+        except (asyncio.TimeoutError, ConnectionError, OSError):
+            failed = True
+        if failed:
+            raise GatewayRefusal(TRANSFER_LIMIT)
+
+    async def _send_error(self, writer: asyncio.StreamWriter, code: str) -> None:
+        if writer.is_closing():
+            return
+        status, reason = _ERROR_STATUS.get(code, _ERROR_STATUS[CONNECT_FAILED])
+        authenticate = (
+            'Proxy-Authenticate: Basic realm="ConnectOnion Remote Browser"\r\n'
+            if code == AUTH_REQUIRED
+            else ""
+        )
+        response = (
+            f"HTTP/1.1 {status} {reason}\r\n"
+            "Connection: close\r\n"
+            "Content-Length: 0\r\n"
+            f"X-ConnectOnion-Error: {code}\r\n"
+            f"{authenticate}\r\n"
+        ).encode("ascii")
+        writer.write(response)
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(writer.drain(), timeout=1.0)

--- a/docs/blog/2026-08-26-the-proxy-replied-but-the-429-disappeared.md
+++ b/docs/blog/2026-08-26-the-proxy-replied-but-the-429-disappeared.md
@@ -1,0 +1,50 @@
+---
+title: "The proxy replied, but the 429 disappeared"
+date: 2026-08-26
+description: "What one vanished overload response taught us about building a fail-closed browser gateway."
+author: ConnectOnion Team
+tags: [remote-browser, proxy, security, testing]
+---
+
+# The proxy replied, but the 429 disappeared
+
+The overload test looked almost insulting in its simplicity. Hold one proxy
+connection open, set the limit to one, open a second, and expect `429 Too Many
+Requests`. The server wrote the response. The client received nothing.
+
+On macOS, closing a TCP connection while peer bytes remain unread can reset the
+connection. Our gateway had correctly refused the second client without parsing
+its request, then erased its own refusal while cleaning up. That is not an SSRF
+bypass, but it is exactly the sort of platform edge that turns a stable failure
+contract into a browser error nobody can diagnose.
+
+The fix is deliberately narrow. An overloaded connection still cannot reach
+authentication, DNS, policy, or dialing. After writing the constant response,
+the gateway consumes at most one bounded request buffer for 50 milliseconds so
+the ordinary client close does not reset away the response. An attacker cannot
+buy work by keeping the socket alive; the same header-size and time limits cap
+the discard.
+
+That failure arrived while building the gateway below Remote Browser. The
+gateway binds one ephemeral IPv4 loopback socket, requires a fresh daemon-scoped
+proxy credential, resolves every hostname once, denies a complete DNS set when
+one address is prohibited, and hands only canonical numeric endpoints to the
+dialer. There is still no Chromium flag and no `open` command. We want proxy
+mistakes to fail in isolation before a browser can depend on them.
+
+The same test pass found a more serious shutdown problem. Python 3.14 waits for
+accepted connections in `Server.wait_closed()`. Waiting for the server before
+cancelling a resolver meant shutdown waited on the very task it was responsible
+for stopping. Reversing that order—close admission, cancel owned handlers, then
+wait for the listener—made cleanup deterministic across the supported Python
+versions.
+
+Other tests attack places where proxies become ambiguous: duplicate
+authorization, a `Connection: content-length` token that tries to strip message
+framing, a second pipelined authority after a declared request body, a WebSocket
+Upgrade, mixed public/private DNS answers, and a hostname smuggled into the
+numeric dialer. The important assertion is usually not the returned status. It
+is that the dialer saw zero calls.
+
+A security proxy has two jobs: refuse the wrong connection and make that refusal
+boringly observable. The missing 429 was small, but it reminded us to test both.

--- a/docs/blog/2026-08-26-the-proxy-replied-but-the-429-disappeared.md
+++ b/docs/blog/2026-08-26-the-proxy-replied-but-the-429-disappeared.md
@@ -32,19 +32,11 @@ one address is prohibited, and hands only canonical numeric endpoints to the
 dialer. There is still no Chromium flag and no `open` command. We want proxy
 mistakes to fail in isolation before a browser can depend on them.
 
-The same test pass found a more serious shutdown problem. Python 3.14 waits for
-accepted connections in `Server.wait_closed()`. Waiting for the server before
-cancelling a resolver meant shutdown waited on the very task it was responsible
-for stopping. Reversing that order—close admission, cancel owned handlers, then
-wait for the listener—made cleanup deterministic across the supported Python
-versions.
-
-Other tests attack places where proxies become ambiguous: duplicate
-authorization, a `Connection: content-length` token that tries to strip message
-framing, a second pipelined authority after a declared request body, a WebSocket
-Upgrade, mixed public/private DNS answers, and a hostname smuggled into the
-numeric dialer. The important assertion is usually not the returned status. It
-is that the dialer saw zero calls.
+The useful turn was realizing that “refused” has two observable halves. The
+protected side must see no dial, while the browser side must receive one clear,
+bounded answer. We had asserted the first and assumed the second because the
+server called `write()`. The failing client made us measure both ends of the
+same refusal instead.
 
 A security proxy has two jobs: refuse the wrong connection and make that refusal
 boringly observable. The missing 429 was small, but it reminded us to test both.

--- a/docs/blog/2026-08-29-the-gateway-held-but-the-answer-leaked.md
+++ b/docs/blog/2026-08-29-the-gateway-held-but-the-answer-leaked.md
@@ -1,0 +1,93 @@
+# The gateway held, but the answer leaked
+
+The egress gateway is the piece that makes remote browsing safe to offer: a
+loopback proxy that Chromium is launched against with no direct fallback, which
+resolves every hostname itself, checks every address the lookup returns, and
+dials only a numeric address it already approved. If it has a hole, a stranger
+reaches your private network through your own browser.
+
+So before merging it I had an independent pass try to break it, with one
+instruction: find a byte that reaches an unapproved socket.
+
+It could not. Not through DNS rebinding on a new connection — the gateway
+re-resolves and re-classifies each time, and answering `8.8.8.8` first and
+`127.0.0.1` second gets the second connection refused with no dial. Not through
+the 26 request-parsing tricks it tried: bare-LF request smuggling, duplicate
+`Host`, obs-fold continuations, `Content-Length` fighting `Transfer-Encoding`,
+`http://example.com@169.254.169.254/`, a CR buried in a header value. Not
+through the authentication path, which is checked before resolution on every
+route and has no second-request branch to skip. Not through the resolver, which
+denies a whole answer set if any member is private. The property the module
+exists for held.
+
+What it found instead was on the way back.
+
+## The response was never ours to relay
+
+The gateway serves exactly one request per connection. After that it stops
+reading, and the connection is finished — from its point of view.
+
+It never told the client that. The upstream response went through a raw byte
+pump: read bytes, write bytes, no parsing, no rewriting. So when a hostile
+origin answered
+
+```
+HTTP/1.1 200 OK
+Content-Length: 0
+Connection: keep-alive
+
+HTTP/1.1 200 OK
+Content-Length: 8
+
+smuggled
+```
+
+both responses reached the client, and the client had been told the proxy socket
+was reusable. Chromium pools plain-HTTP proxy sockets by *proxy server*, not by
+origin. A second response sitting in the receive buffer of a socket the client
+believes it can reuse for a different origin is the shape of a
+response-smuggling bug.
+
+The documentation, meanwhile, said the gateway "forces `Connection: close`." It
+did — on the request going *upstream*. Nobody had asked what the client saw.
+
+The fix is to rewrite the response head as well: drop `Connection`,
+`Keep-Alive`, `Proxy-Connection`, append `Connection: close`, then pump the
+body. Now the one-request-per-connection rule is visible to the client instead
+of being merely true inside the gateway.
+
+## Two more, both from trusting a number a stranger chose
+
+`Content-Length` sized a `readexactly()`. One connection declaring 64 MiB grew
+resident memory by 227 MB before a byte moved; the connection cap multiplies
+that. The transfer limit was there — 128 MiB — but a limit on total bytes
+transferred is not a limit on bytes held at once. Streaming in chunks makes the
+declaration irrelevant to memory.
+
+And admission counted connections before reading any of them. Four TCP
+connections that sent *nothing* — no credential, no request — filled a
+four-connection gateway and made an authenticated `CONNECT` return
+`429 Too Many Requests`, for the full header timeout, renewably. The credential
+was checked carefully and then handed a queue that anyone could fill. Pending
+sockets now have their own budget and only convert to a served slot once the
+credential is proven.
+
+## The test that would have passed on the bug
+
+One more thing worth recording. There is a test named
+`test_numeric_dialer_never_calls_getaddrinfo` — the anti-TOCTOU property, the
+single most important thing this module does. The reviewer replaced the entire
+body of `dial_numeric` with the bug it names, resolving by name instead of
+dialing a pinned address.
+
+All 37 tests still passed.
+
+The test feeds an already-numeric string, and asyncio short-circuits numeric
+strings before it reaches the patched resolver. The property is genuinely
+enforced — by a different function, checked by a different test — but the test
+that reads like the guard is not the guard. That is worse than no test, because
+the name tells the next reader the question has been answered.
+
+Nothing in the suite asserted anything about the response the client receives,
+either, beyond its status line. Which is exactly why the smuggling window was
+invisible: the tests watched everything going out and nothing coming back.

--- a/docs/design-decisions/056-remote-browser-egress-gateway.md
+++ b/docs/design-decisions/056-remote-browser-egress-gateway.md
@@ -281,6 +281,9 @@ OAuth redirects, WebSockets, and downloads remain usable.
 8. Treat shared proxy mode as a separate #1036/#1172 gate; never silently reuse
    Direct when a pinned shared grant fails.
 
+The executable limits and protocol contract for step 2 are documented in
+[Remote Browser egress gateway](../network/remote-browser-egress-gateway.md).
+
 Each step is its own reviewable PR with documentation, unit tests, native E2E,
 and a rollback that leaves navigation unavailable rather than bypassing the
 gateway.

--- a/docs/network/remote-browser-egress-gateway.md
+++ b/docs/network/remote-browser-egress-gateway.md
@@ -50,8 +50,16 @@ results.
   peer. An explicit safe port is required.
 - Absolute-form `http://` and `ws://` HTTP/1.1 requests are normalized, checked
   against `Host`, rewritten to origin-form, and sent to one approved peer.
-- Ordinary HTTP forces `Connection: close` and forwards only the declared
-  `Content-Length`, so pipelined bytes cannot introduce another authority.
+- Ordinary HTTP forces `Connection: close` in **both** directions — on the
+  request sent upstream, and on the response head relayed back — and forwards
+  only the declared `Content-Length`, so pipelined bytes cannot introduce
+  another authority. Rewriting the response matters as much as the request: the
+  gateway answers one request per connection, and an origin replying
+  `Connection: keep-alive` would leave the client believing otherwise while a
+  second response the origin queued sits in its receive buffer.
+- The declared body is streamed in bounded chunks. `Content-Length` is
+  caller-chosen, so reading it in one call would size a resident buffer from a
+  stranger's number.
 - A valid `GET` Upgrade may become a bidirectional tunnel to the same peer.
 - Chunked request bodies, `Expect`, origin-form proxy requests, SOCKS, UDP,
   non-web schemes, ambiguous framing, and security-sensitive `Connection`
@@ -88,7 +96,13 @@ falls back to Direct.
 | Numeric connect timeout across the frozen answer set | 10 seconds |
 | Tunnel idle timeout per read/drain | 60 seconds |
 | Bytes per direction | 128 MiB |
-| Concurrent inbound connections | 32 |
+| Concurrent served connections (after the credential is proven) | 32 |
+| Concurrent sockets awaiting authentication | 128 |
+
+The two connection budgets are separate on purpose. Counting unauthenticated
+sockets against the served limit lets any local process that connects and says
+nothing hold slots for the whole header timeout — and this gateway is the
+browser's only route to the internet.
 | DNS answers before refusal | 32 |
 
 Every configured limit must be finite, positive, and of the expected integer or

--- a/docs/network/remote-browser-egress-gateway.md
+++ b/docs/network/remote-browser-egress-gateway.md
@@ -1,0 +1,133 @@
+# Remote Browser egress gateway
+
+Remote Browser navigation is not exposed yet. Before it can be, the Host must
+own the last security decision before a destination socket is opened. The
+internal `EgressGateway` is that boundary: an authenticated HTTP/CONNECT proxy
+bound to one ephemeral IPv4 loopback port.
+
+The design and threat model live in [DD-056](../design-decisions/056-remote-browser-egress-gateway.md).
+This page records the executable contract of the first gateway implementation.
+
+## Connection path
+
+```text
+one authenticated loopback proxy connection
+             |
+             v
+bounded request headers -> normalized authority -> one bounded DNS lookup
+                                                    |
+                                                    v
+                                      classify the complete answer set
+                                                    |
+                              deny any prohibited address; otherwise
+                                                    |
+                                                    v
+                                numeric family + sockaddr -> TCP socket
+```
+
+Chromium does not consume this component in this PR. There is no public OIP
+command, daemon launch flag, or fallback path. A disabled or failed gateway
+therefore leaves navigation unavailable.
+
+## Authentication and lifetime
+
+Each gateway instance creates a 32-byte URL-safe random password unless its
+owning daemon injects one. The username and password become a Basic proxy
+authorization value. The complete value is compared with
+`hmac.compare_digest`; missing, wrong, or duplicate authorization fails before
+resolution or dialing. `Proxy-Authorization` and `Proxy-Connection` are never
+forwarded upstream.
+
+Credentials live only with the gateway instance. A restarted Host-private
+daemon creates a different gateway and credential. The later BrowserDaemon
+integration must pass these values directly to the private browser context and
+must not write them into the session registry, logs, diagnosis, or command
+results.
+
+## Accepted protocol
+
+- `CONNECT host:port HTTP/1.1` creates one tunnel pinned to one approved numeric
+  peer. An explicit safe port is required.
+- Absolute-form `http://` and `ws://` HTTP/1.1 requests are normalized, checked
+  against `Host`, rewritten to origin-form, and sent to one approved peer.
+- Ordinary HTTP forces `Connection: close` and forwards only the declared
+  `Content-Length`, so pipelined bytes cannot introduce another authority.
+- A valid `GET` Upgrade may become a bidirectional tunnel to the same peer.
+- Chunked request bodies, `Expect`, origin-form proxy requests, SOCKS, UDP,
+  non-web schemes, ambiguous framing, and security-sensitive `Connection`
+  tokens are rejected in the initial boundary.
+
+All input headers must be visible ASCII with a valid token name. Duplicate
+`Host`, proxy authorization, content length, transfer encoding, connection, or
+upgrade semantics fail closed where applicable.
+
+## Resolution and socket pinning
+
+IP literals skip DNS. A hostname is resolved exactly once per new inbound
+connection with `getaddrinfo(AF_UNSPEC, SOCK_STREAM, IPPROTO_TCP)`. The gateway
+canonicalizes every returned address and applies the frozen destination policy;
+one prohibited answer denies the complete set.
+
+Approved strings are converted into `NumericEndpoint` values. That type rejects
+hostnames, alternate textual IP forms, family mismatches, and invalid ports.
+The production dialer creates a socket with the fixed family and calls
+`loop.sock_connect()` with the numeric sockaddr before wrapping the connected
+socket in asyncio streams. A failed approved candidate may try another member
+of the same already-resolved approved set. It never resolves again and never
+falls back to Direct.
+
+## Default limits
+
+| Boundary | Default |
+| --- | ---: |
+| Complete request headers | 16 KiB |
+| Request line | 4 KiB |
+| Header count | 100 |
+| Header read timeout | 5 seconds |
+| DNS timeout | 5 seconds |
+| Numeric connect timeout across the frozen answer set | 10 seconds |
+| Tunnel idle timeout per read/drain | 60 seconds |
+| Bytes per direction | 128 MiB |
+| Concurrent inbound connections | 32 |
+| DNS answers before refusal | 32 |
+
+Every configured limit must be finite, positive, and of the expected integer or
+duration type. Overload is rejected before parsing, authentication, resolution,
+or dialing. Shutdown closes admission, cancels owned resolver/tunnel tasks, then
+waits for the listener; this ordering is required by Python 3.14's stronger
+`Server.wait_closed()` semantics.
+
+## Stable failures and privacy
+
+The proxy returns an empty HTTP response with a constant status and
+`X-ConnectOnion-Error` code when no application response has started. Initial
+codes are:
+
+- destination policy: `DESTINATION_INVALID`, `DESTINATION_SCHEME_DENIED`,
+  `DESTINATION_PORT_DENIED`, `DESTINATION_HOST_DENIED`,
+  `DESTINATION_DNS_FAILED`, `DESTINATION_ADDRESS_DENIED`;
+- gateway boundary: `EGRESS_HEADER_TIMEOUT`, `EGRESS_HEADER_TOO_LARGE`,
+  `EGRESS_AUTH_REQUIRED`, `EGRESS_OVERLOADED`, `EGRESS_CONNECT_FAILED`,
+  `EGRESS_TRANSFER_LIMIT`, `EGRESS_GATEWAY_STOPPING`.
+
+Once a tunnel or upstream response may have emitted bytes, a later failure only
+closes the connection. Appending a second HTTP response would create a request
+smuggling ambiguity.
+
+Failures never echo the normalized host, URL path/query/fragment, credentials,
+headers, cookies, resolver payload, or page bytes. The future bounded decision
+ledger will store a daemon-keyed hostname hash; this transport does not log or
+persist one.
+
+## Verification boundary
+
+Focused tests use injected resolvers and dialers so public policy decisions can
+drive real loopback protocol servers without adding a private-network allow
+exception. They assert zero dial on authentication, parsing, policy, DNS,
+overload, and cancellation failures; exact header/body forwarding; CONNECT and
+WebSocket byte flow; numeric-only socket creation; retry only inside one frozen
+answer set; byte limits; and deterministic task/socket cleanup.
+
+The next child must give BrowserDaemon a Host-private namespace/profile and
+prove Chromium cannot bypass this gateway. Until that native preflight passes,
+Remote Browser remains lifecycle-only.

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -31,7 +31,19 @@ def test_every_pull_request_runs_the_test_workflow():
 
 
 def test_pytest_jobs_install_the_declared_dev_extra():
-    assert TESTS.count('pip install -e ".[dev]"') == 2
+    pytest_jobs = ("test", "remote-browser-egress", "windows-browser")
+    lines = TESTS.splitlines()
+    for job in pytest_jobs:
+        start = lines.index(f"  {job}:")
+        job_lines = []
+        for line in lines[start + 1 :]:
+            if line.startswith("  ") and not line.startswith("    "):
+                break
+            job_lines.append(line)
+        job_body = "\n".join(job_lines)
+        assert 'pip install -e ".[dev]"' in job_body
+
+    assert TESTS.count('pip install -e ".[dev]"') == len(pytest_jobs)
     assert "pip install pytest" not in TESTS
 
 

--- a/tests/unit/test_remote_browser_egress_gateway.py
+++ b/tests/unit/test_remote_browser_egress_gateway.py
@@ -228,13 +228,20 @@ async def test_connect_timeout_bounds_the_complete_answer_set():
 
     async def stalled_dialer(endpoint, timeout):
         calls.append((endpoint, timeout))
-        if len(calls) == 1:
-            await asyncio.sleep(0.01)
-            raise OSError("first approved peer unavailable")
         await asyncio.Event().wait()
 
+    answers = (
+        "1.0.0.1",
+        "1.1.1.1",
+        "8.8.4.4",
+        "8.8.8.8",
+        "9.9.9.9",
+        "2001:4860:4860::8844",
+        "2001:4860:4860::8888",
+        "2606:4700:4700::1111",
+    )
     gateway = EgressGateway(
-        resolver=RecordingResolver(("8.8.8.8", "2001:4860:4860::8888")),
+        resolver=RecordingResolver(answers),
         dialer=stalled_dialer,
         limits=GatewayLimits(connect_timeout=0.1),
         password="secret",
@@ -243,8 +250,8 @@ async def test_connect_timeout_bounds_the_complete_answer_set():
         response = await _exchange(gateway.endpoint, _connect_request(gateway.endpoint))
 
     assert b"502 Bad Gateway" in response
-    assert len(calls) == 2
-    assert 0 < calls[1][1] < calls[0][1] < 0.101
+    assert 1 <= len(calls) < len(answers)
+    assert all(0 < timeout < 0.101 for _, timeout in calls)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_remote_browser_egress_gateway.py
+++ b/tests/unit/test_remote_browser_egress_gateway.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import contextlib
 import socket
+import time
 
 import pytest
 
@@ -243,15 +244,18 @@ async def test_connect_timeout_bounds_the_complete_answer_set():
     gateway = EgressGateway(
         resolver=RecordingResolver(answers),
         dialer=stalled_dialer,
-        limits=GatewayLimits(connect_timeout=0.1),
+        limits=GatewayLimits(connect_timeout=0.2),
         password="secret",
     )
+    started = time.perf_counter()
     async with gateway:
         response = await _exchange(gateway.endpoint, _connect_request(gateway.endpoint))
+    elapsed = time.perf_counter() - started
 
     assert b"502 Bad Gateway" in response
-    assert 1 <= len(calls) < len(answers)
-    assert all(0 < timeout < 0.101 for _, timeout in calls)
+    assert calls
+    assert all(0 < timeout < 0.201 for _, timeout in calls)
+    assert elapsed < 0.75
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_remote_browser_egress_gateway.py
+++ b/tests/unit/test_remote_browser_egress_gateway.py
@@ -244,8 +244,7 @@ async def test_connect_timeout_bounds_the_complete_answer_set():
 
     assert b"502 Bad Gateway" in response
     assert len(calls) == 2
-    assert 0 < calls[1][1] < calls[0][1]
-    assert calls[0][1] == pytest.approx(0.1, abs=1e-9)
+    assert 0 < calls[1][1] < calls[0][1] < 0.101
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_remote_browser_egress_gateway.py
+++ b/tests/unit/test_remote_browser_egress_gateway.py
@@ -545,7 +545,11 @@ async def test_overload_is_rejected_without_read_resolve_or_dial():
             first_writer.write(_connect_request(gateway.endpoint))
             await first_writer.drain()
             await asyncio.wait_for(entered.wait(), timeout=1)
-            second = await _exchange(gateway.endpoint, b"not-even-read")
+            # A second authenticated client beyond the connection cap is
+            # refused after proving its credential, and before any name
+            # resolution or dial. (Unauthenticated sockets are bounded by the
+            # separate pending budget, so they cannot spend these slots at all.)
+            second = await _exchange(gateway.endpoint, _connect_request(gateway.endpoint))
             assert f"X-ConnectOnion-Error: {OVERLOADED}".encode() in second
             assert resolver.calls == [("example.com", 443)]
             assert len(calls) == 1
@@ -702,8 +706,10 @@ async def test_gateway_refusals_do_not_retain_parser_dns_or_body_payloads():
     body_reader = asyncio.StreamReader()
     body_reader.feed_data(b"secret-partial-body")
     body_reader.feed_eof()
+    _, sink = await asyncio.open_connection(sock=socket.socketpair()[0])
     with pytest.raises(GatewayRefusal) as body_refusal:
-        await gateway._read_exactly(body_reader, 100)
+        await gateway._stream_body(body_reader, sink, 100)
+    sink.close()
     assert body_refusal.value.__context__ is None
     assert "secret-partial" not in repr(body_refusal.value)
 
@@ -739,3 +745,195 @@ def test_invalid_limits_credentials_and_operator_policy_fail_at_construction():
         EgressGateway(allowed_ports={True})
     with pytest.raises(ValueError):
         EgressGateway(deny_networks={"not-a-network"})
+
+
+@pytest.mark.asyncio
+async def test_upstream_keep_alive_never_reaches_the_client():
+    """A hostile origin must not tell the client this socket is reusable.
+
+    The gateway serves one request per connection. If the origin's
+    `Connection: keep-alive` is relayed verbatim, the client believes it may
+    send a second request — and a second response the origin queued behind the
+    first is already sitting in the client's receive buffer, waiting to be
+    matched against it.
+    """
+
+    async def hostile(reader, writer):
+        await reader.read(4096)
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n"
+            b"Connection: keep-alive\r\nKeep-Alive: timeout=60\r\n\r\n"
+            b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\nsmuggled"
+        )
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    upstream = await asyncio.start_server(hostile, "127.0.0.1", 0)
+    port = upstream.sockets[0].getsockname()[1]
+    gateway = EgressGateway(resolver=RecordingResolver(), dialer=RecordingDialer(port))
+    try:
+        async with gateway:
+            request = (
+                "GET http://example.com/ HTTP/1.1\r\n"
+                "Host: example.com\r\n"
+                f"Proxy-Authorization: {_authorization(gateway.endpoint)}\r\n\r\n"
+            ).encode("ascii")
+            response = await _exchange(gateway.endpoint, request)
+    finally:
+        await gateway.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    head = response.split(b"\r\n\r\n", 1)[0].lower()
+    assert b"connection: close" in head
+    assert b"keep-alive" not in head
+
+
+@pytest.mark.asyncio
+async def test_a_declared_body_is_streamed_rather_than_buffered_whole():
+    """`Content-Length` is caller-controlled; it must not size a RAM buffer."""
+    captured = bytearray()
+    body_arrived = asyncio.Event()
+
+    async def sink(reader, writer):
+        # Read incrementally: a gateway that buffers the whole declared length
+        # forwards nothing until it has all of it, and this never fires.
+        while len(captured) < 1024:
+            chunk = await reader.read(4096)
+            if not chunk:
+                break
+            captured.extend(chunk)
+        body_arrived.set()
+        with contextlib.suppress(Exception):
+            writer.write(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            )
+            await writer.drain()
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+
+    upstream = await asyncio.start_server(sink, "127.0.0.1", 0)
+    port = upstream.sockets[0].getsockname()[1]
+    gateway = EgressGateway(resolver=RecordingResolver(), dialer=RecordingDialer(port))
+    try:
+        async with gateway:
+            reader, writer = await asyncio.open_connection(
+                gateway.endpoint.host, gateway.endpoint.port
+            )
+            writer.write(
+                (
+                    "POST http://example.com/ HTTP/1.1\r\n"
+                    "Host: example.com\r\n"
+                    f"Proxy-Authorization: {_authorization(gateway.endpoint)}\r\n"
+                    "Content-Length: 1048576\r\n\r\n"
+                ).encode("ascii")
+            )
+            await writer.drain()
+            # Declare a megabyte, send a kilobyte, then stall. A gateway that
+            # buffers the whole declared length waits here holding it all.
+            writer.write(b"x" * 1024)
+            await writer.drain()
+            arrived = True
+            try:
+                await asyncio.wait_for(body_arrived.wait(), timeout=3)
+            except asyncio.TimeoutError:
+                arrived = False
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+    finally:
+        await gateway.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    # The bytes that did arrive were forwarded as they arrived, not held back
+    # until the declared length completed.
+    assert arrived
+    assert bytes(captured).endswith(b"x" * 1024)
+
+
+@pytest.mark.asyncio
+async def test_silent_connections_cannot_starve_an_authenticated_client():
+    """A local process with no credentials must not consume the egress path.
+
+    Admission happens before a single byte is read, so sockets that send
+    nothing hold their slots for the whole header timeout. Chromium's only
+    route to the internet is this gateway; an unauthenticated neighbour must
+    not be able to close it.
+    """
+    limits = GatewayLimits(max_connections=2, header_timeout=5.0)
+    gateway = EgressGateway(
+        resolver=RecordingResolver(), dialer=RecordingDialer(), limits=limits
+    )
+    silent = []
+    try:
+        async with gateway:
+            for _ in range(limits.max_connections):
+                silent.append(
+                    await asyncio.open_connection(
+                        gateway.endpoint.host, gateway.endpoint.port
+                    )
+                )
+            await asyncio.sleep(0.1)
+            response = await _exchange(
+                gateway.endpoint, _connect_request(gateway.endpoint)
+            )
+    finally:
+        for _, writer in silent:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+        await gateway.stop()
+
+    assert OVERLOADED.encode("ascii") not in response
+
+
+@pytest.mark.asyncio
+async def test_the_proxy_password_stays_out_of_the_endpoint_repr():
+    gateway = EgressGateway()
+    async with gateway:
+        endpoint = gateway.endpoint
+        assert endpoint.password
+        assert endpoint.password not in repr(endpoint)
+
+
+@pytest.mark.asyncio
+async def test_an_unexpected_resolver_failure_answers_instead_of_closing_silently():
+    """The resolver is pluggable; a custom one must not produce a dead socket."""
+
+    async def broken_resolver(_host, _port):
+        raise ValueError("resolver blew up")
+
+    dialer = RecordingDialer()
+    gateway = EgressGateway(resolver=broken_resolver, dialer=dialer)
+    try:
+        async with gateway:
+            response = await _exchange(
+                gateway.endpoint, _connect_request(gateway.endpoint)
+            )
+    finally:
+        await gateway.stop()
+
+    assert b"EGRESS" in response or b"DESTINATION_DNS_FAILED" in response
+    assert dialer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_fragment_is_a_malformed_target_not_a_denied_scheme():
+    dialer = RecordingDialer()
+    gateway = EgressGateway(resolver=RecordingResolver(), dialer=dialer)
+    try:
+        async with gateway:
+            request = (
+                "GET http://example.com/a#frag HTTP/1.1\r\n"
+                "Host: example.com\r\n"
+                f"Proxy-Authorization: {_authorization(gateway.endpoint)}\r\n\r\n"
+            ).encode("ascii")
+            response = await _exchange(gateway.endpoint, request)
+    finally:
+        await gateway.stop()
+
+    assert b"DESTINATION_INVALID" in response
+    assert dialer.calls == []

--- a/tests/unit/test_remote_browser_egress_gateway.py
+++ b/tests/unit/test_remote_browser_egress_gateway.py
@@ -244,7 +244,8 @@ async def test_connect_timeout_bounds_the_complete_answer_set():
 
     assert b"502 Bad Gateway" in response
     assert len(calls) == 2
-    assert 0 < calls[1][1] < calls[0][1] <= 0.1
+    assert 0 < calls[1][1] < calls[0][1]
+    assert calls[0][1] == pytest.approx(0.1, abs=1e-9)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_remote_browser_egress_gateway.py
+++ b/tests/unit/test_remote_browser_egress_gateway.py
@@ -228,20 +228,23 @@ async def test_connect_timeout_bounds_the_complete_answer_set():
 
     async def stalled_dialer(endpoint, timeout):
         calls.append((endpoint, timeout))
+        if len(calls) == 1:
+            await asyncio.sleep(0.01)
+            raise OSError("first approved peer unavailable")
         await asyncio.Event().wait()
 
     gateway = EgressGateway(
         resolver=RecordingResolver(("8.8.8.8", "2001:4860:4860::8888")),
         dialer=stalled_dialer,
-        limits=GatewayLimits(connect_timeout=0.02),
+        limits=GatewayLimits(connect_timeout=0.1),
         password="secret",
     )
     async with gateway:
         response = await _exchange(gateway.endpoint, _connect_request(gateway.endpoint))
 
     assert b"502 Bad Gateway" in response
-    assert len(calls) == 1
-    assert 0 < calls[0][1] <= 0.02
+    assert len(calls) == 2
+    assert 0 < calls[1][1] < calls[0][1] <= 0.1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_remote_browser_egress_gateway.py
+++ b/tests/unit/test_remote_browser_egress_gateway.py
@@ -1,0 +1,727 @@
+"""Protocol and zero-dial contracts for the Remote Browser egress gateway."""
+
+import asyncio
+import base64
+import contextlib
+import socket
+
+import pytest
+
+from connectonion.network.host.destination_policy import normalize_web_destination
+from connectonion.network.host.egress_gateway import (
+    AUTH_REQUIRED,
+    HEADER_TIMEOUT,
+    HEADER_TOO_LARGE,
+    OVERLOADED,
+    EgressGateway,
+    GatewayLimits,
+    GatewayRefusal,
+    NumericEndpoint,
+    dial_numeric,
+)
+
+
+def _authorization(endpoint) -> str:
+    value = f"{endpoint.username}:{endpoint.password}".encode("ascii")
+    return "Basic " + base64.b64encode(value).decode("ascii")
+
+
+def _connect_request(endpoint, target="example.com:443", *, extra_headers=()) -> bytes:
+    headers = [
+        f"CONNECT {target} HTTP/1.1",
+        f"Host: {target}",
+        f"Proxy-Authorization: {_authorization(endpoint)}",
+        *extra_headers,
+        "",
+        "",
+    ]
+    return "\r\n".join(headers).encode("ascii")
+
+
+async def _exchange(endpoint, payload: bytes) -> bytes:
+    reader, writer = await asyncio.open_connection(endpoint.host, endpoint.port)
+    writer.write(payload)
+    await writer.drain()
+    with contextlib.suppress(NotImplementedError):
+        writer.write_eof()
+    response = await asyncio.wait_for(reader.read(), timeout=2)
+    writer.close()
+    await writer.wait_closed()
+    return response
+
+
+class RecordingResolver:
+    def __init__(self, answers=("8.8.8.8",)):
+        self.answers = answers
+        self.calls = []
+
+    async def __call__(self, host, port):
+        self.calls.append((host, port))
+        return self.answers
+
+
+class RecordingDialer:
+    def __init__(self, redirect_port=None):
+        self.redirect_port = redirect_port
+        self.calls = []
+
+    async def __call__(self, endpoint, timeout):
+        self.calls.append((endpoint, timeout))
+        if self.redirect_port is None:
+            raise OSError("test dial refused")
+        return await asyncio.open_connection("127.0.0.1", self.redirect_port)
+
+
+@pytest.mark.asyncio
+async def test_gateway_binds_only_ephemeral_ipv4_loopback_and_rotates_credentials():
+    first = EgressGateway()
+    second = EgressGateway()
+    async with first, second:
+        assert first.endpoint.host == second.endpoint.host == "127.0.0.1"
+        assert first.endpoint.port > 0
+        assert second.endpoint.port > 0
+        assert first.endpoint.password != second.endpoint.password
+
+
+@pytest.mark.asyncio
+async def test_concurrent_start_and_stop_share_one_listener_and_cleanup_once():
+    gateway = EgressGateway()
+    endpoints = await asyncio.gather(*(gateway.start() for _ in range(10)))
+
+    assert len({(endpoint.host, endpoint.port) for endpoint in endpoints}) == 1
+    await asyncio.gather(*(gateway.stop() for _ in range(10)))
+    assert gateway._server is None
+    assert gateway._client_tasks == set()
+    with pytest.raises(RuntimeError):
+        _ = gateway.endpoint
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "authorization",
+    [None, "Basic wrong", "Basic one\r\nProxy-Authorization: Basic two"],
+)
+async def test_auth_failure_never_resolves_or_dials(authorization):
+    resolver = RecordingResolver()
+    dialer = RecordingDialer()
+    gateway = EgressGateway(resolver=resolver, dialer=dialer, password="test-secret")
+    async with gateway:
+        headers = ["CONNECT example.com:443 HTTP/1.1", "Host: example.com:443"]
+        if authorization is not None:
+            headers.append(f"Proxy-Authorization: {authorization}")
+        response = await _exchange(
+            gateway.endpoint, ("\r\n".join([*headers, "", ""])).encode("ascii")
+        )
+
+    assert b"407 Proxy Authentication Required" in response
+    assert f"X-ConnectOnion-Error: {AUTH_REQUIRED}".encode() in response
+    assert resolver.calls == []
+    assert dialer.calls == []
+    assert b"test-secret" not in response
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("target", "status"),
+    [
+        ("127.1:443", b"403 Forbidden"),
+        ("2130706433:443", b"403 Forbidden"),
+        ("169.254.169.254:80", b"403 Forbidden"),
+        ("example.com:22", b"403 Forbidden"),
+        ("localhost:443", b"403 Forbidden"),
+    ],
+)
+async def test_literal_and_authority_denials_are_zero_dial(target, status):
+    resolver = RecordingResolver()
+    dialer = RecordingDialer()
+    gateway = EgressGateway(resolver=resolver, dialer=dialer, password="secret")
+    async with gateway:
+        response = await _exchange(
+            gateway.endpoint, _connect_request(gateway.endpoint, target)
+        )
+
+    assert status in response
+    assert dialer.calls == []
+    if target[0].isdigit():
+        assert resolver.calls == []
+
+
+@pytest.mark.asyncio
+async def test_mixed_dns_answer_set_is_denied_before_any_dial():
+    resolver = RecordingResolver(("8.8.8.8", "127.0.0.1"))
+    dialer = RecordingDialer()
+    gateway = EgressGateway(resolver=resolver, dialer=dialer, password="secret")
+    async with gateway:
+        response = await _exchange(gateway.endpoint, _connect_request(gateway.endpoint))
+
+    assert b"403 Forbidden" in response
+    assert resolver.calls == [("example.com", 443)]
+    assert dialer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_hostname_resolves_once_and_only_numeric_candidates_reach_the_dialer():
+    resolver = RecordingResolver(("2001:4860:4860::8888", "8.8.8.8"))
+    dialer = RecordingDialer()
+    gateway = EgressGateway(resolver=resolver, dialer=dialer, password="secret")
+    async with gateway:
+        response = await _exchange(gateway.endpoint, _connect_request(gateway.endpoint))
+
+    assert b"502 Bad Gateway" in response
+    assert resolver.calls == [("example.com", 443)]
+    assert [call[0].address for call in dialer.calls] == [
+        "8.8.8.8",
+        "2001:4860:4860::8888",
+    ]
+    assert [call[0].family for call in dialer.calls] == [
+        socket.AF_INET,
+        socket.AF_INET6,
+    ]
+    assert all(call[0].address != "example.com" for call in dialer.calls)
+
+
+@pytest.mark.asyncio
+async def test_dial_failure_retries_only_the_frozen_approved_answer_set():
+    upstream_connected = asyncio.Event()
+
+    async def upstream_handler(_reader, writer):
+        upstream_connected.set()
+        writer.close()
+        await writer.wait_closed()
+
+    upstream = await asyncio.start_server(upstream_handler, "127.0.0.1", 0)
+    port = upstream.sockets[0].getsockname()[1]
+    calls = []
+
+    async def fallback_dialer(endpoint, _timeout):
+        calls.append(endpoint)
+        if len(calls) == 1:
+            raise OSError("first approved peer unavailable")
+        return await asyncio.open_connection("127.0.0.1", port)
+
+    resolver = RecordingResolver(("2001:4860:4860::8888", "8.8.8.8"))
+    gateway = EgressGateway(
+        resolver=resolver, dialer=fallback_dialer, password="secret"
+    )
+    try:
+        async with gateway:
+            response = await _exchange(
+                gateway.endpoint, _connect_request(gateway.endpoint)
+            )
+            await asyncio.wait_for(upstream_connected.wait(), timeout=1)
+    finally:
+        await gateway.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert response.startswith(b"HTTP/1.1 200 Connection Established")
+    assert [endpoint.address for endpoint in calls] == [
+        "8.8.8.8",
+        "2001:4860:4860::8888",
+    ]
+    assert resolver.calls == [("example.com", 443)]
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_bounds_the_complete_answer_set():
+    calls = []
+
+    async def stalled_dialer(endpoint, timeout):
+        calls.append((endpoint, timeout))
+        await asyncio.Event().wait()
+
+    gateway = EgressGateway(
+        resolver=RecordingResolver(("8.8.8.8", "2001:4860:4860::8888")),
+        dialer=stalled_dialer,
+        limits=GatewayLimits(connect_timeout=0.02),
+        password="secret",
+    )
+    async with gateway:
+        response = await _exchange(gateway.endpoint, _connect_request(gateway.endpoint))
+
+    assert b"502 Bad Gateway" in response
+    assert len(calls) == 1
+    assert 0 < calls[0][1] <= 0.02
+
+
+@pytest.mark.asyncio
+async def test_connect_tunnels_bytes_only_after_policy_and_numeric_dial():
+    received = bytearray()
+
+    async def echo(reader, writer):
+        try:
+            while data := await reader.read(1024):
+                received.extend(data)
+                writer.write(data)
+                await writer.drain()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    upstream = await asyncio.start_server(echo, "127.0.0.1", 0)
+    port = upstream.sockets[0].getsockname()[1]
+    resolver = RecordingResolver()
+    dialer = RecordingDialer(port)
+    gateway = EgressGateway(resolver=resolver, dialer=dialer, password="secret")
+    try:
+        async with gateway:
+            reader, writer = await asyncio.open_connection(
+                gateway.endpoint.host, gateway.endpoint.port
+            )
+            writer.write(_connect_request(gateway.endpoint))
+            await writer.drain()
+            assert await reader.readuntil(b"\r\n\r\n") == (
+                b"HTTP/1.1 200 Connection Established\r\n\r\n"
+            )
+            assert received == b""
+            writer.write(b"tls-client-hello")
+            await writer.drain()
+            assert (
+                await reader.readexactly(len(b"tls-client-hello"))
+                == b"tls-client-hello"
+            )
+            writer.close()
+            await writer.wait_closed()
+    finally:
+        await gateway.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert received == b"tls-client-hello"
+    assert dialer.calls[0][0] == NumericEndpoint(socket.AF_INET, "8.8.8.8", 443)
+
+
+@pytest.mark.asyncio
+async def test_absolute_http_is_rewritten_and_proxy_credentials_are_stripped():
+    captured = bytearray()
+
+    async def http_server(reader, writer):
+        captured.extend(await reader.read())
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+        )
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    upstream = await asyncio.start_server(http_server, "127.0.0.1", 0)
+    port = upstream.sockets[0].getsockname()[1]
+    dialer = RecordingDialer(port)
+    gateway = EgressGateway(
+        resolver=RecordingResolver(), dialer=dialer, password="strip-me"
+    )
+    try:
+        async with gateway:
+            request = (
+                "GET http://example.com/private?q=secret HTTP/1.1\r\n"
+                "Host: example.com\r\n"
+                f"Proxy-Authorization: {_authorization(gateway.endpoint)}\r\n"
+                "Proxy-Connection: keep-alive\r\n"
+                "Connection: keep-alive\r\n"
+                "X-Public: yes\r\n\r\n"
+            ).encode("ascii")
+            response = await _exchange(gateway.endpoint, request)
+    finally:
+        await gateway.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert response.endswith(b"\r\n\r\nok")
+    assert captured.startswith(b"GET /private?q=secret HTTP/1.1\r\n")
+    assert b"Host: example.com\r\n" in captured
+    assert b"Connection: close\r\n" in captured
+    assert b"proxy-authorization" not in captured.lower()
+    assert b"proxy-connection" not in captured.lower()
+    assert b"strip-me" not in captured
+
+
+@pytest.mark.asyncio
+async def test_plain_http_forwards_only_the_declared_body_not_a_pipelined_request():
+    captured = bytearray()
+
+    async def http_server(reader, writer):
+        captured.extend(await reader.read())
+        writer.write(b"HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n")
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    upstream = await asyncio.start_server(http_server, "127.0.0.1", 0)
+    port = upstream.sockets[0].getsockname()[1]
+    gateway = EgressGateway(
+        resolver=RecordingResolver(), dialer=RecordingDialer(port), password="secret"
+    )
+    try:
+        async with gateway:
+            request = (
+                "POST http://example.com/form HTTP/1.1\r\n"
+                "Host: example.com\r\n"
+                f"Proxy-Authorization: {_authorization(gateway.endpoint)}\r\n"
+                "Content-Length: 4\r\n\r\n"
+                "body"
+                "GET http://other.example/ HTTP/1.1\r\nHost: other.example\r\n\r\n"
+            ).encode("ascii")
+            await _exchange(gateway.endpoint, request)
+    finally:
+        await gateway.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert captured.endswith(b"\r\n\r\nbody")
+    assert b"other.example" not in captured
+
+
+@pytest.mark.asyncio
+async def test_websocket_upgrade_stays_on_the_pinned_peer():
+    captured_headers = bytearray()
+
+    async def websocket_server(reader, writer):
+        captured_headers.extend(await reader.readuntil(b"\r\n\r\n"))
+        writer.write(
+            b"HTTP/1.1 101 Switching Protocols\r\n"
+            b"Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n"
+        )
+        await writer.drain()
+        while data := await reader.read(1024):
+            writer.write(data)
+            await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    upstream = await asyncio.start_server(websocket_server, "127.0.0.1", 0)
+    port = upstream.sockets[0].getsockname()[1]
+    gateway = EgressGateway(
+        resolver=RecordingResolver(), dialer=RecordingDialer(port), password="secret"
+    )
+    try:
+        async with gateway:
+            reader, writer = await asyncio.open_connection(
+                gateway.endpoint.host, gateway.endpoint.port
+            )
+            request = (
+                "GET ws://example.com/socket HTTP/1.1\r\n"
+                "Host: example.com\r\n"
+                f"Proxy-Authorization: {_authorization(gateway.endpoint)}\r\n"
+                "Connection: keep-alive, Upgrade\r\n"
+                "Upgrade: websocket\r\n\r\n"
+            ).encode("ascii")
+            writer.write(request)
+            await writer.drain()
+            response = await reader.readuntil(b"\r\n\r\n")
+            assert b"101 Switching Protocols" in response
+            writer.write(b"frame")
+            await writer.drain()
+            assert await reader.readexactly(5) == b"frame"
+            writer.close()
+            await writer.wait_closed()
+    finally:
+        await gateway.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert captured_headers.startswith(b"GET /socket HTTP/1.1\r\n")
+    assert b"Connection: Upgrade\r\n" in captured_headers
+    assert b"proxy-authorization" not in captured_headers.lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw_request",
+    [
+        b"GET /origin-form HTTP/1.1\r\nHost: example.com\r\n",
+        b"CONNECT [broken:443 HTTP/1.1\r\nHost: [broken:443\r\n",
+        b"GET ftp://example.com/file HTTP/1.1\r\nHost: example.com\r\n",
+        b"GET http://example.com/ HTTP/1.1\r\nHost: other.example\r\n",
+        b"GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\nConnection: content-length\r\nContent-Length: 1\r\n",
+        b"POST http://example.com/ HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n",
+    ],
+)
+async def test_malformed_or_ambiguous_requests_never_resolve_or_dial(raw_request):
+    resolver = RecordingResolver()
+    dialer = RecordingDialer()
+    gateway = EgressGateway(resolver=resolver, dialer=dialer, password="secret")
+    async with gateway:
+        payload = (
+            raw_request
+            + f"Proxy-Authorization: {_authorization(gateway.endpoint)}\r\n\r\n".encode()
+        )
+        response = await _exchange(gateway.endpoint, payload)
+
+    assert response.startswith((b"HTTP/1.1 400", b"HTTP/1.1 403"))
+    assert resolver.calls == []
+    assert dialer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_header_timeout_and_size_limits_are_bounded_and_zero_dial():
+    resolver = RecordingResolver()
+    dialer = RecordingDialer()
+    limits = GatewayLimits(
+        header_bytes=128,
+        request_line_bytes=64,
+        header_timeout=0.02,
+    )
+    gateway = EgressGateway(
+        resolver=resolver, dialer=dialer, limits=limits, password="secret"
+    )
+    async with gateway:
+        reader, writer = await asyncio.open_connection(
+            gateway.endpoint.host, gateway.endpoint.port
+        )
+        timeout_response = await asyncio.wait_for(reader.read(), timeout=1)
+        writer.close()
+        await writer.wait_closed()
+        oversized = await _exchange(gateway.endpoint, b"X" * 256 + b"\r\n\r\n")
+
+    assert f"X-ConnectOnion-Error: {HEADER_TIMEOUT}".encode() in timeout_response
+    assert f"X-ConnectOnion-Error: {HEADER_TOO_LARGE}".encode() in oversized
+    assert resolver.calls == []
+    assert dialer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_dns_timeout_empty_and_answer_limit_are_zero_dial():
+    async def timeout_resolver(_host, _port):
+        await asyncio.Event().wait()
+
+    for resolver in (
+        timeout_resolver,
+        RecordingResolver(()),
+        RecordingResolver(tuple(f"8.8.8.{index}" for index in range(1, 34))),
+    ):
+        dialer = RecordingDialer()
+        gateway = EgressGateway(
+            resolver=resolver,
+            dialer=dialer,
+            limits=GatewayLimits(resolve_timeout=0.02),
+            password="secret",
+        )
+        async with gateway:
+            response = await _exchange(
+                gateway.endpoint, _connect_request(gateway.endpoint)
+            )
+        assert b"502 Bad Gateway" in response
+        assert dialer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_overload_is_rejected_without_read_resolve_or_dial():
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    calls = []
+
+    async def held_dialer(endpoint, timeout):
+        calls.append((endpoint, timeout))
+        entered.set()
+        await release.wait()
+        raise OSError("released")
+
+    resolver = RecordingResolver()
+    gateway = EgressGateway(
+        resolver=resolver,
+        dialer=held_dialer,
+        limits=GatewayLimits(max_connections=1),
+        password="secret",
+    )
+    try:
+        async with gateway:
+            first_reader, first_writer = await asyncio.open_connection(
+                gateway.endpoint.host, gateway.endpoint.port
+            )
+            first_writer.write(_connect_request(gateway.endpoint))
+            await first_writer.drain()
+            await asyncio.wait_for(entered.wait(), timeout=1)
+            second = await _exchange(gateway.endpoint, b"not-even-read")
+            assert f"X-ConnectOnion-Error: {OVERLOADED}".encode() in second
+            assert resolver.calls == [("example.com", 443)]
+            assert len(calls) == 1
+            release.set()
+            await asyncio.wait_for(first_reader.read(), timeout=1)
+            first_writer.close()
+            await first_writer.wait_closed()
+    finally:
+        release.set()
+        await gateway.stop()
+
+
+@pytest.mark.asyncio
+async def test_numeric_dialer_never_calls_getaddrinfo(monkeypatch):
+    async def accept_then_close(_reader, writer):
+        writer.close()
+        await writer.wait_closed()
+
+    server = await asyncio.start_server(accept_then_close, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    loop = asyncio.get_running_loop()
+
+    async def forbidden_getaddrinfo(*_args, **_kwargs):
+        raise AssertionError("numeric dial attempted hostname resolution")
+
+    monkeypatch.setattr(loop, "getaddrinfo", forbidden_getaddrinfo)
+    try:
+        _reader, writer = await dial_numeric(
+            NumericEndpoint(socket.AF_INET, "127.0.0.1", port), 1
+        )
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_tunnel_byte_limit_closes_before_an_oversized_chunk_reaches_upstream():
+    received = bytearray()
+
+    async def collect(reader, writer):
+        received.extend(await reader.read())
+        writer.close()
+        await writer.wait_closed()
+
+    upstream = await asyncio.start_server(collect, "127.0.0.1", 0)
+    port = upstream.sockets[0].getsockname()[1]
+    gateway = EgressGateway(
+        resolver=RecordingResolver(),
+        dialer=RecordingDialer(port),
+        limits=GatewayLimits(bytes_per_direction=4),
+        password="secret",
+    )
+    try:
+        async with gateway:
+            reader, writer = await asyncio.open_connection(
+                gateway.endpoint.host, gateway.endpoint.port
+            )
+            writer.write(_connect_request(gateway.endpoint))
+            await writer.drain()
+            await reader.readuntil(b"\r\n\r\n")
+            writer.write(b"12345")
+            await writer.drain()
+            assert await asyncio.wait_for(reader.read(), timeout=1) == b""
+            writer.close()
+            await writer.wait_closed()
+    finally:
+        await gateway.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert received == b""
+
+
+@pytest.mark.asyncio
+async def test_stopping_during_resolution_cancels_owned_work_without_dialing():
+    resolver_entered = asyncio.Event()
+    resolver_cancelled = asyncio.Event()
+
+    async def held_resolver(_host, _port):
+        resolver_entered.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            resolver_cancelled.set()
+
+    dialer = RecordingDialer()
+    gateway = EgressGateway(resolver=held_resolver, dialer=dialer, password="secret")
+    await gateway.start()
+    reader, writer = await asyncio.open_connection(
+        gateway.endpoint.host, gateway.endpoint.port
+    )
+    writer.write(_connect_request(gateway.endpoint))
+    await writer.drain()
+    await asyncio.wait_for(resolver_entered.wait(), timeout=1)
+
+    await asyncio.wait_for(gateway.stop(), timeout=1)
+
+    assert await asyncio.wait_for(reader.read(), timeout=1) == b""
+    assert resolver_cancelled.is_set()
+    assert dialer.calls == []
+    assert gateway._active == 0
+    assert gateway._client_tasks == set()
+    writer.close()
+    await writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_refusal_response_never_echoes_target_or_header_secrets():
+    gateway = EgressGateway(password="proxy-secret")
+    async with gateway:
+        request = (
+            "GET http://localhost/private/customer?token=url-secret HTTP/1.1\r\n"
+            "Host: localhost\r\n"
+            f"Proxy-Authorization: {_authorization(gateway.endpoint)}\r\n"
+            "Cookie: cookie-secret\r\n\r\n"
+        ).encode("ascii")
+        response = await _exchange(gateway.endpoint, request)
+
+    assert b"403 Forbidden" in response
+    for secret in (
+        b"localhost",
+        b"customer",
+        b"url-secret",
+        b"cookie-secret",
+        b"proxy-secret",
+    ):
+        assert secret not in response
+
+
+@pytest.mark.asyncio
+async def test_gateway_refusals_do_not_retain_parser_dns_or_body_payloads():
+    reader = asyncio.StreamReader(limit=64)
+    reader.feed_data(b"secret-incomplete-header")
+    reader.feed_eof()
+    gateway = EgressGateway(password="secret")
+
+    with pytest.raises(GatewayRefusal) as header_refusal:
+        await gateway._read_request(reader)
+    assert header_refusal.value.__context__ is None
+    assert b"secret" not in repr(header_refusal.value).encode()
+
+    async def failed_resolver(_host, _port):
+        raise OSError("secret-dns-payload")
+
+    gateway = EgressGateway(resolver=failed_resolver, password="secret")
+    authority = normalize_web_destination("https://example.com/")
+    with pytest.raises(GatewayRefusal) as dns_refusal:
+        await gateway._approved_endpoints(authority)
+    assert dns_refusal.value.__context__ is None
+    assert "secret-dns" not in repr(dns_refusal.value)
+
+    body_reader = asyncio.StreamReader()
+    body_reader.feed_data(b"secret-partial-body")
+    body_reader.feed_eof()
+    with pytest.raises(GatewayRefusal) as body_refusal:
+        await gateway._read_exactly(body_reader, 100)
+    assert body_refusal.value.__context__ is None
+    assert "secret-partial" not in repr(body_refusal.value)
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        (socket.AF_INET, "example.com", 443),
+        (socket.AF_INET6, "8.8.8.8", 443),
+        (socket.AF_INET, "127.1", 443),
+        (socket.AF_INET, "8.8.8.8", 0),
+    ],
+)
+def test_numeric_endpoint_rejects_every_nonnumeric_or_noncanonical_form(endpoint):
+    with pytest.raises(ValueError):
+        NumericEndpoint(*endpoint)
+
+
+def test_invalid_limits_credentials_and_operator_policy_fail_at_construction():
+    with pytest.raises(ValueError):
+        GatewayLimits(max_connections=0)
+    with pytest.raises(ValueError):
+        GatewayLimits(idle_timeout=float("nan"))
+    with pytest.raises(ValueError):
+        GatewayLimits(header_count=1.5)
+    with pytest.raises(ValueError):
+        EgressGateway(username="bad:name")
+    with pytest.raises(ValueError):
+        EgressGateway(password="")
+    with pytest.raises(ValueError):
+        EgressGateway(username=1)
+    with pytest.raises(ValueError):
+        EgressGateway(allowed_ports={True})
+    with pytest.raises(ValueError):
+        EgressGateway(deny_networks={"not-a-network"})


### PR DESCRIPTION
## Description

Add the authenticated, bounded loopback gateway that resolves, classifies, and pins every future Remote Browser connection to an approved numeric socket. The component remains internal: no Chromium or OIP navigation command consumes it yet.

## Related Issue

Fixes #1302. Child of #1297 and #991. Stacked on classifier PR #1301 and design PR #1299; it must not merge ahead of either boundary.

## Labels and target release (required)

- **Suggested labels:** feature, browser, tests
- **Proposed target version:** 1.8.0
- **Estimated release window:** next alpha, before BrowserDaemon/Chromium integration
- **Milestone:** maintainer assigns the confirmed release milestone
- **Why this release:** URL policy is not a socket boundary while Chromium can resolve or dial independently. This gateway must be reviewed before navigation exists. Rollback deletes an unused internal component and leaves navigation unavailable; there is no Direct fallback.
- **Forward-port tracking issue (stable patches only):** N/A — alpha feature work

## How this was written

- [ ] I wrote this myself
- [ ] AI-assisted — I reviewed every line and can explain why each change is there
- [x] Mostly AI-generated

**Which model?** GPT-5.6 via Codex desktop.

The part I am least confident about is compatibility with Chromium's eventual effective proxy traffic: this PR deliberately tests HTTP/CONNECT protocol behavior without launching Chromium, so later preflight may reveal another conservative header form that must be supported without weakening framing. I did not run Python 3.10-3.13 or Windows locally; the new 12-runner OS/runtime matrix is intended to supply that evidence. I also did not test QUIC/WebRTC blocking, browser resolver flags, downloads, Service Workers, or Remote Browser `open` because those belong to the next native integration boundary. If this is wrong, the first break should be a focused socket/protocol test or a fail-closed proxy refusal before any public navigation API exists.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Dev Blog (required)

Blog file in this PR:

> docs/blog/2026-08-26-the-proxy-replied-but-the-429-disappeared.md

## Changes Made

- bind one ephemeral IPv4 loopback listener with per-instance random Basic proxy credentials and constant-time authorization;
- accept bounded HTTP absolute-form and CONNECT requests, reject ambiguous framing, and strip proxy/hop-by-hop credentials;
- resolve once per inbound connection, classify the complete answer set through #1301, and deny any prohibited answer before dialing;
- convert approved answers into canonical family-bound numeric endpoints and connect without a hostname lookup or Direct fallback;
- pin one destination per connection, constrain plain HTTP to its declared body, and tunnel CONNECT/WebSocket Upgrade only to the selected peer;
- bound headers, DNS, total connect time, idle time, bytes, answer count, concurrency, cancellation, and shutdown;
- add 37 focused protocol/security tests and a dedicated 12-job Linux/macOS/Windows × Python 3.10-3.13 matrix;
- document exact limits, error/privacy contracts, credential lifetime, and rollback behavior.

No dependency was added.

## Testing

```text
$ python3 <isolated pytest bootstrap> tests/unit/test_remote_browser_destination_policy.py tests/unit/test_remote_browser_egress_gateway.py
........................................................................ [ 34%]
........................................................................ [ 69%]
..............................................................           [100%]
206 passed in 0.19s

$ python3 -m ruff check connectonion/network/host/destination_policy.py connectonion/network/host/egress_gateway.py tests/unit/test_remote_browser_destination_policy.py tests/unit/test_remote_browser_egress_gateway.py
All checks passed!

$ python3 -m black --check connectonion/network/host/destination_policy.py connectonion/network/host/egress_gateway.py tests/unit/test_remote_browser_destination_policy.py tests/unit/test_remote_browser_egress_gateway.py
All done! 4 files would be left unchanged.

$ python3 -m compileall -q connectonion/network/host/destination_policy.py connectonion/network/host/egress_gateway.py tests/unit/test_remote_browser_destination_policy.py tests/unit/test_remote_browser_egress_gateway.py
$ git diff --check

$ python3 <workflow YAML assertion>
workflow YAML parsed; remote-browser-egress matrix: 12 jobs
```

- [x] I have added tests for new functionality

## Scope

- `connectonion/network/host/egress_gateway.py`: internal listener, parser, auth, resolver, policy, numeric dialer, forwarding, limits, and lifecycle.
- `tests/unit/test_remote_browser_egress_gateway.py`: zero-dial, real-loopback protocol, framing, privacy, retry, timeout, race, cancellation, and cleanup contracts.
- `.github/workflows/tests.yml`: focused native socket matrix on every supported Python and desktop/server OS.
- `docs/network/remote-browser-egress-gateway.md`: executable behavior and defaults.
- `docs/design-decisions/056-remote-browser-egress-gateway.md`: implementation-doc link for design step 2.
- `docs/blog/2026-08-26-the-proxy-replied-but-the-429-disappeared.md`: engineering story.

## Example Usage

```python
from connectonion.network.host.egress_gateway import EgressGateway

async with EgressGateway() as gateway:
    endpoint = gateway.endpoint
    # A later Host-private BrowserDaemon context will receive endpoint directly.
```

## Checklist

- [x] I proposed at least one label and a target version above
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings locally
- [ ] Any dependent changes have been merged and published — #1299 and #1301 remain deliberate review dependencies
- [x] If this targets a stable patch, its separate `forward-port-required` tracker names every active higher line — N/A, alpha feature work
- [x] Every piece of evidence the linked issue's AI implementation contract requires is attached or linked here; hosted matrix pending

## Screenshots (if applicable)

N/A — internal network boundary and documentation only.

## Additional Notes

The tests redirect approved public numeric endpoints to injected local protocol servers. That exercises real loopback TCP behavior without creating a private-network allow exception in production policy. No external destination is contacted.
