### PR TITLE
feat: isolate the Remote Browser private runtime

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,9 +102,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Run destination policy and native loopback gateway contracts
+      - name: Run destination, gateway, and private runtime contracts
         run: |
-          python -m pytest tests/unit/test_remote_browser_destination_policy.py tests/unit/test_remote_browser_egress_gateway.py -v --tb=short
+          python -m pytest tests/unit/test_remote_browser_destination_policy.py tests/unit/test_remote_browser_egress_gateway.py tests/unit/test_remote_browser_private_runtime.py tests/unit/test_remote_browser_service.py tests/e2e/cli/test_remote_browser_daemon.py -v --tb=short
 
   # Validate the native Windows browser IPC (named-pipe daemon transport) — the
   # `co browser` daemon uses Unix sockets on POSIX and Windows named pipes here.

--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -2,8 +2,8 @@
 Purpose: Browser daemon client — sends short browser commands over the platform transport and runs the natural-language `do` agent locally so model waits never occupy the daemon.
 LLM-Note:
   Dependencies: imports from [socket, os, json, sys, time, shlex, inspect, functools, pathlib, browser_agent.transport | lazy: BrowserAutomation and browser_agent.agent for `do`] | imported by [cli/commands/browser_commands.py] | tested by [tests/e2e/cli/test_browser_daemon.py]
-  Data flow: direct verb → _request() → wire-v1 JSON {v,caller,account,tab,line,raw}; `do` → local Agent + DaemonBrowserProxy → each tool invocation becomes one short _request(raw=True) to the shared daemon
-  State/Effects: may spawn the daemon via `python -m connectonion.cli.browser_agent.daemon <sock> [--headless]` detached (transport.spawn_detached: start_new_session POSIX / DETACHED_PROCESS Windows), logging to ~/.co/browser.log | writes to stdout/stderr
+  Data flow: direct verb → _request() → wire-v1 JSON {v,caller,account,tab,line,raw}; Host request_target_as() selects an explicit private endpoint/profile/authkey/log without putting proxy credentials on argv; `do` → local Agent + DaemonBrowserProxy → each tool invocation becomes one short _request(raw=True) to the shared daemon
+  State/Effects: may spawn the daemon via `python -m connectonion.cli.browser_agent.daemon <sock> [--headless]` detached (transport.spawn_detached: start_new_session POSIX / DETACHED_PROCESS Windows), logging to ~/.co/browser.log or the explicit private target log | writes to stdout/stderr
   Integration: exposes _caller() -> str, send(line, headless=False, tab=None) -> int | FIRST-RUN AUTO-INSTALL: on the cold-start path (no daemon yet) AND when a warm daemon answers "No browser is installed for this user" (send retries once), a page-driving verb with no system Chrome triggers `python -m patchright install chromium` right in the user's terminal (chromium: per-user dir, never needs admin — the branded chrome channel runs a system installer) (_ensure_browser_ready) — `co browser` just works with zero setup commands; PAGELESS_VERBS (status/tab/close/...) never provision
   Performance: direct verbs import only the lightweight transport client, then make one connect + request/response; Agent/Playwright and browser tool schemas load only for `do` or inside the daemon | daemon spawn adds browser launch latency on first call | model thinking happens in the caller process and holds no daemon lane
   Errors: _connect() retries transient refusal/backpressure and never unlinks an endpoint whose recorded owner is alive; only a truly stale POSIX socket is removed | missing endpoint → spawn daemon and wait until ready or timeout | setup RuntimeErrors become one clean stderr line, never a traceback containing HMAC-path locals | daemon death, overload shedding, or disconnect mid-request becomes a clean exit 1
@@ -54,7 +54,7 @@ def _wait_for_pid_exit(pid: int, timeout: float = 15.0) -> bool:
     return True
 
 
-def _connect(sock_path: str):
+def _connect(sock_path: str, authkey_path: str | Path | None = None):
     """Connect to the daemon. Returns a live connection, or None if the daemon is
     genuinely gone. A daemon at its bounded connection cap can momentarily refuse —
     that is NOT a dead daemon, so retry
@@ -63,7 +63,7 @@ def _connect(sock_path: str):
     authenticated named-pipe client from `transport`. Raises RuntimeError only for
     an authkey mismatch against a live daemon (send() turns it into a clean line)."""
     if transport.IS_WINDOWS:
-        return _connect_windows(sock_path)
+        return _connect_windows(sock_path, authkey_path=authkey_path)
     return _connect_posix(sock_path)
 
 
@@ -94,8 +94,8 @@ def _connect_posix(sock_path: str):
     return None  # still refusing after the window — let the caller spawn a fresh daemon
 
 
-def _connect_windows(sock_path: str):
-    authkey = transport.load_or_create_authkey()  # one 64-byte read, hoisted off the loop
+def _connect_windows(sock_path: str, authkey_path: str | Path | None = None):
+    authkey = transport.load_or_create_authkey(authkey_path)  # one 64-byte read, hoisted off the loop
     # Retry window for a briefly-unavailable pipe. (mpc's Client additionally waits out
     # PIPE_BUSY internally, so a genuinely busy daemon behaves like the POSIX backlog:
     # the client waits rather than erroring.)
@@ -121,13 +121,18 @@ def _connect_windows(sock_path: str):
     return None  # still unavailable after the window — let the caller spawn a fresh daemon
 
 
-def _spawn_daemon(sock_path: str, headless: bool):
+def _spawn_daemon(sock_path: str, headless: bool, target=None):
     """Launch the daemon detached and wait until its socket accepts connections."""
-    log_path = Path.home() / ".co" / "browser.log"
+    log_path = Path(target.log_path) if target is not None else Path.home() / ".co" / "browser.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
     cmd = [sys.executable, "-m", "connectonion.cli.browser_agent.daemon", sock_path]
     if headless:
         cmd.append("--headless")
+    if target is not None:
+        cmd.extend(["--profile-dir", str(target.profile_dir)])
+        cmd.extend(["--authkey-file", str(target.authkey_path)])
+        if target.remote_egress:
+            cmd.append("--remote-egress")
     with open(log_path, "a", encoding="utf-8") as log:  # the child dups the handle; ours closes right away
         transport.spawn_detached(cmd, log)  # POSIX: new session · Windows: DETACHED_PROCESS
 
@@ -135,7 +140,11 @@ def _spawn_daemon(sock_path: str, headless: bool):
     # can itself take ~2s of refused-retries, so counting attempts multiplies silently.
     deadline = time.time() + 15
     while time.time() < deadline:
-        conn = _connect(sock_path)
+        conn = (
+            _connect(sock_path, authkey_path=target.authkey_path)
+            if target is not None
+            else _connect(sock_path)
+        )
         if conn:
             return conn
         time.sleep(0.1)
@@ -224,6 +233,7 @@ def _request_with_identity(
     tab: str = None,
     raw_result: bool = False,
     _provisioned: bool = False,
+    target=None,
 ) -> tuple:
     """Send one short daemon request and return ``(code, payload)``.
 
@@ -239,10 +249,15 @@ def _request_with_identity(
         "line": line,
         "raw": raw_result,
     })
-    sock_path = default_sock_path()
+    sock_path = target.address if target is not None else default_sock_path()
+    authkey_path = target.authkey_path if target is not None else None
     owner_pid = None
     try:
-        conn = _connect(sock_path)
+        conn = (
+            _connect(sock_path, authkey_path=authkey_path)
+            if authkey_path is not None
+            else _connect(sock_path)
+        )
         if conn is None:
             if line.split()[:1] == ["status"]:
                 # Asking whether the browser is running must not start it. With
@@ -265,7 +280,7 @@ def _request_with_identity(
                     return 0, "Browser daemon: running, busy at connection capacity — try again shortly"
                 return 0, "Browser daemon: not running — the next page command starts one"
             _ensure_browser_ready(line)  # cold start: provision the browser first
-            conn = _spawn_daemon(sock_path, headless)
+            conn = _spawn_daemon(sock_path, headless, target=target)
         # A successful whole-browser close is a lifecycle barrier on Windows.
         # Record the exact process serving this connection so a concurrently
         # started replacement is never mistaken for the daemon being closed.
@@ -329,6 +344,7 @@ def _request_with_identity(
                 tab=tab,
                 raw_result=raw_result,
                 _provisioned=True,
+                target=target,
             )
 
     # An old (pre-upgrade) daemon shlex-splits the JSON envelope and rejects its first
@@ -391,6 +407,28 @@ def request_as(
         account=account,
         headless=headless,
         tab=tab,
+    )
+
+
+def request_target_as(
+    target,
+    line: str,
+    *,
+    caller: str,
+    account: str,
+    headless: bool = False,
+    tab: str = None,
+) -> tuple:
+    """Send an authenticated Host command only to an explicit daemon target."""
+    if not caller or not account:
+        return 3, "authenticated caller and account are required"
+    return _request_with_identity(
+        line,
+        caller=caller,
+        account=account,
+        headless=headless,
+        tab=tab,
+        target=target,
     )
 
 

--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -280,7 +280,11 @@ def _request_with_identity(
                     return 0, "Browser daemon: running, busy at connection capacity — try again shortly"
                 return 0, "Browser daemon: not running — the next page command starts one"
             _ensure_browser_ready(line)  # cold start: provision the browser first
-            conn = _spawn_daemon(sock_path, headless, target=target)
+            conn = (
+                _spawn_daemon(sock_path, headless, target=target)
+                if target is not None
+                else _spawn_daemon(sock_path, headless)
+            )
         # A successful whole-browser close is a lifecycle barrier on Windows.
         # Record the exact process serving this connection so a concurrently
         # started replacement is never mistaken for the daemon being closed.

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -1,14 +1,15 @@
 """
 Purpose: Persistent concurrent browser daemon — owns one AsyncBrowserCore/event loop and dispatches authenticated CLI requests over POSIX Unix sockets or Windows named pipes.
 LLM-Note:
-  Dependencies: asyncio + bounded Windows transport executor + AsyncBrowserCore + browser_agent.transport; BrowserAutomation is imported only to preserve the public CLI help/schema until #500 installs the sync facade | imported by browser_agent.client and browser_commands | tested by test_async_browser_daemon.py, test_browser_daemon.py, test_transport.py
+  Dependencies: asyncio + bounded Windows transport executor + AsyncBrowserCore + browser_agent.transport; private mode lazily imports EgressGateway and its immutable launch-policy factory; BrowserAutomation is imported only to preserve the public CLI help/schema until #500 installs the sync facade | imported by browser_agent.client and browser_commands | tested by test_async_browser_daemon.py, test_browser_daemon.py, test_transport.py, test_remote_browser_private_runtime.py
   Data flow: wire-v1 JSON {v,caller,account,tab,line,raw} (legacy plain line accepted) → atomic registry/claim admission → request-scoped audit lease → awaited async browser verb → bounded reply with exit code 2 usage / 3 unknown tab / 4 busy; `do` keeps model latency in the client and sends only its short tool calls
-  State/Effects: one asyncio-owned AsyncBrowserCore and persistent context | independent tab tasks interleave; AsyncBrowserCore's per-tab locks serialize one tab | registry lock makes conflicting claims deterministic and clears each request lease in finally | POSIX uses asyncio.start_unix_server with a 1 MiB request cap, absolute 120s read/write deadlines, 32-client cap, and immediate overload shedding | Windows preserves the HMAC named-pipe handshake and bridges accept/read/write through an 8-worker bounded executor into the same loop | lifetime OS lock + pid sidecar preserve cold-start/stale-owner rules | shutdown stops admission, cancels owned connection tasks, closes the runtime, and removes only its own endpoint
+  State/Effects: one asyncio-owned AsyncBrowserCore and persistent context | private mode starts its egress gateway and fixed launch policy before IPC bind; gateway loss rejects before browser mutation; shutdown closes browser before gateway | independent tab tasks interleave; AsyncBrowserCore's per-tab locks serialize one tab | registry lock makes conflicting claims deterministic and clears each request lease in finally | POSIX uses asyncio.start_unix_server with a 1 MiB request cap, absolute 120s read/write deadlines, 32-client cap, and immediate overload shedding | Windows preserves the HMAC named-pipe handshake and bridges accept/read/write through an 8-worker bounded executor into the same loop | lifetime OS lock + pid sidecar preserve cold-start/stale-owner rules | shutdown stops admission, cancels owned connection tasks, closes the runtime, and removes only its own endpoint
   Integration: exposes default_sock_path(), signature_str(), list_functions(), BrowserDaemon, main(); launched detached via `python -m connectonion.cli.browser_agent.daemon <address> [--headless]`; dispatch() is a non-loop compatibility seam for existing pure tests, production awaits dispatch_async()
   Performance: page operations on separate tabs overlap; same-tab work queues; browser/model/image blocking work never owns the event-loop thread; first browser launch remains 1-3s
   Errors: malformed/oversized/stalled clients are bounded at their own connection boundary; cancellation clears only its request lease; vanished readers are logged and cannot stop the daemon; launch failure or closed shared runtime releases the endpoint
 """
 
+import argparse
 import asyncio
 import atexit
 import contextlib
@@ -223,9 +224,32 @@ def launch_failure_advice(first_line: str) -> str:
 class BrowserDaemon:
     """Concurrent server owning one asyncio-native browser runtime."""
 
-    def __init__(self, sock_path: str, headless: bool = False):
+    def __init__(
+        self,
+        sock_path: str,
+        headless: bool = False,
+        *,
+        profile_dir: str | Path | None = None,
+        remote_egress: bool = False,
+        authkey_path: str | Path | None = None,
+        gateway_factory=None,
+        browser_factory=AsyncBrowserCore,
+    ):
         self.sock_path = sock_path
-        self.browser = AsyncBrowserCore(headless=headless)
+        self._headless = headless
+        self._profile_dir = (
+            Path(profile_dir).expanduser().resolve() if profile_dir is not None else None
+        )
+        self._remote_egress = remote_egress
+        self._authkey_path = Path(authkey_path) if authkey_path is not None else None
+        self._gateway_factory = gateway_factory
+        self._browser_factory = browser_factory
+        if self._remote_egress and self._profile_dir is None:
+            raise ValueError("remote browser daemon requires an explicit profile")
+        self._gateway = None
+        self.browser = (
+            None if self._remote_egress else self._browser_factory(headless=headless)
+        )
         self._srv = None
         # Set by _cleanup before it closes the listener, so serve() can tell "we are
         # stopping" from "the socket broke while we were meant to be serving".
@@ -290,6 +314,10 @@ class BrowserDaemon:
             return 2, f"unparseable request: {exc}"
         if not tokens:
             return 2, "empty request"
+        if self._remote_egress and (
+            self._gateway is None or not self._gateway.is_running
+        ):
+            return False, "EGRESS_GATEWAY_UNAVAILABLE"
         verb = tokens[0]
 
         # -t targeting: each task drives its OWN tab. Unknown-tab is only an error for a
@@ -746,13 +774,13 @@ class BrowserDaemon:
 
     async def serve_async(self):
         self._loop = asyncio.get_running_loop()
-        self._bind()
-        atexit.register(self._cleanup)
-        if threading.current_thread() is threading.main_thread():
-            with contextlib.suppress(NotImplementedError, RuntimeError):
-                self._loop.add_signal_handler(signal.SIGTERM, self._begin_shutdown)
-
         try:
+            await self._prepare_runtime()
+            self._bind()
+            atexit.register(self._cleanup)
+            if threading.current_thread() is threading.main_thread():
+                with contextlib.suppress(NotImplementedError, RuntimeError):
+                    self._loop.add_signal_handler(signal.SIGTERM, self._begin_shutdown)
             if transport.IS_WINDOWS:
                 self._transport_pool = ThreadPoolExecutor(
                     max_workers=WINDOWS_TRANSPORT_WORKERS,
@@ -776,6 +804,40 @@ class BrowserDaemon:
                 raise
         finally:
             await self._shutdown_async()
+
+    async def _prepare_runtime(self) -> None:
+        """Start private network authority before exposing the daemon endpoint."""
+        if not self._remote_egress:
+            return
+        if self._gateway is not None or self.browser is not None:
+            if (
+                self._gateway is not None
+                and self.browser is not None
+                and self._gateway.is_running
+            ):
+                return
+            raise RuntimeError("private browser runtime is only prepared once")
+        from connectonion.network.host.egress_gateway import EgressGateway
+        from connectonion.network.host.private_browser_runtime import (
+            remote_browser_launch_policy,
+        )
+
+        gateway = (
+            self._gateway_factory()
+            if self._gateway_factory is not None
+            else EgressGateway()
+        )
+        endpoint = await gateway.start()
+        try:
+            policy = remote_browser_launch_policy(self._profile_dir, endpoint)
+            browser = self._browser_factory(
+                headless=self._headless, launch_policy=policy
+            )
+        except BaseException:
+            await gateway.stop()
+            raise
+        self._gateway = gateway
+        self.browser = browser
 
     def _accept_posix_client(self, reader, writer) -> None:
         """Admit at most ``MAX_IN_FLIGHT`` clients; shed excess immediately."""
@@ -1013,6 +1075,15 @@ class BrowserDaemon:
                     f"browser cleanup failed: {type(exc).__name__}: {exc}",
                     file=sys.stderr,
                 )
+        if self._gateway is not None:
+            try:
+                await self._gateway.stop()
+            except Exception as exc:
+                print(
+                    f"egress gateway cleanup failed: {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                )
+            self._gateway = None
         if self._transport_pool is not None:
             self._transport_pool.shutdown(wait=True, cancel_futures=True)
             self._transport_pool = None
@@ -1039,11 +1110,14 @@ class BrowserDaemon:
         The lifetime lock, pid-file location, and (on Windows) the named-pipe wire live
         behind `transport` so POSIX behavior is byte-identical while Windows gets native
         named pipes with an HMAC-authenticated handshake."""
+        transport.ensure_endpoint_parent(self.sock_path)
         self._bind_lock = transport.acquire_singleton_lock(transport.lock_path(self.sock_path))
         if self._bind_lock is None:
             sys.exit(0)  # another daemon is binding or already serving
         if transport.IS_WINDOWS:
-            self._authkey = transport.load_or_create_authkey()  # the pipe wire's HMAC secret
+            self._authkey = transport.load_or_create_authkey(
+                self._authkey_path
+            )  # the pipe wire's HMAC secret
             self._bind_windows()
         else:
             self._bind_posix()
@@ -1195,9 +1269,20 @@ def main():
         for stream in (sys.stdout, sys.stderr):
             if hasattr(stream, "reconfigure"):
                 stream.reconfigure(encoding="utf-8", errors="replace")
-    sock_path = sys.argv[1] if len(sys.argv) > 1 else default_sock_path()
-    headless = "--headless" in sys.argv[2:]
-    BrowserDaemon(sock_path, headless=headless).serve()
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("sock_path", nargs="?", default=default_sock_path())
+    parser.add_argument("--headless", action="store_true")
+    parser.add_argument("--profile-dir")
+    parser.add_argument("--authkey-file")
+    parser.add_argument("--remote-egress", action="store_true")
+    args = parser.parse_args()
+    BrowserDaemon(
+        args.sock_path,
+        headless=args.headless,
+        profile_dir=args.profile_dir,
+        authkey_path=args.authkey_file,
+        remote_egress=args.remote_egress,
+    ).serve()
 
 
 if __name__ == "__main__":

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -246,6 +246,12 @@ class BrowserDaemon:
         self._browser_factory = browser_factory
         if self._remote_egress and self._profile_dir is None:
             raise ValueError("remote browser daemon requires an explicit profile")
+        if not self._remote_egress and self._profile_dir is not None:
+            # A profile only reaches the browser through the launch policy, which
+            # exists in remote-egress mode. Accepting it here and using the
+            # shared local profile anyway would give a caller its own socket,
+            # lock and log while silently pooling cookies with `co browser`.
+            raise ValueError("a profile directory requires --remote-egress")
         self._gateway = None
         self.browser = (
             None if self._remote_egress else self._browser_factory(headless=headless)

--- a/connectonion/cli/browser_agent/transport.py
+++ b/connectonion/cli/browser_agent/transport.py
@@ -2,9 +2,9 @@ r"""
 Purpose: Cross-platform IPC primitives for the browser daemon/client so `co browser` runs natively on Windows (named pipes) as well as macOS/Linux (Unix sockets) — no WSL.
 LLM-Note:
   Dependencies: imports from [os, time, getpass, subprocess, tempfile, hashlib, binascii, threading, multiprocessing.connection, pathlib | lazy: fcntl/msvcrt, ctypes] | imported by [browser_agent/daemon.py, browser_agent/client.py] | tested by [tests/unit/test_transport.py, tests/e2e/cli/test_browser_daemon.py]
-  Data flow: daemon/client call default_address() → POSIX returns a Unix-socket filesystem path, Windows returns a per-user named pipe \\.\pipe\co-browser-<hash> | pid_path()/lock_path() resolve filesystem sidecars | Windows wire: win_listener() creates the pipe WITHOUT an authkey and accept_authenticated() runs the mutual HMAC challenge under a hard deadline before the daemon submits the connection to its asyncio runtime; win_connect() is a normal authenticated mpc.Client | POSIX binding is handed to asyncio.start_unix_server after the same stale-owner checks
+  Data flow: daemon/client call default_address() for the ordinary endpoint or namespaced_address() for a short hashed private endpoint → POSIX returns a Unix-socket filesystem path, Windows returns a per-user named pipe \\.\pipe\co-browser-<hash> | pid_path()/lock_path() resolve filesystem sidecars | Windows wire: win_listener() creates the pipe WITHOUT an authkey and accept_authenticated() runs the mutual HMAC challenge under a hard deadline before the daemon submits the connection to its asyncio runtime; win_connect() is a normal authenticated mpc.Client | POSIX binding is handed to asyncio.start_unix_server after the same stale-owner checks
   State/Effects: default_address()/_sidecar_dir() may mkdir the runtime dir (and chmod 0700 on POSIX — the socket dir IS the POSIX trust boundary, so a chmod failure raises loudly) | load_or_create_authkey() creates a 0600 key file in the sidecar dir (only used on Windows) and atomically replaces a persistently-corrupt one | acquire_singleton_lock() holds an OS lock (fcntl.flock POSIX / msvcrt.locking Windows) for the daemon's lifetime, released by the OS on death | spawn_detached() launches the daemon fully detached
-  Integration: exposes IS_WINDOWS, AuthenticationError (= mpc's class), HANDSHAKE_TIMEOUT, default_address(), pid_path(), lock_path(), load_or_create_authkey(), pid_alive(), acquire_singleton_lock(), spawn_detached(), win_listener(), win_connect(), bounded_io(), accept_authenticated() | daemon.py owns asyncio admission/backpressure; this module preserves native platform security and blocking-pipe primitives
+  Integration: exposes IS_WINDOWS, AuthenticationError (= mpc's class), HANDSHAKE_TIMEOUT, default_address(), namespaced_address(), ensure_endpoint_parent(), pid_path(), lock_path(), load_or_create_authkey(), pid_alive(), acquire_singleton_lock(), spawn_detached(), win_listener(), win_connect(), bounded_io(), accept_authenticated() | daemon.py owns asyncio admission/backpressure; this module preserves native platform security and blocking-pipe primitives
   Performance: all helpers are cheap local ops | authkey is a 64-byte file read | bounded_io adds one short-lived thread per bounded pipe operation (handshake/read/reply — never touches Playwright)
   Errors: acquire_singleton_lock returns None when the lock is held (caller exits 0) | pid_alive treats EPERM/access-denied as ALIVE (the pid exists — same lesson as browser.py's _pid_alive) | load_or_create_authkey converges on ONE key under the O_EXCL create race, atomically replaces a file that stays invalid past the writers' microsecond window, and RAISES if no valid key can be produced — it never falls back to a fixed key, which would silently disable authentication | bounded_io raises TimeoutError on deadline (after closing the connection so the helper unblocks) and re-raises the operation's own exception otherwise | accept_authenticated returns None on a bad key, a stalled handshake, or a vanished client (the daemon keeps serving); a closed listener still raises out of accept() so a dying daemon exits instead of spinning
 """
@@ -29,6 +29,7 @@ AuthenticationError = mpc.AuthenticationError
 # The mutual HMAC handshake is three tiny local messages — normally sub-millisecond.
 # The deadline exists for a client that connects and then stalls mid-challenge.
 HANDSHAKE_TIMEOUT = 10.0
+_SHORT_RUNTIME_ROOT = Path("/tmp")
 
 
 def _current_user() -> str:
@@ -83,6 +84,47 @@ def default_address() -> str:
         who = hashlib.sha1(_current_user().encode()).hexdigest()[:12]
         return r"\\.\pipe\co-browser-" + who
     return str(_sidecar_dir() / "browser.sock")
+
+
+def namespaced_address(namespace: str) -> str:
+    """Return a short, per-user endpoint for an explicitly isolated daemon.
+
+    The caller's namespace may contain a long project path, so only its digest is
+    used in the Unix socket or named-pipe name. This avoids AF_UNIX path limits
+    while keeping different Host projects and the ordinary local daemon apart.
+    """
+    if not isinstance(namespace, str) or not namespace:
+        raise ValueError("browser daemon namespace must be nonempty")
+    digest = hashlib.sha256(namespace.encode("utf-8")).hexdigest()[:20]
+    if IS_WINDOWS:
+        who = hashlib.sha1(_current_user().encode()).hexdigest()[:12]
+        return rf"\\.\pipe\co-browser-{who}-{digest}"
+    filename = f"browser-{digest}.sock"
+    candidate = _sidecar_dir() / filename
+    # Darwin's sockaddr_un.sun_path is only 104 bytes (Linux is 108). An
+    # unusually long XDG_RUNTIME_DIR must not make every private daemon fail to
+    # bind, so use a deliberately short per-user 0700 fallback before the limit.
+    if len(os.fsencode(candidate)) >= 100:
+        who = hashlib.sha1(_current_user().encode()).hexdigest()[:12]
+        candidate = _SHORT_RUNTIME_ROOT / f"co-{who}" / filename
+    return str(candidate)
+
+
+def ensure_endpoint_parent(address: str) -> None:
+    """Create and protect a missing POSIX endpoint directory before binding.
+
+    An explicit legacy socket may live directly in a shared directory such as
+    ``/tmp``. That directory is not ours to chmod. Private endpoints use the
+    per-user directory returned by :func:`namespaced_address`, which is either
+    already protected by ``_sidecar_dir`` or created here with mode 0700.
+    """
+    if IS_WINDOWS:
+        return
+    parent = Path(address).parent
+    existed = parent.exists()
+    parent.mkdir(parents=True, exist_ok=True)
+    if not existed:
+        os.chmod(parent, 0o700)
 
 
 def _addr_key(address: str) -> str:
@@ -144,7 +186,7 @@ def _replace_corrupt_key(key_file: Path):
     return key
 
 
-def load_or_create_authkey() -> bytes:
+def load_or_create_authkey(path: str | Path | None = None) -> bytes:
     """A per-user secret shared by daemon and client for the named-pipe HMAC handshake.
 
     Only used on Windows (POSIX relies on the 0700 socket dir). Fails CLOSED: this
@@ -154,7 +196,10 @@ def load_or_create_authkey() -> bytes:
     microsecond create→write window), and a file that stays invalid past that window
     is a crashed writer's leftover, replaced atomically.
     """
-    key_file = _sidecar_dir() / "authkey"
+    key_file = Path(path) if path is not None else _sidecar_dir() / "authkey"
+    key_file.parent.mkdir(parents=True, exist_ok=True)
+    if not IS_WINDOWS:
+        os.chmod(key_file.parent, 0o700)
     for attempt in range(50):
         key = _read_key(key_file)
         if key:

--- a/connectonion/cli/browser_agent/transport.py
+++ b/connectonion/cli/browser_agent/transport.py
@@ -106,7 +106,14 @@ def namespaced_address(namespace: str) -> str:
     # bind, so use a deliberately short per-user 0700 fallback before the limit.
     if len(os.fsencode(candidate)) >= 100:
         who = hashlib.sha1(_current_user().encode()).hexdigest()[:12]
-        candidate = _SHORT_RUNTIME_ROOT / f"co-{who}" / filename
+        fallback = _SHORT_RUNTIME_ROOT / f"co-{who}"
+        fallback.mkdir(parents=True, exist_ok=True)
+        # Unlike an explicit legacy socket directly under /tmp, this directory
+        # is ours and is the private endpoint's trust boundary. Re-apply the
+        # mode even when it already exists; a directory owned by someone else
+        # makes chmod fail closed instead of exposing the daemon socket.
+        os.chmod(fallback, 0o700)
+        candidate = fallback / filename
     return str(candidate)
 
 

--- a/connectonion/network/host/egress_gateway.py
+++ b/connectonion/network/host/egress_gateway.py
@@ -285,6 +285,11 @@ class EgressGateway:
             raise RuntimeError("egress gateway is not started")
         return ProxyEndpoint("127.0.0.1", self._port, self.username, self.password)
 
+    @property
+    def is_running(self) -> bool:
+        """Whether this instance still owns a serving listener."""
+        return self._server is not None and self._server.is_serving()
+
     async def start(self) -> ProxyEndpoint:
         async with self._lifecycle_lock:
             if self._server is not None:

--- a/connectonion/network/host/private_browser_runtime.py
+++ b/connectonion/network/host/private_browser_runtime.py
@@ -1,0 +1,70 @@
+"""Host-private BrowserDaemon target and fail-closed launch-policy factory."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from ...cli.browser_agent import transport
+from ...useful_tools.browser_tools.browser_config import (
+    CHROME_DEFAULT_ARGS,
+    IGNORE_DEFAULT_ARGS,
+)
+from ...useful_tools.browser_tools.launch_policy import (
+    BrowserLaunchPolicy,
+    BrowserProxySettings,
+)
+from .egress_gateway import ProxyEndpoint
+
+REMOTE_BROWSER_CHROME_ARGS = (
+    *CHROME_DEFAULT_ARGS,
+    "--proxy-bypass-list=<-loopback>",
+    "--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1",
+    "--disable-quic",
+    "--force-webrtc-ip-handling-policy=disable_non_proxied_udp",
+    "--disable-extensions",
+)
+
+
+@dataclass(frozen=True)
+class PrivateBrowserTarget:
+    """Non-secret paths and mode passed from the Host to its daemon client."""
+
+    address: str
+    profile_dir: Path
+    log_path: Path
+    authkey_path: Path
+    remote_egress: bool = True
+
+    @classmethod
+    def from_state_path(cls, state_path: Path) -> "PrivateBrowserTarget":
+        state_path = Path(state_path).expanduser().resolve()
+        namespace = hashlib.sha256(str(state_path).encode("utf-8")).hexdigest()[:20]
+        root = state_path.parent / "remote-browser-runtime" / namespace
+        root.mkdir(parents=True, exist_ok=True)
+        if os.name != "nt":
+            os.chmod(root, 0o700)
+        return cls(
+            address=transport.namespaced_address(f"remote-{namespace}"),
+            profile_dir=root / "profile",
+            log_path=root / "browser.log",
+            authkey_path=root / "authkey",
+        )
+
+
+def remote_browser_launch_policy(profile_dir: Path, endpoint: ProxyEndpoint) -> BrowserLaunchPolicy:
+    """Bind one gateway endpoint to the exact requested private launch contract."""
+    return BrowserLaunchPolicy(
+        profile_dir=profile_dir,
+        proxy=BrowserProxySettings(
+            server=f"http://{endpoint.host}:{endpoint.port}",
+            username=endpoint.username,
+            password=endpoint.password,
+        ),
+        args=REMOTE_BROWSER_CHROME_ARGS,
+        ignore_default_args=tuple(IGNORE_DEFAULT_ARGS) + ("--use-mock-keychain",),
+        service_workers="block",
+        accept_downloads=True,
+    )

--- a/connectonion/network/host/private_browser_runtime.py
+++ b/connectonion/network/host/private_browser_runtime.py
@@ -18,12 +18,19 @@ from ...useful_tools.browser_tools.launch_policy import (
 )
 from .egress_gateway import ProxyEndpoint
 
+# Every entry here is a switch the launched binary actually defines. A switch
+# Chromium does not recognise is ignored in silence, which makes a misspelling
+# indistinguishable from a working control: `--force-webrtc-ip-handling-policy`
+# appears nowhere in Chrome 151 and left non-proxied UDP fully available, so a
+# page could still open direct UDP sockets past this gateway. The spelling below
+# is the one present in the binary, and BrowserLaunchPolicy now refuses a
+# policy that omits any of REQUIRED_EGRESS_ARGS.
 REMOTE_BROWSER_CHROME_ARGS = (
     *CHROME_DEFAULT_ARGS,
     "--proxy-bypass-list=<-loopback>",
     "--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1",
     "--disable-quic",
-    "--force-webrtc-ip-handling-policy=disable_non_proxied_udp",
+    "--webrtc-ip-handling-policy=disable_non_proxied_udp",
     "--disable-extensions",
 )
 

--- a/connectonion/network/host/remote_browser.py
+++ b/connectonion/network/host/remote_browser.py
@@ -84,10 +84,15 @@ class RemoteBrowserService:
         self.state_path = Path(state_path)
         self.clock = clock
         self._lock = threading.RLock()
+        self.daemon_target = None
         if daemon_request is None:
-            from ...cli.browser_agent.client import request_as
+            from ...cli.browser_agent.client import request_target_as
+            from .private_browser_runtime import PrivateBrowserTarget
 
-            daemon_request = request_as
+            self.daemon_target = PrivateBrowserTarget.from_state_path(self.state_path)
+
+            def daemon_request(line, **identity):
+                return request_target_as(self.daemon_target, line, **identity)
         self.daemon_request = daemon_request
 
     def _load(self) -> dict:

--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -1,9 +1,9 @@
 """
 Purpose: Internal Patchright async browser core for the 1.8 driver migration.
 LLM-Note:
-  Dependencies: imports patchright.async_api, async element finding/humanization, browser_config/chrome_finder, and stdlib | imported by [future async daemon/runtime; tests during migration] | tested by [tests/unit/test_async_browser_core.py, tests/e2e/test_async_browser_core_real_driver.py]
+  Dependencies: imports patchright.async_api, async element finding/humanization, browser_config/chrome_finder, immutable BrowserLaunchPolicy, and stdlib | imported by [future async daemon/runtime; tests during migration] | tested by [tests/unit/test_async_browser_core.py, tests/unit/test_remote_browser_private_runtime.py, tests/e2e/test_async_browser_core_real_driver.py]
   Data flow: caller binds a session in a ContextVar → each async operation acquires that tab's lock → the shared persistent context lazily creates/restores one page per session → model-selected actions await extraction and worker-thread matching → independent tab operations may interleave on one event loop
-  State/Effects: persistent profile at $CO_BROWSER_PROFILE_DIR or ~/.co/browser_profile | one shared BrowserContext | per-session pages/metadata/restore URLs | cancellation-safe context and driver teardown
+  State/Effects: ordinary mode keeps its persistent profile and proxy environment compatibility; private mode uses only the explicit policy profile/proxy/args/service-worker/download settings | one shared BrowserContext | per-session pages/metadata/restore URLs | cancellation-safe context and driver teardown
   Integration: internal AsyncBrowserCore; used directly by the daemon and through the public synchronous BrowserAutomation compatibility facade
   Errors: live profile ownership fails before driver start | launch/cancellation tears down partially-created driver state | destructive keyboard shortcuts fail closed outside editable focus | element ambiguity and non-match errors preserve the synchronous finder contract
 
@@ -32,6 +32,7 @@ from . import _async_scroll as async_scroll
 from . import _async_terminal as terminal
 from .browser_config import CHROME_DEFAULT_ARGS, IGNORE_DEFAULT_ARGS
 from .chrome_finder import find_system_chrome
+from .launch_policy import BrowserLaunchPolicy
 
 try:
     from patchright.async_api import BrowserContext, Page, Playwright, async_playwright
@@ -296,6 +297,7 @@ class AsyncBrowserCore:
         tab_idle_ttl: float = 3600.0,
         max_tabs: int = 10,
         use_mock_keychain: bool = False,
+        launch_policy: BrowserLaunchPolicy | None = None,
     ) -> None:
         self.playwright: Optional[Playwright] = None
         self.browser: Optional[BrowserContext] = None
@@ -311,6 +313,7 @@ class AsyncBrowserCore:
         self._seed_state = seed_state
         self._seeded = False
         self._use_mock_keychain = use_mock_keychain
+        self._launch_policy = launch_policy
         self.current_url = ""
         self.screenshots_dir = str(Path.cwd() / ".tmp")
         self.last_screenshot_path: Optional[str] = None
@@ -521,7 +524,8 @@ class AsyncBrowserCore:
                 if had_previous_state:
                     await self._teardown_unlocked()
 
-            profile_dir = _profile_dir()
+            policy = self._launch_policy
+            profile_dir = policy.profile_dir if policy is not None else _profile_dir()
             profile_dir.mkdir(parents=True, exist_ok=True)
             _clear_stale_profile_lock(profile_dir)
             holder = _profile_lock_holder(profile_dir)
@@ -544,20 +548,27 @@ class AsyncBrowserCore:
                     playwright, _ = await _complete_cleanup(start_task)
                     raise
 
-                launch_task = asyncio.create_task(
-                    playwright.chromium.launch_persistent_context(
-                        str(profile_dir),
-                        headless=headless,
-                        executable_path=find_system_chrome(),
+                launch_options = {
+                    "headless": headless,
+                    "executable_path": find_system_chrome(),
+                    "no_viewport": True,
+                    "timeout": 120000,
+                }
+                if policy is None:
+                    launch_options.update(
                         args=CHROME_DEFAULT_ARGS,
                         ignore_default_args=(
                             IGNORE_DEFAULT_ARGS
                             if self._use_mock_keychain
                             else IGNORE_DEFAULT_ARGS + ["--use-mock-keychain"]
                         ),
-                        no_viewport=True,
                         proxy=_proxy_from_env(),
-                        timeout=120000,
+                    )
+                else:
+                    launch_options.update(policy.playwright_options())
+                launch_task = asyncio.create_task(
+                    playwright.chromium.launch_persistent_context(
+                        str(profile_dir), **launch_options
                     )
                 )
                 try:

--- a/connectonion/useful_tools/browser_tools/launch_policy.py
+++ b/connectonion/useful_tools/browser_tools/launch_policy.py
@@ -1,0 +1,83 @@
+"""Explicit, immutable browser launch inputs for policy-owned runtimes.
+
+The ordinary local browser keeps its environment-compatible launch path.  A
+Host-private runtime instead receives one of these values directly so proxy and
+profile authority cannot drift through process environment variables.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+from urllib.parse import urlsplit
+
+
+@dataclass(frozen=True)
+class BrowserProxySettings:
+    """Playwright proxy settings whose credential is safe to repr or log."""
+
+    server: str
+    username: str
+    password: str = field(repr=False)
+
+    def __post_init__(self) -> None:
+        try:
+            parsed = urlsplit(self.server)
+            port = parsed.port
+        except (TypeError, ValueError):
+            parsed, port = None, None
+        if not (
+            parsed is not None
+            and parsed.scheme == "http"
+            and parsed.hostname == "127.0.0.1"
+            and parsed.username is None
+            and parsed.password is None
+            and parsed.path == ""
+            and parsed.query == ""
+            and parsed.fragment == ""
+            and port is not None
+            and parsed.netloc == f"127.0.0.1:{port}"
+            and isinstance(self.username, str)
+            and isinstance(self.password, str)
+            and self.username
+            and self.password
+        ):
+            raise ValueError("browser proxy must be one authenticated loopback server")
+
+    def playwright_value(self) -> dict[str, str]:
+        return {
+            "server": self.server,
+            "username": self.username,
+            "password": self.password,
+        }
+
+
+@dataclass(frozen=True)
+class BrowserLaunchPolicy:
+    """Complete non-environment launch inputs for one private browser context."""
+
+    profile_dir: Path
+    proxy: BrowserProxySettings
+    args: tuple[str, ...]
+    ignore_default_args: tuple[str, ...] = ()
+    service_workers: Literal["allow", "block"] = "block"
+    accept_downloads: bool = True
+
+    def __post_init__(self) -> None:
+        profile = Path(self.profile_dir).expanduser().resolve()
+        object.__setattr__(self, "profile_dir", profile)
+        if not self.args or len(set(self.args)) != len(self.args):
+            raise ValueError("browser launch arguments must be nonempty and unique")
+        if self.service_workers != "block":
+            raise ValueError("private browser launch policy must block Service Workers")
+
+    def playwright_options(self) -> dict:
+        """Return a fresh mapping so a driver cannot mutate the frozen policy."""
+        return {
+            "args": list(self.args),
+            "ignore_default_args": list(self.ignore_default_args),
+            "proxy": self.proxy.playwright_value(),
+            "service_workers": self.service_workers,
+            "accept_downloads": self.accept_downloads,
+        }

--- a/connectonion/useful_tools/browser_tools/launch_policy.py
+++ b/connectonion/useful_tools/browser_tools/launch_policy.py
@@ -53,6 +53,19 @@ class BrowserProxySettings:
         }
 
 
+# The switches that make a private policy fail closed. Held here rather than
+# only in the caller's constant, because a policy that pins a proxy while
+# leaving the browser free to bypass it, resolve names itself, or open QUIC and
+# WebRTC UDP sockets is not a boundary — and it validated fine when the only
+# check was "the constant equals itself".
+REQUIRED_EGRESS_ARGS = (
+    "--proxy-bypass-list=<-loopback>",
+    "--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1",
+    "--disable-quic",
+    "--webrtc-ip-handling-policy=disable_non_proxied_udp",
+)
+
+
 @dataclass(frozen=True)
 class BrowserLaunchPolicy:
     """Complete non-environment launch inputs for one private browser context."""
@@ -71,6 +84,13 @@ class BrowserLaunchPolicy:
             raise ValueError("browser launch arguments must be nonempty and unique")
         if self.service_workers != "block":
             raise ValueError("private browser launch policy must block Service Workers")
+        missing = [arg for arg in REQUIRED_EGRESS_ARGS if arg not in self.args]
+        if missing:
+            raise ValueError(
+                f"private browser launch policy is missing egress arguments: {missing}"
+            )
+        if any(arg == "--proxy-server" or arg.startswith("--proxy-server=") for arg in self.args):
+            raise ValueError("proxy authority belongs to `proxy`, not to a bare argument")
 
     def playwright_options(self) -> dict:
         """Return a fresh mapping so a driver cannot mutate the frozen policy."""

--- a/docs/blog/2026-08-26-a-private-tab-is-not-a-private-browser.md
+++ b/docs/blog/2026-08-26-a-private-tab-is-not-a-private-browser.md
@@ -1,0 +1,60 @@
+# A Private Tab Is Not a Private Browser
+
+*2026-08-26*
+
+Remote Browser already had owner-bound tabs. Alice could reconnect to her tab,
+Bob could not see it, and the Host could stop it without guessing which caller
+owned the session. It was tempting to put the new egress proxy on that tab and
+move on to navigation.
+
+Then we looked at where Chromium accepts a proxy.
+
+The durable profile and proxy belong to the browser context, not to our tab
+registry. A Remote Browser tab inside the ordinary `co browser` process would
+therefore share network authority with local tabs. Setting the gateway for the
+remote tab could redirect local browsing. Keeping the existing context could
+do the reverse: a local environment proxy or profile preference could become
+part of Remote Browser without the Host ever choosing it.
+
+The tab was private in our database. The browser was not private at the layer
+that opens sockets.
+
+## We kept the implementation and changed the ownership boundary
+
+The fix was not a second browser driver. The Host now starts the same
+`BrowserDaemon` and `AsyncBrowserCore` behind a different native endpoint, lock,
+profile, log, and Windows authentication key. Its launch inputs arrive as one
+immutable value instead of being rediscovered from process environment
+variables.
+
+That separation gave startup an order we can test. The egress gateway must be
+serving before the browser object exists, and both must exist before the IPC
+endpoint becomes reachable. Shutdown reverses the authority: browser first,
+gateway second. If the gateway disappears, the daemon refuses commands before
+touching a tab. It never tries Direct because Direct is not a recovery path; it
+is a different security policy.
+
+One regression made the boundary clearer. Our first endpoint helper protected
+its parent directory with mode `0700`. That was correct for the private runtime
+directory and disastrously broad for an explicit legacy socket at
+`/tmp/browser.sock`: it tried to change `/tmp` itself. The adjacent local-daemon
+suite caught it. The helper now hardens only a directory it creates, while the
+private address factory owns and verifies its dedicated directory.
+
+## Configuration is evidence, not the verdict
+
+The private launch asks Chromium to use one authenticated loopback proxy, block
+Service Workers, disable QUIC and non-proxied WebRTC UDP, subtract Chromium's
+implicit loopback bypass, and fail browser-side hostname resolution outside the
+gateway. Tests also prove that ordinary local browsing still honors its old
+environment-compatible configuration.
+
+But a list of launch flags is not proof that Chromium cannot escape them. This
+slice deliberately leaves navigation unavailable. The next test must run the
+pinned browser on every supported operating system, attempt redirects,
+subresources, workers, WebSockets, downloads, and DNS rebinding, and observe
+zero connections at private sentinels.
+
+A private session begins with identity. A private browser also needs exclusive
+ownership of the process boundaries that decide profile, proxy, and sockets.
+The word “private” is only earned at the lowest layer that can violate it.

--- a/docs/design-decisions/056-remote-browser-egress-gateway.md
+++ b/docs/design-decisions/056-remote-browser-egress-gateway.md
@@ -309,6 +309,9 @@ OAuth redirects, WebSockets, and downloads remain usable.
 
 The executable limits and protocol contract for step 2 are documented in
 [Remote Browser egress gateway](../network/remote-browser-egress-gateway.md).
+The namespace, profile, launch-policy, and shutdown contract for step 3 is
+documented in
+[Remote Browser private runtime](../network/remote-browser-private-runtime.md).
 
 Each step is its own reviewable PR with documentation, unit tests, native E2E,
 and a rollback that leaves navigation unavailable rather than bypassing the

--- a/docs/network/remote-browser-private-runtime.md
+++ b/docs/network/remote-browser-private-runtime.md
@@ -59,8 +59,24 @@ requests:
 - QUIC disabled;
 - non-proxied WebRTC UDP disabled;
 - extensions disabled;
-- Service Workers blocked; and
+- Service Workers requested blocked; and
 - a dedicated persistent profile with downloads accepted.
+
+Each switch above is present in the launched binary. That is not a formality:
+`--force-webrtc-ip-handling-policy` — the spelling this policy carried until it
+was checked against Chrome 151 — appears nowhere in that binary, and Chromium
+ignores an unknown switch in silence, so a page kept full non-proxied UDP while
+the configuration read as enforced. `BrowserLaunchPolicy` now refuses to
+construct without each of the four egress switches, so the invariant belongs to
+the type rather than to one module's tuple.
+
+**The Service Worker request is not effective on the shipped driver.** Measured
+against real Chrome with these options, `service_workers="block"` registers,
+activates and controls a page exactly as `"allow"` does; the bundled driver
+gates only its own network inspection on that value. Worker traffic still goes
+through the gateway, which remains the final authority, so this widens no
+egress — but it is a requested control that does not hold, tracked separately
+rather than described here as a guarantee.
 
 The proxy value rejects non-loopback hosts, alternate spellings, paths,
 userinfo, query strings, fragments, empty credentials, and fallback proxy

--- a/docs/network/remote-browser-private-runtime.md
+++ b/docs/network/remote-browser-private-runtime.md
@@ -1,0 +1,83 @@
+# Remote Browser private runtime
+
+Remote Browser lifecycle uses the existing `BrowserDaemon` and
+`AsyncBrowserCore`, but it does not attach to the ordinary local `co browser`
+instance. The Host derives a private target from its durable Remote Browser
+state path and starts the same daemon implementation with explicit authority.
+
+This is delivery step 3 of
+[DD-056](../design-decisions/056-remote-browser-egress-gateway.md). It isolates
+the runtime and wires the loopback gateway into Chromium's requested launch
+configuration. It does **not** expose navigation or claim that Chromium's
+effective network behavior has passed the native bypass vectors required by
+step 4.
+
+## Isolation contract
+
+Each Host state file deterministically selects one private runtime with its own:
+
+- native Unix socket or Windows named-pipe namespace;
+- lifetime PID and singleton-lock sidecars;
+- persistent browser profile;
+- daemon log;
+- Windows IPC authentication key; and
+- ephemeral authenticated egress gateway credential.
+
+The local `co browser` namespace and profile remain unchanged. Local and private
+daemons can run at the same time and stop independently. Long project paths are
+hashed into short endpoint names so Darwin's `AF_UNIX` limit cannot collapse
+the isolation contract into a launch failure.
+
+The private runtime directory is mode `0700` on POSIX. The Windows auth key is
+created through the existing atomic, per-file HMAC-key path. Gateway passwords
+are never command-line arguments and are excluded from dataclass
+representations. The session registry, state file, log path, errors, and command
+results contain no proxy credential.
+
+## Start and stop order
+
+```text
+start gateway -> build immutable launch policy -> build browser -> bind IPC
+
+stop admission -> close browser -> stop gateway -> remove owned IPC state
+```
+
+If the gateway cannot start or the browser cannot be constructed, the daemon
+never binds its IPC endpoint. If the gateway stops serving later, every daemon
+command returns `EGRESS_GATEWAY_UNAVAILABLE` before a tab or browser mutation.
+There is no Direct fallback.
+
+## Requested Chromium launch policy
+
+The daemon passes one immutable policy directly to `AsyncBrowserCore`; private
+launch does not consult `BROWSER_PROXY` or `CO_BROWSER_PROFILE_DIR`. The policy
+requests:
+
+- the authenticated gateway at exactly `http://127.0.0.1:<ephemeral-port>`;
+- Chromium's subtractive `<-loopback>` proxy-bypass rule;
+- `MAP * ~NOTFOUND, EXCLUDE 127.0.0.1` host-resolver rules;
+- QUIC disabled;
+- non-proxied WebRTC UDP disabled;
+- extensions disabled;
+- Service Workers blocked; and
+- a dedicated persistent profile with downloads accepted.
+
+The proxy value rejects non-loopback hosts, alternate spellings, paths,
+userinfo, query strings, fragments, empty credentials, and fallback proxy
+lists. These tests prove the configuration requested from Playwright. They do
+not prove that a pinned Chromium build honored every switch or that every
+request class used the proxy; those are the native zero-socket assertions in
+the next delivery step.
+
+## Verification and rollback
+
+The focused matrix runs on Linux, macOS, and Windows with Python 3.10–3.13. It
+checks namespace separation, secret-safe launch values, gateway-before-bind and
+browser-before-gateway ordering, fail-closed gateway loss, environment
+independence, concurrent local/private native daemons, and signed OIP lifecycle
+reconnection through the private target.
+
+Rollback removes the private target selection and daemon launch mode together.
+Remote Browser then returns to lifecycle-only operation with navigation still
+unavailable. Rollback must never point Remote Browser at the ordinary local
+daemon or remove the gateway while leaving page commands enabled.

--- a/docs/network/remote-browser.md
+++ b/docs/network/remote-browser.md
@@ -104,7 +104,10 @@ The remote browser runs as a separate instance from your local `co browser` —
 same code, its own profile and socket namespace. Two reasons: a remote caller's
 session must not sit in the browser holding your logins, and Chromium's proxy
 setting is per-browser, not per-tab, so pinning the gateway on your everyday
-browser would cut off your own local browsing.
+browser would cut off your own local browsing. The namespace, profile, IPC
+credential and gateway are described in
+[Remote Browser private runtime](remote-browser-private-runtime.md); that
+isolation is the runtime boundary navigation needs, not navigation itself.
 
 TLS stays end to end. The gateway installs no root certificate and reads no page
 content; for `CONNECT` it dials the approved address while the browser's own

--- a/tests/e2e/cli/test_remote_browser_daemon.py
+++ b/tests/e2e/cli/test_remote_browser_daemon.py
@@ -3,15 +3,15 @@
 import asyncio
 import contextlib
 import json
-import os
 import threading
 import time
+from pathlib import Path
 
 from connectonion import address
 from connectonion.cli.browser_agent import transport
-from connectonion.cli.browser_agent.client import request_as
 from connectonion.cli.browser_agent.daemon import BrowserDaemon
 from connectonion.network.connect import RemoteAgent
+from connectonion.network.host.private_browser_runtime import PrivateBrowserTarget
 from connectonion.network.host.remote_browser import RemoteBrowserService
 from connectonion.network.host.server import _make_remote_browser
 from connectonion.network.host.ws_router import session as ws_session
@@ -20,7 +20,7 @@ from connectonion.network.host.ws_router import session as ws_session
 class LifecycleBrowser:
     """Small runtime seam: the test targets transport/claims, not Chrome."""
 
-    def __init__(self):
+    def __init__(self, **_kwargs):
         self._tab_meta = {}
         self._pages = {}
 
@@ -31,7 +31,7 @@ class LifecycleBrowser:
         self._tab_meta.pop(name, None)
         return f"Closed tab {name}"
 
-    def close(self):
+    async def close(self):
         return "Browser closed"
 
 
@@ -102,7 +102,7 @@ async def _signed_start(service, monkeypatch):
 def _wait_for_daemon(socket_path):
     deadline = time.time() + 5
     while time.time() < deadline:
-        if os.path.exists(transport.pid_path(socket_path)):
+        if Path(transport.pid_path(socket_path)).exists():
             return
         time.sleep(0.02)
     raise RuntimeError("daemon did not bind in time")
@@ -111,25 +111,28 @@ def _wait_for_daemon(socket_path):
 def test_remote_lifecycle_uses_one_native_daemon_and_survives_host_restart(
     tmp_path, monkeypatch
 ):
-    socket_path = f"/tmp/co_remote_{os.getpid()}_{time.time_ns()}.sock"
-    monkeypatch.setenv("CO_BROWSER_SOCK", socket_path)
-    daemon = BrowserDaemon(socket_path, headless=True)
-    daemon.browser = LifecycleBrowser()
+    state_path = tmp_path / "remote-browser-sessions.json"
+    target = PrivateBrowserTarget.from_state_path(state_path)
+    daemon = BrowserDaemon(
+        target.address,
+        headless=True,
+        profile_dir=target.profile_dir,
+        authkey_path=target.authkey_path,
+        remote_egress=True,
+        browser_factory=LifecycleBrowser,
+    )
     thread = threading.Thread(target=daemon.serve, daemon=True)
     thread.start()
     try:
-        _wait_for_daemon(socket_path)
-        state_path = tmp_path / "remote-browser-sessions.json"
-        service = RemoteBrowserService(state_path, daemon_request=request_as)
+        _wait_for_daemon(target.address)
+        service = RemoteBrowserService(state_path)
         started, owner = asyncio.run(_signed_start(service, monkeypatch))
         assert started["ok"] is True
         session_id = started["result"]["session_id"]
         assert len(daemon.browser._tab_meta) == 1
         assert next(iter(daemon.browser._tab_meta.values()))["opened_by"] == owner
 
-        restarted_host_service = RemoteBrowserService(
-            state_path, daemon_request=request_as
-        )
+        restarted_host_service = RemoteBrowserService(state_path)
         status = restarted_host_service.handle(
             {
                 "request_id": "native-status",
@@ -156,10 +159,9 @@ def test_remote_lifecycle_uses_one_native_daemon_and_survives_host_restart(
         daemon._cleanup()
         thread.join(timeout=2)
         for path in (
-            socket_path,
-            transport.pid_path(socket_path),
-            transport.lock_path(socket_path),
+            target.address,
+            transport.pid_path(target.address),
+            transport.lock_path(target.address),
         ):
             with contextlib.suppress(OSError):
-                if os.path.exists(path):
-                    os.unlink(path)
+                Path(path).unlink(missing_ok=True)

--- a/tests/unit/test_remote_browser_egress_gateway.py
+++ b/tests/unit/test_remote_browser_egress_gateway.py
@@ -90,7 +90,9 @@ async def test_concurrent_start_and_stop_share_one_listener_and_cleanup_once():
     endpoints = await asyncio.gather(*(gateway.start() for _ in range(10)))
 
     assert len({(endpoint.host, endpoint.port) for endpoint in endpoints}) == 1
+    assert gateway.is_running is True
     await asyncio.gather(*(gateway.stop() for _ in range(10)))
+    assert gateway.is_running is False
     assert gateway._server is None
     assert gateway._client_tasks == set()
     with pytest.raises(RuntimeError):

--- a/tests/unit/test_remote_browser_private_runtime.py
+++ b/tests/unit/test_remote_browser_private_runtime.py
@@ -1,0 +1,437 @@
+"""Isolation and launch contracts for the Host-private browser runtime."""
+
+import contextlib
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from connectonion.cli.browser_agent import client, transport
+from connectonion.cli.browser_agent.daemon import BrowserDaemon
+from connectonion.network.host.egress_gateway import ProxyEndpoint
+from connectonion.network.host.private_browser_runtime import (
+    REMOTE_BROWSER_CHROME_ARGS,
+    PrivateBrowserTarget,
+    remote_browser_launch_policy,
+)
+from connectonion.network.host.remote_browser import RemoteBrowserService
+from connectonion.useful_tools.browser_tools import _async_browser as async_browser
+from connectonion.useful_tools.browser_tools.launch_policy import BrowserProxySettings
+
+
+class LifecycleBrowser:
+    def __init__(self, *, headless=True, launch_policy=None, events=None):
+        self._headless = headless
+        self.launch_policy = launch_policy
+        self.events = events
+        self._tab_meta = {}
+        self._pages = {}
+
+    def _bind_session(self, session):
+        self.session = session
+
+    def close_tab(self, name):
+        self._tab_meta.pop(name, None)
+        return f"Closed tab {name}"
+
+    async def close(self):
+        if self.events is not None:
+            self.events.append("browser.stop")
+
+
+class RecordingGateway:
+    def __init__(self, events, password="gateway-secret"):
+        self.events = events
+        self.endpoint = ProxyEndpoint("127.0.0.1", 43123, "connectonion", password)
+        self.is_running = False
+
+    async def start(self):
+        self.events.append("gateway.start")
+        self.is_running = True
+        return self.endpoint
+
+    async def stop(self):
+        self.events.append("gateway.stop")
+        self.is_running = False
+
+
+def _wait_for_daemon(address):
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        if Path(transport.pid_path(address)).exists():
+            return
+        time.sleep(0.02)
+    raise RuntimeError("daemon did not bind")
+
+
+def test_private_target_is_stable_short_and_separate_from_local(tmp_path, monkeypatch):
+    monkeypatch.setattr(transport, "IS_WINDOWS", False)
+    monkeypatch.setattr(transport, "_sidecar_dir", lambda: tmp_path / "ipc")
+    monkeypatch.setattr(transport, "_SHORT_RUNTIME_ROOT", Path("/r"))
+    state = tmp_path / ("deep-" * 40) / ".co" / "sessions.json"
+
+    first = PrivateBrowserTarget.from_state_path(state)
+    second = PrivateBrowserTarget.from_state_path(state)
+    other = PrivateBrowserTarget.from_state_path(state.parent / "other-sessions.json")
+
+    assert first == second
+    assert first.address != other.address
+    assert first.address != transport.default_address()
+    assert len(first.address.encode()) < 100
+    assert first.profile_dir != other.profile_dir
+    assert first.log_path.parent == first.authkey_path.parent
+    assert transport.pid_path(first.address) != transport.pid_path(transport.default_address())
+    assert transport.lock_path(first.address) != transport.lock_path(transport.default_address())
+    assert first.profile_dir.parent.stat().st_mode & 0o777 == 0o700
+
+
+def test_windows_namespaces_include_user_and_stable_digest(monkeypatch):
+    monkeypatch.setattr(transport, "IS_WINDOWS", True)
+    monkeypatch.setattr(transport, "_current_user", lambda: "alice")
+
+    one = transport.namespaced_address("host-one")
+    two = transport.namespaced_address("host-two")
+
+    assert one.startswith(r"\\.\pipe\co-browser-")
+    assert one == transport.namespaced_address("host-one")
+    assert one != two
+
+
+def test_launch_policy_is_fixed_fail_closed_and_secret_safe(tmp_path):
+    endpoint = ProxyEndpoint("127.0.0.1", 43123, "connectonion", "proxy-secret")
+    policy = remote_browser_launch_policy(tmp_path / "profile", endpoint)
+    options = policy.playwright_options()
+
+    assert options["proxy"] == {
+        "server": "http://127.0.0.1:43123",
+        "username": "connectonion",
+        "password": "proxy-secret",
+    }
+    assert options["service_workers"] == "block"
+    assert options["accept_downloads"] is True
+    assert tuple(options["args"]) == REMOTE_BROWSER_CHROME_ARGS
+    assert "--proxy-bypass-list=<-loopback>" in options["args"]
+    assert "--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1" in options["args"]
+    assert "--disable-quic" in options["args"]
+    assert "--force-webrtc-ip-handling-policy=disable_non_proxied_udp" in options["args"]
+    assert "--disable-extensions" in options["args"]
+    assert "direct" not in options["proxy"]["server"].lower()
+    assert "proxy-secret" not in repr(endpoint)
+    assert "proxy-secret" not in repr(policy)
+
+
+@pytest.mark.parametrize(
+    "server",
+    (
+        "https://127.0.0.1:43123",
+        "http://localhost:43123",
+        "http://127.0.0.1:43123/path",
+        "http://127.0.0.1:43123@public.example",
+        "http://127.0.0.1:43123,direct://",
+    ),
+)
+def test_launch_proxy_rejects_every_noncanonical_or_fallback_server(server):
+    with pytest.raises(ValueError, match="authenticated loopback"):
+        BrowserProxySettings(server, "connectonion", "secret")
+
+
+@pytest.mark.asyncio
+async def test_daemon_starts_gateway_before_browser_and_stops_it_after_browser(
+    tmp_path,
+):
+    events = []
+    gateway = RecordingGateway(events)
+
+    def browser_factory(**kwargs):
+        events.append("browser.create")
+        return LifecycleBrowser(events=events, **kwargs)
+
+    daemon = BrowserDaemon(
+        str(tmp_path / "private.sock"),
+        headless=True,
+        profile_dir=tmp_path / "profile",
+        remote_egress=True,
+        gateway_factory=lambda: gateway,
+        browser_factory=browser_factory,
+    )
+
+    await daemon._prepare_runtime()
+    assert events == ["gateway.start", "browser.create"]
+    assert daemon.browser.launch_policy.profile_dir == (tmp_path / "profile").resolve()
+    await daemon._prepare_runtime()
+    assert events == ["gateway.start", "browser.create"]
+    await daemon._shutdown_async()
+    assert events == [
+        "gateway.start",
+        "browser.create",
+        "browser.stop",
+        "gateway.stop",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_browser_construction_failure_closes_gateway_before_ipc_bind(tmp_path):
+    events = []
+    gateway = RecordingGateway(events)
+
+    def fail_browser(**_kwargs):
+        events.append("browser.fail")
+        raise RuntimeError("launch policy rejected")
+
+    daemon = BrowserDaemon(
+        str(tmp_path / "never-bound.sock"),
+        profile_dir=tmp_path / "profile",
+        remote_egress=True,
+        gateway_factory=lambda: gateway,
+        browser_factory=fail_browser,
+    )
+    with pytest.raises(RuntimeError, match="launch policy rejected"):
+        await daemon._prepare_runtime()
+
+    assert events == ["gateway.start", "browser.fail", "gateway.stop"]
+    assert not Path(daemon.sock_path).exists()
+    assert not Path(transport.pid_path(daemon.sock_path)).exists()
+
+
+@pytest.mark.asyncio
+async def test_gateway_loss_rejects_lifecycle_before_browser_mutation(tmp_path):
+    events = []
+    gateway = RecordingGateway(events)
+    daemon = BrowserDaemon(
+        str(tmp_path / "private.sock"),
+        profile_dir=tmp_path / "profile",
+        remote_egress=True,
+        gateway_factory=lambda: gateway,
+        browser_factory=LifecycleBrowser,
+    )
+    await daemon._prepare_runtime()
+    gateway.is_running = False
+
+    ok, message = await daemon.dispatch_async("tab open remote --who alice --for remote-browser")
+
+    assert ok is False
+    assert message == "EGRESS_GATEWAY_UNAVAILABLE"
+    assert daemon.browser._tab_meta == {}
+    await daemon._shutdown_async()
+
+
+class FakeContext:
+    def __init__(self):
+        self.pages = []
+
+    async def cookies(self):
+        return []
+
+    async def new_page(self):
+        page = FakePage()
+        self.pages.append(page)
+        return page
+
+    async def close(self):
+        return None
+
+
+class FakePage:
+    def is_closed(self):
+        return False
+
+    def set_default_navigation_timeout(self, _timeout):
+        return None
+
+    async def set_viewport_size(self, _viewport):
+        return None
+
+
+class FakePlaywright:
+    def __init__(self):
+        self.context = FakeContext()
+        self.profile = None
+        self.options = None
+        self.chromium = self
+
+    async def launch_persistent_context(self, profile, **options):
+        self.profile = profile
+        self.options = options
+        return self.context
+
+    async def stop(self):
+        return None
+
+
+class FakeManager:
+    def __init__(self, playwright):
+        self.playwright = playwright
+
+    async def start(self):
+        return self.playwright
+
+
+@pytest.mark.asyncio
+async def test_async_core_uses_private_policy_not_environment_proxy(tmp_path, monkeypatch):
+    playwright = FakePlaywright()
+    monkeypatch.setenv("BROWSER_PROXY", "http://environment.invalid:9999")
+    monkeypatch.setattr(async_browser, "ASYNC_BROWSER_AVAILABLE", True)
+    monkeypatch.setattr(async_browser, "async_playwright", lambda: FakeManager(playwright))
+    monkeypatch.setattr(async_browser, "find_system_chrome", lambda: "/fake/chrome")
+    policy = remote_browser_launch_policy(
+        tmp_path / "private-profile",
+        ProxyEndpoint("127.0.0.1", 43123, "connectonion", "secret"),
+    )
+    browser = async_browser.AsyncBrowserCore(headless=True, launch_policy=policy)
+
+    await browser.open_browser()
+
+    assert playwright.profile == str((tmp_path / "private-profile").resolve())
+    assert playwright.options["proxy"]["server"] == "http://127.0.0.1:43123"
+    assert "environment.invalid" not in repr(playwright.options)
+    assert playwright.options["service_workers"] == "block"
+    await browser.close()
+
+
+@pytest.mark.asyncio
+async def test_ordinary_async_core_keeps_environment_proxy_compatibility(tmp_path, monkeypatch):
+    playwright = FakePlaywright()
+    monkeypatch.setenv("BROWSER_PROXY", "http://local-proxy.example:8080")
+    monkeypatch.setenv("CO_BROWSER_PROFILE_DIR", str(tmp_path / "local-profile"))
+    monkeypatch.setattr(async_browser, "ASYNC_BROWSER_AVAILABLE", True)
+    monkeypatch.setattr(async_browser, "async_playwright", lambda: FakeManager(playwright))
+    monkeypatch.setattr(async_browser, "find_system_chrome", lambda: "/fake/chrome")
+    browser = async_browser.AsyncBrowserCore(headless=True)
+
+    await browser.open_browser()
+
+    assert playwright.profile == str((tmp_path / "local-profile").resolve())
+    assert playwright.options["proxy"]["server"] == "http://local-proxy.example:8080"
+    assert "service_workers" not in playwright.options
+    await browser.close()
+
+
+def test_default_remote_service_targets_private_daemon(tmp_path, monkeypatch):
+    calls = []
+
+    def request_target_as(target, line, **identity):
+        calls.append((target, line, identity))
+        return 0, line.split()[2]
+
+    monkeypatch.setattr(client, "request_target_as", request_target_as)
+    state_path = tmp_path / ".co" / "remote-browser-sessions.json"
+    service = RemoteBrowserService(state_path, clock=lambda: 1000)
+    result = service.handle(
+        {
+            "request_id": "private-start",
+            "command": "start",
+            "args": {"proxy": "direct", "headless": True},
+        },
+        owner="0xalice",
+        transport="direct",
+    )
+
+    assert result["ok"] is True
+    target, _, identity = calls[0]
+    assert target == service.daemon_target
+    assert target.remote_egress is True
+    assert target.profile_dir != Path.home() / ".co" / "browser_profile"
+    assert target.address != transport.default_address()
+    assert identity["caller"] == identity["account"] == "0xalice"
+    assert "password" not in service.state_path.read_text(encoding="utf-8")
+
+
+def test_private_spawn_argv_and_log_never_contain_gateway_secret(tmp_path, monkeypatch):
+    target = PrivateBrowserTarget(
+        address=transport.namespaced_address(f"spawn-{time.time_ns()}"),
+        profile_dir=tmp_path / "profile",
+        log_path=tmp_path / "private.log",
+        authkey_path=tmp_path / "authkey",
+    )
+    spawned = []
+    connection = object()
+    monkeypatch.setattr(
+        transport,
+        "spawn_detached",
+        lambda command, _log: spawned.append(tuple(command)),
+    )
+    monkeypatch.setattr(
+        client,
+        "_connect",
+        lambda _address, authkey_path=None: connection,
+    )
+
+    result = client._spawn_daemon(target.address, True, target=target)
+
+    assert result is connection
+    command = spawned[0]
+    assert "--remote-egress" in command
+    assert command[command.index("--profile-dir") + 1] == str(target.profile_dir)
+    assert command[command.index("--authkey-file") + 1] == str(target.authkey_path)
+    assert "gateway-secret" not in repr(command)
+    assert target.log_path.read_text(encoding="utf-8") == ""
+
+
+def test_local_and_private_native_daemons_run_and_stop_independently(tmp_path):
+    local_address = transport.namespaced_address(f"test-local-{time.time_ns()}")
+    local_target = PrivateBrowserTarget(
+        address=local_address,
+        profile_dir=tmp_path / "local-profile",
+        log_path=tmp_path / "local.log",
+        authkey_path=tmp_path / "local-authkey",
+        remote_egress=False,
+    )
+    private_target = PrivateBrowserTarget.from_state_path(tmp_path / ".co" / "remote-browser-sessions.json")
+    local = BrowserDaemon(local_address, headless=True, authkey_path=local_target.authkey_path)
+    local.browser = LifecycleBrowser()
+    private = BrowserDaemon(
+        private_target.address,
+        headless=True,
+        profile_dir=private_target.profile_dir,
+        authkey_path=private_target.authkey_path,
+        remote_egress=True,
+        gateway_factory=lambda: RecordingGateway([]),
+        browser_factory=LifecycleBrowser,
+    )
+    threads = [
+        threading.Thread(target=local.serve, daemon=True),
+        threading.Thread(target=private.serve, daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+    try:
+        _wait_for_daemon(local_address)
+        _wait_for_daemon(private_target.address)
+        local_code, local_tab = client.request_target_as(
+            local_target,
+            "tab open local --who alice --for local",
+            caller="alice",
+            account="0xalice",
+            headless=True,
+        )
+        private_code, private_tab = client.request_target_as(
+            private_target,
+            "tab open remote --who alice --for remote-browser",
+            caller="alice",
+            account="0xalice",
+            headless=True,
+        )
+        assert (local_code, local_tab) == (0, "local")
+        assert (private_code, private_tab) == (0, "remote")
+        assert set(local.browser._tab_meta) == {"local"}
+        assert set(private.browser._tab_meta) == {"remote"}
+
+        private._cleanup()
+        threads[1].join(timeout=2)
+        assert not threads[1].is_alive()
+        assert threads[0].is_alive()
+        assert set(local.browser._tab_meta) == {"local"}
+    finally:
+        local._cleanup()
+        private._cleanup()
+        for thread in threads:
+            thread.join(timeout=2)
+        for address in (local_address, private_target.address):
+            for path in (
+                address,
+                transport.pid_path(address),
+                transport.lock_path(address),
+            ):
+                with contextlib.suppress(OSError):
+                    Path(path).unlink()

--- a/tests/unit/test_remote_browser_private_runtime.py
+++ b/tests/unit/test_remote_browser_private_runtime.py
@@ -69,7 +69,8 @@ def _wait_for_daemon(address):
 def test_private_target_is_stable_short_and_separate_from_local(tmp_path, monkeypatch):
     monkeypatch.setattr(transport, "IS_WINDOWS", False)
     monkeypatch.setattr(transport, "_sidecar_dir", lambda: tmp_path / "ipc")
-    monkeypatch.setattr(transport, "_SHORT_RUNTIME_ROOT", Path("/r"))
+    short_root = tmp_path / "fallback"
+    monkeypatch.setattr(transport, "_SHORT_RUNTIME_ROOT", short_root)
     state = tmp_path / ("deep-" * 40) / ".co" / "sessions.json"
 
     first = PrivateBrowserTarget.from_state_path(state)
@@ -79,13 +80,14 @@ def test_private_target_is_stable_short_and_separate_from_local(tmp_path, monkey
     assert first == second
     assert first.address != other.address
     assert first.address != transport.default_address()
-    assert len(first.address.encode()) < 100
+    assert Path(first.address).is_relative_to(short_root)
     assert first.profile_dir != other.profile_dir
     assert first.log_path.parent == first.authkey_path.parent
     assert transport.pid_path(first.address) != transport.pid_path(transport.default_address())
     assert transport.lock_path(first.address) != transport.lock_path(transport.default_address())
     if os.name != "nt":
         assert first.profile_dir.parent.stat().st_mode & 0o777 == 0o700
+        assert Path(first.address).parent.stat().st_mode & 0o777 == 0o700
 
 
 def test_windows_namespaces_include_user_and_stable_digest(monkeypatch):

--- a/tests/unit/test_remote_browser_private_runtime.py
+++ b/tests/unit/test_remote_browser_private_runtime.py
@@ -10,7 +10,7 @@ import pytest
 
 from connectonion.cli.browser_agent import client, transport
 from connectonion.cli.browser_agent.daemon import BrowserDaemon
-from connectonion.network.host.egress_gateway import ProxyEndpoint
+from connectonion.network.host.egress_gateway import EgressGateway, ProxyEndpoint
 from connectonion.network.host.private_browser_runtime import (
     REMOTE_BROWSER_CHROME_ARGS,
     PrivateBrowserTarget,
@@ -18,7 +18,10 @@ from connectonion.network.host.private_browser_runtime import (
 )
 from connectonion.network.host.remote_browser import RemoteBrowserService
 from connectonion.useful_tools.browser_tools import _async_browser as async_browser
-from connectonion.useful_tools.browser_tools.launch_policy import BrowserProxySettings
+from connectonion.useful_tools.browser_tools.launch_policy import (
+    BrowserLaunchPolicy,
+    BrowserProxySettings,
+)
 
 
 class LifecycleBrowser:
@@ -118,7 +121,10 @@ def test_launch_policy_is_fixed_fail_closed_and_secret_safe(tmp_path):
     assert "--proxy-bypass-list=<-loopback>" in options["args"]
     assert "--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1" in options["args"]
     assert "--disable-quic" in options["args"]
-    assert "--force-webrtc-ip-handling-policy=disable_non_proxied_udp" in options["args"]
+    # The switch Chromium actually defines. `--force-webrtc-ip-handling-policy`
+    # is silently ignored, so asserting that spelling pinned a dead control.
+    assert "--webrtc-ip-handling-policy=disable_non_proxied_udp" in options["args"]
+    assert not any(arg.startswith("--force-webrtc") for arg in options["args"])
     assert "--disable-extensions" in options["args"]
     assert "direct" not in options["proxy"]["server"].lower()
     assert "proxy-secret" not in repr(endpoint)
@@ -341,7 +347,12 @@ def test_default_remote_service_targets_private_daemon(tmp_path, monkeypatch):
     assert "password" not in service.state_path.read_text(encoding="utf-8")
 
 
-def test_private_spawn_argv_and_log_never_contain_gateway_secret(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_private_spawn_argv_and_log_never_contain_gateway_secret(
+    tmp_path, monkeypatch
+):
+    gateway = EgressGateway()
+    await gateway.start()
     target = PrivateBrowserTarget(
         address=transport.namespaced_address(f"spawn-{time.time_ns()}"),
         profile_dir=tmp_path / "profile",
@@ -361,14 +372,25 @@ def test_private_spawn_argv_and_log_never_contain_gateway_secret(tmp_path, monke
         lambda _address, authkey_path=None: connection,
     )
 
-    result = client._spawn_daemon(target.address, True, target=target)
+    try:
+        secret = gateway.endpoint.password
+        result = client._spawn_daemon(target.address, True, target=target)
+    finally:
+        await gateway.stop()
 
     assert result is connection
     command = spawned[0]
     assert "--remote-egress" in command
     assert command[command.index("--profile-dir") + 1] == str(target.profile_dir)
     assert command[command.index("--authkey-file") + 1] == str(target.authkey_path)
-    assert "gateway-secret" not in repr(command)
+    # Assert the credential the gateway actually minted is absent, not a
+    # literal chosen by this test: the previous form passed on any argv,
+    # including one carrying a real password, because this code path never
+    # sees a gateway at all.
+    assert secret
+    assert secret not in repr(command)
+    assert secret not in " ".join(command)
+    assert secret not in target.log_path.read_text(encoding="utf-8")
     assert target.log_path.read_text(encoding="utf-8") == ""
 
 
@@ -439,3 +461,42 @@ def test_local_and_private_native_daemons_run_and_stop_independently(tmp_path):
             ):
                 with contextlib.suppress(OSError):
                     Path(path).unlink()
+
+
+@pytest.mark.parametrize(
+    "dropped",
+    [
+        "--proxy-bypass-list=<-loopback>",
+        "--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1",
+        "--disable-quic",
+        "--webrtc-ip-handling-policy=disable_non_proxied_udp",
+    ],
+)
+def test_a_policy_missing_any_egress_argument_will_not_construct(tmp_path, dropped):
+    """The invariants live in the type, not in one module's constant.
+
+    A policy that pins a proxy while leaving the browser free to bypass it,
+    resolve names itself, or open QUIC and WebRTC UDP sockets is not a
+    boundary. Validating only the constant is what let a misspelled WebRTC
+    switch — silently ignored by Chromium — read as an enforced control.
+    """
+    proxy = BrowserProxySettings(
+        server="http://127.0.0.1:9999", username="connectonion", password="x"
+    )
+    args = tuple(arg for arg in REMOTE_BROWSER_CHROME_ARGS if arg != dropped)
+
+    with pytest.raises(ValueError) as raised:
+        BrowserLaunchPolicy(profile_dir=tmp_path, proxy=proxy, args=args)
+    assert "egress" in str(raised.value)
+
+
+def test_a_bare_proxy_server_argument_is_refused(tmp_path):
+    proxy = BrowserProxySettings(
+        server="http://127.0.0.1:9999", username="connectonion", password="x"
+    )
+    with pytest.raises(ValueError):
+        BrowserLaunchPolicy(
+            profile_dir=tmp_path,
+            proxy=proxy,
+            args=(*REMOTE_BROWSER_CHROME_ARGS, "--proxy-server=http://127.0.0.1:1"),
+        )

--- a/tests/unit/test_remote_browser_private_runtime.py
+++ b/tests/unit/test_remote_browser_private_runtime.py
@@ -1,6 +1,7 @@
 """Isolation and launch contracts for the Host-private browser runtime."""
 
 import contextlib
+import os
 import threading
 import time
 from pathlib import Path
@@ -83,7 +84,8 @@ def test_private_target_is_stable_short_and_separate_from_local(tmp_path, monkey
     assert first.log_path.parent == first.authkey_path.parent
     assert transport.pid_path(first.address) != transport.pid_path(transport.default_address())
     assert transport.lock_path(first.address) != transport.lock_path(transport.default_address())
-    assert first.profile_dir.parent.stat().st_mode & 0o777 == 0o700
+    if os.name != "nt":
+        assert first.profile_dir.parent.stat().st_mode & 0o777 == 0o700
 
 
 def test_windows_namespaces_include_user_and_stable_digest(monkeypatch):


### PR DESCRIPTION
**Proposed target version:** 1.8.0 / next alpha
**Estimated release window:** 1.8 alpha after stacked security parents and DD-056 native step 4

Closes #1304

Stacked on #1303. This is DD-056 delivery step 3 and intentionally keeps Remote Browser navigation unavailable.

## What changes

- derive a deterministic Host-private daemon namespace, PID/lock sidecars, profile, log, and Windows IPC key from the durable session-state path
- start the authenticated loopback egress gateway before browser construction and bind IPC only after both succeed
- pass an immutable, environment-independent launch policy to the existing AsyncBrowserCore
- request one canonical loopback proxy, subtract Chromium loopback bypass, fail browser-side DNS, disable QUIC/non-proxied WebRTC UDP/extensions, and block Service Workers
- close the browser before its gateway and reject every command before tab mutation if gateway authority disappears
- preserve ordinary local co browser environment/profile behavior and allow local/private native daemons to run and stop independently
- keep proxy credentials out of argv, registry state, paths, logs, reprs, and errors

## Verification

- 218 focused and adjacent tests passed locally, including ordinary daemon regressions
- focused Remote Browser suite: 64 passed
- Ruff on every changed Python file: passed
- compileall: passed
- full local run reached 457 passed and 4 skipped before interruption; its one completed failure was the test subprocess resolving a global co executable outside the worktree virtualenv
- CI extends the existing focused job across Linux/macOS/Windows and Python 3.10-3.13

## Security boundary

This PR proves requested launch configuration and private runtime lifecycle. It does not claim that pinned Chromium honored every switch or that every request class used the gateway. Navigation remains disabled until DD-056 step 4 passes native zero-socket redirect, subresource, worker, WebSocket, download, DNS-rebinding, and gateway-crash vectors.

## Rollback

Remove private target selection and the private daemon launch mode together. Remote Browser returns to lifecycle-only operation. Never point Remote Browser at the ordinary local daemon or remove the gateway while page commands remain enabled.