### PR TITLE
feat: fail closed on unproven browser egress

### DIFF
--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -847,7 +847,9 @@ class BrowserDaemon:
                 proxy_auth_path,
             )
             browser = self._browser_factory(
-                headless=self._headless, launch_policy=policy
+                headless=self._headless,
+                launch_policy=policy,
+                egress_gateway=gateway,
             )
         except BaseException:
             remove_proxy_auth_file(proxy_auth_path)

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -244,6 +244,7 @@ class BrowserDaemon:
         self._authkey_path = Path(authkey_path) if authkey_path is not None else None
         self._gateway_factory = gateway_factory
         self._browser_factory = browser_factory
+        self._proxy_auth_path = None
         if self._remote_egress and self._profile_dir is None:
             raise ValueError("remote browser daemon requires an explicit profile")
         if not self._remote_egress and self._profile_dir is not None:
@@ -825,7 +826,10 @@ class BrowserDaemon:
             raise RuntimeError("private browser runtime is only prepared once")
         from connectonion.network.host.egress_gateway import EgressGateway
         from connectonion.network.host.private_browser_runtime import (
+            proxy_auth_path_for_profile,
             remote_browser_launch_policy,
+            remove_proxy_auth_file,
+            write_proxy_auth_file,
         )
 
         gateway = (
@@ -834,15 +838,23 @@ class BrowserDaemon:
             else EgressGateway()
         )
         endpoint = await gateway.start()
+        proxy_auth_path = proxy_auth_path_for_profile(self._profile_dir)
         try:
-            policy = remote_browser_launch_policy(self._profile_dir, endpoint)
+            write_proxy_auth_file(proxy_auth_path, endpoint)
+            policy = remote_browser_launch_policy(
+                self._profile_dir,
+                endpoint,
+                proxy_auth_path,
+            )
             browser = self._browser_factory(
                 headless=self._headless, launch_policy=policy
             )
         except BaseException:
+            remove_proxy_auth_file(proxy_auth_path)
             await gateway.stop()
             raise
         self._gateway = gateway
+        self._proxy_auth_path = proxy_auth_path
         self.browser = browser
 
     def _accept_posix_client(self, reader, writer) -> None:
@@ -1081,6 +1093,12 @@ class BrowserDaemon:
                     f"browser cleanup failed: {type(exc).__name__}: {exc}",
                     file=sys.stderr,
                 )
+        from connectonion.network.host.private_browser_runtime import (
+            remove_proxy_auth_file,
+        )
+
+        remove_proxy_auth_file(self._proxy_auth_path)
+        self._proxy_auth_path = None
         if self._gateway is not None:
             try:
                 await self._gateway.stop()

--- a/connectonion/network/host/egress_gateway.py
+++ b/connectonion/network/host/egress_gateway.py
@@ -1,8 +1,9 @@
 """Bounded loopback egress gateway for future Remote Browser navigation.
 
-The gateway owns hostname resolution and numeric socket selection.  It has no
-Chromium integration and is not reachable through OIP yet; keeping that seam
-closed lets the proxy boundary be tested before a browser can depend on it.
+The gateway owns hostname resolution and numeric socket selection.  A private
+launch policy can request this proxy, but Remote Browser page commands remain
+unavailable until the credential-enabled paid artifact and native preflight
+both pass their installed-artifact acceptance suite.
 """
 
 from __future__ import annotations

--- a/connectonion/network/host/egress_gateway.py
+++ b/connectonion/network/host/egress_gateway.py
@@ -279,6 +279,7 @@ class EgressGateway:
         self._lifecycle_lock = asyncio.Lock()
         self._state_lock = asyncio.Lock()
         self._client_tasks: set[asyncio.Task] = set()
+        self._handled = 0
 
     @property
     def endpoint(self) -> ProxyEndpoint:
@@ -290,6 +291,17 @@ class EgressGateway:
     def is_running(self) -> bool:
         """Whether this instance still owns a serving listener."""
         return self._server is not None and self._server.is_serving()
+
+    @property
+    def handled_requests(self) -> int:
+        """How many authenticated requests this gateway has decided.
+
+        The positive control for anything asserting an absence: "the sentinel
+        saw no sockets" and "the browser never made the request" produce the
+        same zero, and a proof built on the first needs this to tell them
+        apart.
+        """
+        return self._handled
 
     async def start(self) -> ProxyEndpoint:
         async with self._lifecycle_lock:
@@ -416,6 +428,10 @@ class EgressGateway:
         try:
             request = await self._read_request(reader)
             self._authenticate(request)
+            # Counted the moment the credential is proven, which is the point
+            # this gateway has definitely seen the request, whatever the policy
+            # decides next.
+            self._handled += 1
             await self._promote(admission)
             authority, origin_target, upgrade = self._request_destination(request)
             endpoints = await self._approved_endpoints(authority)
@@ -843,13 +859,21 @@ class EgressGateway:
             if code == AUTH_REQUIRED
             else ""
         )
+        # A refusal carries a body because Chromium will not commit a bodyless
+        # 4xx/5xx main-frame navigation: it reports ERR_HTTP_RESPONSE_CODE_FAILURE
+        # instead, so `page.goto` raises rather than returning the status. The
+        # native preflight has to read this refusal as evidence that the browser
+        # reached this gateway, and with no body it never sees one. The body
+        # holds the stable code and nothing caller-controlled.
+        body = f"{code}\n".encode("ascii")
         response = (
             f"HTTP/1.1 {status} {reason}\r\n"
             "Connection: close\r\n"
-            "Content-Length: 0\r\n"
+            "Content-Type: text/plain; charset=utf-8\r\n"
+            f"Content-Length: {len(body)}\r\n"
             f"X-ConnectOnion-Error: {code}\r\n"
             f"{authenticate}\r\n"
-        ).encode("ascii")
+        ).encode("ascii") + body
         writer.write(response)
         with contextlib.suppress(Exception):
             await asyncio.wait_for(writer.drain(), timeout=1.0)

--- a/connectonion/network/host/private_browser_runtime.py
+++ b/connectonion/network/host/private_browser_runtime.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
+import re
+import stat
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -33,6 +37,10 @@ REMOTE_BROWSER_CHROME_ARGS = (
     "--webrtc-ip-handling-policy=disable_non_proxied_udp",
     "--disable-extensions",
 )
+PROXY_AUTH_FILENAME = "proxy-auth.json"
+PROXY_AUTH_REALM = "ConnectOnion Remote Browser"
+PROXY_AUTH_USERNAME = "connectonion"
+_PROXY_AUTH_PASSWORD = re.compile(r"[A-Za-z0-9_-]{43}\Z")
 
 
 @dataclass(frozen=True)
@@ -43,6 +51,7 @@ class PrivateBrowserTarget:
     profile_dir: Path
     log_path: Path
     authkey_path: Path
+    proxy_auth_path: Path | None = None
     remote_egress: bool = True
 
     @classmethod
@@ -58,19 +67,94 @@ class PrivateBrowserTarget:
             profile_dir=root / "profile",
             log_path=root / "browser.log",
             authkey_path=root / "authkey",
+            proxy_auth_path=root / PROXY_AUTH_FILENAME,
         )
 
 
-def remote_browser_launch_policy(profile_dir: Path, endpoint: ProxyEndpoint) -> BrowserLaunchPolicy:
+def canonical_proxy_auth(endpoint: ProxyEndpoint) -> bytes:
+    """Return the exact credential document accepted by the closed browser."""
+    if (
+        endpoint.host != "127.0.0.1"
+        or isinstance(endpoint.port, bool)
+        or not isinstance(endpoint.port, int)
+        or not 1 <= endpoint.port <= 65535
+        or endpoint.username != PROXY_AUTH_USERNAME
+        or not isinstance(endpoint.password, str)
+        or not _PROXY_AUTH_PASSWORD.fullmatch(endpoint.password)
+    ):
+        raise ValueError("native proxy credentials are not canonical")
+    body = {
+        "challenger": f"127.0.0.1:{endpoint.port}",
+        "password": endpoint.password,
+        "realm": PROXY_AUTH_REALM,
+        "scheme": "basic",
+        "username": PROXY_AUTH_USERNAME,
+        "v": 1,
+    }
+    return json.dumps(body, sort_keys=True, separators=(",", ":")).encode("ascii")
+
+
+def proxy_auth_path_for_profile(profile_dir: Path) -> Path:
+    """Keep the credential beside, never inside, the persistent profile."""
+    profile = Path(profile_dir).expanduser().resolve()
+    return profile.parent / PROXY_AUTH_FILENAME
+
+
+def write_proxy_auth_file(path: Path, endpoint: ProxyEndpoint) -> Path:
+    """Atomically create a mode-0600 credential in an existing private root."""
+    path = Path(path).expanduser()
+    if not path.is_absolute() or not path.parent.is_dir() or path.parent.is_symlink():
+        raise ValueError("proxy auth path must be absolute in an existing private root")
+    if os.name != "nt":
+        parent_stat = path.parent.stat()
+        if (
+            stat.S_IMODE(parent_stat.st_mode) & 0o077
+            or parent_stat.st_uid != os.getuid()
+        ):
+            raise ValueError("proxy auth root must be private and owned by this user")
+    payload = canonical_proxy_auth(endpoint)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as stream:
+            temporary = Path(stream.name)
+            if os.name != "nt":
+                os.chmod(temporary, 0o600)
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        temporary = None
+        return path
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def remove_proxy_auth_file(path: Path | None) -> None:
+    """Remove the private credential without following a replacement symlink."""
+    if path is not None:
+        Path(path).unlink(missing_ok=True)
+
+
+def remote_browser_launch_policy(
+    profile_dir: Path,
+    endpoint: ProxyEndpoint,
+    proxy_auth_path: Path,
+) -> BrowserLaunchPolicy:
     """Bind one gateway endpoint to the exact requested private launch contract."""
+    canonical_proxy_auth(endpoint)
+    proxy_auth_path = Path(proxy_auth_path).expanduser()
+    proxy_auth_switch = f"--connectonion-proxy-auth-file={proxy_auth_path}"
     return BrowserLaunchPolicy(
         profile_dir=profile_dir,
-        proxy=BrowserProxySettings(
-            server=f"http://{endpoint.host}:{endpoint.port}",
-            username=endpoint.username,
-            password=endpoint.password,
-        ),
-        args=REMOTE_BROWSER_CHROME_ARGS,
+        proxy=BrowserProxySettings(server=f"http://{endpoint.host}:{endpoint.port}"),
+        proxy_auth_file=proxy_auth_path,
+        args=(*REMOTE_BROWSER_CHROME_ARGS, proxy_auth_switch),
         ignore_default_args=tuple(IGNORE_DEFAULT_ARGS) + ("--use-mock-keychain",),
         service_workers="block",
         accept_downloads=True,

--- a/connectonion/network/host/private_browser_runtime.py
+++ b/connectonion/network/host/private_browser_runtime.py
@@ -74,4 +74,5 @@ def remote_browser_launch_policy(profile_dir: Path, endpoint: ProxyEndpoint) -> 
         ignore_default_args=tuple(IGNORE_DEFAULT_ARGS) + ("--use-mock-keychain",),
         service_workers="block",
         accept_downloads=True,
+        native_preflight="remote-egress-v1",
     )

--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -299,7 +299,12 @@ class AsyncBrowserCore:
         max_tabs: int = 10,
         use_mock_keychain: bool = False,
         launch_policy: BrowserLaunchPolicy | None = None,
+        egress_gateway: object | None = None,
     ) -> None:
+        # Only read for its decision count, which is the preflight's positive
+        # control: without it, "the sentinel saw nothing" cannot be told apart
+        # from "the browser never asked".
+        self._egress_gateway = egress_gateway
         self.playwright: Optional[Playwright] = None
         self.browser: Optional[BrowserContext] = None
         self._pages: Dict[Optional[str], Page] = {}
@@ -584,6 +589,7 @@ class AsyncBrowserCore:
                     await run_native_egress_preflight(
                         policy.native_preflight,
                         context,
+                        gateway=self._egress_gateway,
                     )
 
                 if self._seed_state and not self._seeded:

--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -33,6 +33,7 @@ from . import _async_terminal as terminal
 from .browser_config import CHROME_DEFAULT_ARGS, IGNORE_DEFAULT_ARGS
 from .chrome_finder import find_system_chrome
 from .launch_policy import BrowserLaunchPolicy
+from .native_egress import run_native_egress_preflight
 
 try:
     from patchright.async_api import BrowserContext, Page, Playwright, async_playwright
@@ -578,6 +579,12 @@ class AsyncBrowserCore:
                     raise
                 self.playwright = playwright
                 self.browser = context
+
+                if policy is not None and policy.native_preflight is not None:
+                    await run_native_egress_preflight(
+                        policy.native_preflight,
+                        context,
+                    )
 
                 if self._seed_state and not self._seeded:
                     cookies = json.loads(

--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -33,7 +33,7 @@ from . import _async_terminal as terminal
 from .browser_config import CHROME_DEFAULT_ARGS, IGNORE_DEFAULT_ARGS
 from .chrome_finder import find_system_chrome
 from .launch_policy import BrowserLaunchPolicy
-from .native_egress import run_native_egress_preflight
+from .native_egress import native_egress_failure, run_native_egress_preflight
 
 try:
     from patchright.async_api import BrowserContext, Page, Playwright, async_playwright
@@ -595,7 +595,7 @@ class AsyncBrowserCore:
                     self._seeded = True
 
                 await self._ensure_page(key)
-            except BaseException:
+            except BaseException as exc:
                 self.browser = None
                 self.playwright = None
                 if context is not None:
@@ -612,6 +612,10 @@ class AsyncBrowserCore:
                         )
                     except BaseException:
                         pass
+                if isinstance(exc, (asyncio.CancelledError, KeyboardInterrupt, SystemExit)):
+                    raise
+                if policy is not None and policy.native_preflight is not None:
+                    raise native_egress_failure() from None
                 raise
 
             if force and had_previous_state:

--- a/connectonion/useful_tools/browser_tools/launch_policy.py
+++ b/connectonion/useful_tools/browser_tools/launch_policy.py
@@ -76,6 +76,7 @@ class BrowserLaunchPolicy:
     ignore_default_args: tuple[str, ...] = ()
     service_workers: Literal["allow", "block"] = "block"
     accept_downloads: bool = True
+    native_preflight: Literal["remote-egress-v1"] | None = None
 
     def __post_init__(self) -> None:
         profile = Path(self.profile_dir).expanduser().resolve()
@@ -91,6 +92,8 @@ class BrowserLaunchPolicy:
             )
         if any(arg == "--proxy-server" or arg.startswith("--proxy-server=") for arg in self.args):
             raise ValueError("proxy authority belongs to `proxy`, not to a bare argument")
+        if self.native_preflight not in (None, "remote-egress-v1"):
+            raise ValueError("unknown native browser preflight")
 
     def playwright_options(self) -> dict:
         """Return a fresh mapping so a driver cannot mutate the frozen policy."""

--- a/connectonion/useful_tools/browser_tools/launch_policy.py
+++ b/connectonion/useful_tools/browser_tools/launch_policy.py
@@ -7,7 +7,7 @@ profile authority cannot drift through process environment variables.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 from urllib.parse import urlsplit
@@ -15,11 +15,9 @@ from urllib.parse import urlsplit
 
 @dataclass(frozen=True)
 class BrowserProxySettings:
-    """Playwright proxy settings whose credential is safe to repr or log."""
+    """One loopback proxy server; native code owns its credentials."""
 
     server: str
-    username: str
-    password: str = field(repr=False)
 
     def __post_init__(self) -> None:
         try:
@@ -38,19 +36,11 @@ class BrowserProxySettings:
             and parsed.fragment == ""
             and port is not None
             and parsed.netloc == f"127.0.0.1:{port}"
-            and isinstance(self.username, str)
-            and isinstance(self.password, str)
-            and self.username
-            and self.password
         ):
-            raise ValueError("browser proxy must be one authenticated loopback server")
+            raise ValueError("browser proxy must be one canonical loopback server")
 
     def playwright_value(self) -> dict[str, str]:
-        return {
-            "server": self.server,
-            "username": self.username,
-            "password": self.password,
-        }
+        return {"server": self.server}
 
 
 # The switches that make a private policy fail closed. Held here rather than
@@ -72,6 +62,7 @@ class BrowserLaunchPolicy:
 
     profile_dir: Path
     proxy: BrowserProxySettings
+    proxy_auth_file: Path
     args: tuple[str, ...]
     ignore_default_args: tuple[str, ...] = ()
     service_workers: Literal["allow", "block"] = "block"
@@ -80,9 +71,16 @@ class BrowserLaunchPolicy:
 
     def __post_init__(self) -> None:
         profile = Path(self.profile_dir).expanduser().resolve()
+        proxy_auth_file = Path(self.proxy_auth_file).expanduser()
+        if not proxy_auth_file.is_absolute():
+            raise ValueError("native proxy auth file must be absolute")
         object.__setattr__(self, "profile_dir", profile)
+        object.__setattr__(self, "proxy_auth_file", proxy_auth_file)
         if not self.args or len(set(self.args)) != len(self.args):
             raise ValueError("browser launch arguments must be nonempty and unique")
+        expected_switch = f"--connectonion-proxy-auth-file={proxy_auth_file}"
+        if self.args.count(expected_switch) != 1:
+            raise ValueError("private browser policy must name its native proxy auth file")
         if self.service_workers != "block":
             raise ValueError("private browser launch policy must block Service Workers")
         missing = [arg for arg in REQUIRED_EGRESS_ARGS if arg not in self.args]

--- a/connectonion/useful_tools/browser_tools/native_egress.py
+++ b/connectonion/useful_tools/browser_tools/native_egress.py
@@ -155,19 +155,57 @@ async def _exercise_subresource_paths(page: Any, origin: str) -> None:
     )
 
 
+GATEWAY_WITNESS_HEADER = "x-connectonion-error"
+
+
+def _require_gateway_denial(response: Any) -> None:
+    """Require a denial that this gateway, authenticated, produced.
+
+    Two independent things have to hold and neither implies the other. The
+    header proves the answer came from this gateway — no origin, captive
+    portal or intermediary on this path emits it, and a bare status would
+    accept a 403 from whatever the browser happened to reach. The status
+    proves the request was decided rather than turned away at the door: a 407
+    also carries the header, and it means the credential never arrived, which
+    is a misconfigured browser reported as a proven one.
+    """
+    if response is None:
+        raise native_egress_failure()
+    try:
+        headers = response.headers
+        witness = headers.get(GATEWAY_WITNESS_HEADER) if headers else None
+        status = response.status
+    except Exception:
+        raise native_egress_failure() from None
+    if not witness or status != 403:
+        raise native_egress_failure()
+
+
+def _gateway_request_count(gateway: Any) -> int | None:
+    """Read the gateway's own decision count, when the caller supplied one."""
+    count = getattr(gateway, "handled_requests", None)
+    return count if isinstance(count, int) else None
+
+
 async def run_native_egress_preflight(
     name: str,
     context: Any,
     *,
     timeout: float = 8.0,
     sentinel_factory: type[LoopbackSentinel] = LoopbackSentinel,
+    gateway: Any = None,
 ) -> None:
     """Prove the effective Chromium proxy path or fail with one stable code.
 
-    A 403 response proves the authenticated gateway saw and denied the owned
-    loopback main-frame request.  Zero sentinel accepts proves Chromium did not
-    silently take its implicit localhost DIRECT path.  Representative
-    subresource, WebSocket, and worker attempts repeat the zero-socket check.
+    Each probe must be answered by *this* gateway, identified by the
+    ``X-ConnectOnion-Error`` header no other party on the path produces.
+    Matching a bare status would accept a 403 from anything the browser could
+    reach.  Zero sentinel accepts then proves Chromium did not take its
+    implicit localhost DIRECT path.
+
+    Zero is also what "the request was never made" looks like, so the gateway's
+    own request count is read before and after: an absence is only evidence
+    once the thing that would have produced a presence is known to have run.
     """
     if name != REMOTE_EGRESS_PREFLIGHT:
         raise native_egress_failure()
@@ -190,8 +228,13 @@ async def run_native_egress_preflight(
                 ),
                 timeout=timeout,
             )
-            if response is None or response.status != 502:
-                raise native_egress_failure()
+            # `.invalid` is reserved never to resolve, and the destination
+            # policy denies it by name before DNS is consulted at all — so the
+            # gateway answers HOST_DENIED, not the DNS witness an earlier
+            # revision expected. What proves the browser got here is the
+            # header: a direct path fails locally under the fixed host-resolver
+            # rule and cannot manufacture it.
+            _require_gateway_denial(response)
             loopback_response = await asyncio.wait_for(
                 page.goto(
                     sentinel.origin + "/main-frame",
@@ -200,14 +243,22 @@ async def run_native_egress_preflight(
                 ),
                 timeout=timeout,
             )
-            if loopback_response is None or loopback_response.status != 403:
-                raise native_egress_failure()
+            _require_gateway_denial(loopback_response)
+            before = _gateway_request_count(gateway)
             await asyncio.wait_for(
                 _exercise_subresource_paths(page, sentinel.origin),
                 timeout=timeout,
             )
             await asyncio.sleep(0.1)
             if sentinel.accepted_connections or sentinel.accepted_bytes:
+                raise native_egress_failure()
+            # The subresource probes are wrapped in a bounded race that
+            # swallows their own errors, so a probe that silently did nothing —
+            # a wrong URL, a blocked API, an await that resolves on the timer —
+            # leaves exactly the zero-socket reading a correctly proxied one
+            # leaves. Requiring the gateway to have decided at least one more
+            # request separates "denied" from "never attempted".
+            if before is not None and _gateway_request_count(gateway) <= before:
                 raise native_egress_failure()
     except asyncio.CancelledError:
         raise

--- a/connectonion/useful_tools/browser_tools/native_egress.py
+++ b/connectonion/useful_tools/browser_tools/native_egress.py
@@ -23,6 +23,11 @@ class NativeEgressPreflightError(RuntimeError):
     """Stable, non-secret failure returned when effective egress is uncertain."""
 
 
+def native_egress_failure() -> NativeEgressPreflightError:
+    """Construct the one public error for private launch or preflight uncertainty."""
+    return NativeEgressPreflightError(_PREFLIGHT_MESSAGE)
+
+
 class LoopbackSentinel:
     """Owned HTTP sentinel whose accepted sockets prove a proxy bypass."""
 
@@ -165,7 +170,7 @@ async def run_native_egress_preflight(
     subresource, WebSocket, and worker attempts repeat the zero-socket check.
     """
     if name != REMOTE_EGRESS_PREFLIGHT:
-        raise NativeEgressPreflightError(_PREFLIGHT_MESSAGE)
+        raise native_egress_failure()
 
     page = None
     try:
@@ -186,7 +191,7 @@ async def run_native_egress_preflight(
                 timeout=timeout,
             )
             if response is None or response.status != 502:
-                raise NativeEgressPreflightError(_PREFLIGHT_MESSAGE)
+                raise native_egress_failure()
             loopback_response = await asyncio.wait_for(
                 page.goto(
                     sentinel.origin + "/main-frame",
@@ -196,20 +201,20 @@ async def run_native_egress_preflight(
                 timeout=timeout,
             )
             if loopback_response is None or loopback_response.status != 403:
-                raise NativeEgressPreflightError(_PREFLIGHT_MESSAGE)
+                raise native_egress_failure()
             await asyncio.wait_for(
                 _exercise_subresource_paths(page, sentinel.origin),
                 timeout=timeout,
             )
             await asyncio.sleep(0.1)
             if sentinel.accepted_connections or sentinel.accepted_bytes:
-                raise NativeEgressPreflightError(_PREFLIGHT_MESSAGE)
+                raise native_egress_failure()
     except asyncio.CancelledError:
         raise
     except NativeEgressPreflightError:
         raise
     except BaseException:
-        raise NativeEgressPreflightError(_PREFLIGHT_MESSAGE) from None
+        raise native_egress_failure() from None
     finally:
         if page is not None:
             with contextlib.suppress(BaseException):

--- a/connectonion/useful_tools/browser_tools/native_egress.py
+++ b/connectonion/useful_tools/browser_tools/native_egress.py
@@ -1,0 +1,216 @@
+"""Effective-runtime preflight for the Host-private browser boundary.
+
+The launch policy is only a request to Chromium.  This module verifies the
+result: the real browser must reach the authenticated gateway for a loopback
+request, while an owned loopback sentinel observes zero direct sockets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import socket
+from typing import Any
+
+REMOTE_EGRESS_PREFLIGHT = "remote-egress-v1"
+PREFLIGHT_FAILED = "EGRESS_PREFLIGHT_FAILED"
+_PREFLIGHT_MESSAGE = (
+    f"{PREFLIGHT_FAILED}: native browser egress boundary could not be proven"
+)
+
+
+class NativeEgressPreflightError(RuntimeError):
+    """Stable, non-secret failure returned when effective egress is uncertain."""
+
+
+class LoopbackSentinel:
+    """Owned HTTP sentinel whose accepted sockets prove a proxy bypass."""
+
+    def __init__(self) -> None:
+        self.accepted_connections = 0
+        self.accepted_bytes = 0
+        self._server: asyncio.AbstractServer | None = None
+        self._tasks: set[asyncio.Task] = set()
+        self._writers: set[asyncio.StreamWriter] = set()
+
+    @property
+    def origin(self) -> str:
+        if self._server is None or not self._server.sockets:
+            raise RuntimeError("loopback sentinel is not started")
+        host, port = self._server.sockets[0].getsockname()[:2]
+        return f"http://{host}:{port}"
+
+    async def start(self) -> None:
+        if self._server is not None:
+            raise RuntimeError("loopback sentinel is already started")
+        self._server = await asyncio.start_server(
+            self._accept,
+            host="127.0.0.1",
+            port=0,
+            family=socket.AF_INET,
+        )
+        sockets = self._server.sockets or ()
+        if len(sockets) != 1 or sockets[0].getsockname()[0] != "127.0.0.1":
+            await self.stop()
+            raise RuntimeError("loopback sentinel escaped IPv4 loopback")
+
+    async def _accept(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        task = asyncio.current_task()
+        if task is not None:
+            self._tasks.add(task)
+        self._writers.add(writer)
+        self.accepted_connections += 1
+        try:
+            with contextlib.suppress(asyncio.TimeoutError):
+                data = await asyncio.wait_for(reader.read(4096), timeout=0.5)
+                self.accepted_bytes += len(data)
+            writer.write(
+                b"HTTP/1.1 204 No Content\r\n"
+                b"Content-Length: 0\r\n"
+                b"Connection: close\r\n\r\n"
+            )
+            with contextlib.suppress(
+                BrokenPipeError, ConnectionResetError, asyncio.TimeoutError
+            ):
+                await asyncio.wait_for(writer.drain(), timeout=0.5)
+        finally:
+            writer.close()
+            with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                await writer.wait_closed()
+            self._writers.discard(writer)
+            if task is not None:
+                self._tasks.discard(task)
+
+    async def stop(self) -> None:
+        server, self._server = self._server, None
+        if server is not None:
+            server.close()
+            await server.wait_closed()
+        for writer in tuple(self._writers):
+            writer.close()
+        tasks = tuple(task for task in self._tasks if not task.done())
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._writers.clear()
+        self._tasks.clear()
+
+    async def __aenter__(self) -> "LoopbackSentinel":
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        await self.stop()
+
+
+async def _exercise_subresource_paths(page: Any, origin: str) -> None:
+    """Start representative browser-owned transports and bound every wait."""
+    await page.set_content("<!doctype html><meta charset=utf-8><title>egress preflight</title>")
+    await page.evaluate(
+        """
+        async (origin) => {
+          const deadline = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+          const bounded = promise => Promise.race([promise, deadline(1500)]);
+          const image = new Promise(resolve => {
+            const node = new Image();
+            node.onload = node.onerror = resolve;
+            node.src = origin + "/image";
+          });
+          const websocket = new Promise(resolve => {
+            let socket;
+            try {
+              socket = new WebSocket(origin.replace(/^http/, "ws") + "/websocket");
+              socket.onopen = () => { socket.close(); resolve(); };
+              socket.onerror = socket.onclose = resolve;
+            } catch (_) {
+              resolve();
+            }
+          });
+          const worker = new Promise(resolve => {
+            const source = `fetch(${JSON.stringify(origin + "/worker")})`
+              + `.catch(() => {}).finally(() => postMessage("done"));`;
+            const url = URL.createObjectURL(new Blob([source], {type: "text/javascript"}));
+            const instance = new Worker(url);
+            instance.onmessage = instance.onerror = () => {
+              instance.terminate();
+              URL.revokeObjectURL(url);
+              resolve();
+            };
+          });
+          await Promise.all([
+            bounded(fetch(origin + "/fetch", {mode: "no-cors"}).catch(() => {})),
+            bounded(image),
+            bounded(websocket),
+            bounded(worker),
+          ]);
+        }
+        """,
+        origin,
+    )
+
+
+async def run_native_egress_preflight(
+    name: str,
+    context: Any,
+    *,
+    timeout: float = 8.0,
+    sentinel_factory: type[LoopbackSentinel] = LoopbackSentinel,
+) -> None:
+    """Prove the effective Chromium proxy path or fail with one stable code.
+
+    A 403 response proves the authenticated gateway saw and denied the owned
+    loopback main-frame request.  Zero sentinel accepts proves Chromium did not
+    silently take its implicit localhost DIRECT path.  Representative
+    subresource, WebSocket, and worker attempts repeat the zero-socket check.
+    """
+    if name != REMOTE_EGRESS_PREFLIGHT:
+        raise NativeEgressPreflightError(_PREFLIGHT_MESSAGE)
+
+    page = None
+    try:
+        async with sentinel_factory() as sentinel:
+            page = await context.new_page()
+            # .invalid is reserved never to resolve.  A 502 response therefore
+            # proves this exact browser reached the authenticated gateway and
+            # let the gateway own DNS; a direct browser path fails locally under
+            # the fixed host-resolver rule and cannot manufacture that response.
+            response = await asyncio.wait_for(
+                page.goto(
+                    "http://remote-browser-preflight.invalid/",
+                    wait_until="commit",
+                    # Let the driver report first; the outer deadline is only a
+                    # guard against a driver call that never resolves.
+                    timeout=max(1000, int(timeout * 500)),
+                ),
+                timeout=timeout,
+            )
+            if response is None or response.status != 502:
+                raise NativeEgressPreflightError(_PREFLIGHT_MESSAGE)
+            loopback_response = await asyncio.wait_for(
+                page.goto(
+                    sentinel.origin + "/main-frame",
+                    wait_until="commit",
+                    timeout=max(1000, int(timeout * 500)),
+                ),
+                timeout=timeout,
+            )
+            if loopback_response is None or loopback_response.status != 403:
+                raise NativeEgressPreflightError(_PREFLIGHT_MESSAGE)
+            await asyncio.wait_for(
+                _exercise_subresource_paths(page, sentinel.origin),
+                timeout=timeout,
+            )
+            await asyncio.sleep(0.1)
+            if sentinel.accepted_connections or sentinel.accepted_bytes:
+                raise NativeEgressPreflightError(_PREFLIGHT_MESSAGE)
+    except asyncio.CancelledError:
+        raise
+    except NativeEgressPreflightError:
+        raise
+    except BaseException:
+        raise NativeEgressPreflightError(_PREFLIGHT_MESSAGE) from None
+    finally:
+        if page is not None:
+            with contextlib.suppress(BaseException):
+                await page.close()

--- a/docs/blog/2026-08-26-the-browser-opened-before-we-knew-it-was-safe.md
+++ b/docs/blog/2026-08-26-the-browser-opened-before-we-knew-it-was-safe.md
@@ -1,0 +1,62 @@
+# The Browser Opened Before We Knew It Was Safe
+
+*2026-08-26*
+
+The private BrowserDaemon had a careful launch policy. Chromium received one
+loopback proxy, no implicit localhost bypass, browser-side DNS failure outside
+the gateway, blocked Service Workers, disabled QUIC, and disabled non-proxied
+WebRTC UDP. The process opened successfully.
+
+That last sentence was the problem.
+
+“The browser opened” only proved that the driver created a context. It did not
+prove which component would resolve a hostname, whether an internal redirect
+would use the proxy, or whether Chromium would recover from a dead gateway by
+opening a direct socket. If the daemon returned ready at that point, every
+later page command would rely on configuration as evidence of network behavior.
+
+For Remote Browser, configuration is a request. Readiness needs a verdict.
+
+## Two witnesses, not one successful page
+
+The native preflight now runs against the real persistent context before seed
+cookies or user pages exist. Its first request uses a reserved `.invalid`
+hostname. Browser-side DNS cannot resolve it; only the authenticated gateway
+can turn that exact attempt into our stable 502 response. That response is a
+witness that the browser reached the gateway and let the gateway own DNS.
+
+The second request points at an owned IPv4 loopback sentinel. The gateway must
+reject it with 403 while the sentinel records zero accepted sockets and zero
+bytes. We repeat the zero-socket observation across fetch, image, WebSocket,
+and worker paths because browser-owned transports do not all share the same
+page interception surface.
+
+Neither response is useful alone. A 403 without the DNS witness could come from
+the wrong layer. A 502 without the sentinel could coexist with Chromium's
+implicit direct path for loopback. Together they prove the behavior we need at
+startup, and any timeout, unexpected status, accepted socket, or internal error
+collapses to one non-secret failure. The partially opened context and driver
+are then closed.
+
+## The 407 that changed the release boundary
+
+The first real-browser experiment did not pass this preflight. System Chrome
+reached the proxy but never supplied `Proxy-Authorization`. Credentials in a
+manual proxy URL are intentionally ignored by Chromium. Playwright routing and
+page-scoped CDP Fetch interception also failed to cover the browser-owned
+challenge early enough. The gateway returned 407, while the direct sentinel
+correctly stayed at zero.
+
+That was not a reason to weaken the test. It clarified the product boundary:
+system Chrome is not an eligible Remote Browser engine. The closed Onion
+Browser must answer only the exact first challenge from the pinned loopback
+proxy, using a credential file owned by the Host-private runtime. A mismatched
+realm, scheme, challenger, or repeated challenge must be cancelled.
+
+This PR therefore stops at a fail-closed checkpoint. Its unit and lifecycle
+tests pass, but it makes no installed-browser claim. The release gate remains
+closed until the paid Onionwright engine, native credential hook, and exact
+browser artifact meet in one stack and pass the full Mac and Linux matrix.
+
+Opening a process is an implementation event. Declaring a private browser ready
+is a security decision. The preflight exists to keep those two moments apart.

--- a/docs/blog/2026-08-26-the-browser-opened-before-we-knew-it-was-safe.md
+++ b/docs/blog/2026-08-26-the-browser-opened-before-we-knew-it-was-safe.md
@@ -53,6 +53,14 @@ Browser must answer only the exact first challenge from the pinned loopback
 proxy, using a credential file owned by the Host-private runtime. A mismatched
 realm, scheme, challenger, or repeated challenge must be cancelled.
 
+The daemon now writes that file atomically beside the private profile. On
+POSIX, its parent must be owned by the current user with no group or world
+access, and the file is mode 0600. The launch policy gives Playwright only the
+loopback proxy server—never its username or password—and passes the browser a
+path-only switch. Construction failures and orderly shutdown both remove the
+file. This still is not native-browser evidence; it is the exact producer side
+of the contract that the pinned Onion Browser must consume.
+
 This PR therefore stops at a fail-closed checkpoint. Its unit and lifecycle
 tests pass, but it makes no installed-browser claim. The release gate remains
 closed until the paid Onionwright engine, native credential hook, and exact

--- a/docs/blog/2026-08-29-every-test-was-green-and-it-had-never-worked.md
+++ b/docs/blog/2026-08-29-every-test-was-green-and-it-had-never-worked.md
@@ -1,0 +1,92 @@
+# Every test was green and the feature had never worked once
+
+The native egress preflight is the part of Remote Browser that refuses to
+start. Launching Chromium behind a loopback proxy proves nothing on its own —
+the process starting successfully says nothing about which socket the next
+request goes out of — so before the first page is opened, the preflight makes
+the browser prove it: navigate somewhere the gateway must refuse, then check
+that the refusal came from the gateway, then check that a loopback sentinel
+saw no connections at all.
+
+Its tests passed. All of them, every run. And it had never once succeeded
+against a real browser.
+
+## Two facts nobody had put together
+
+The first probe asks for `http://remote-browser-preflight.invalid/`. The
+reasoning is good: `.invalid` is reserved never to resolve, so a browser that
+resolved names itself would fail locally, while a browser going through the
+gateway gets the gateway's DNS failure. The code required status 502.
+
+The gateway answers **403**. Its destination policy denies `.invalid` by name,
+before DNS is ever consulted — the very special-use suffix list that another
+review had hardened a day earlier. The 502 path exists, but only for a host the
+policy *admits* and that then fails to resolve. The witness could never fire.
+
+The second is smaller and worse. The gateway's refusals are sent with
+`Content-Length: 0`. Chromium will not commit a bodyless 4xx or 5xx main-frame
+navigation — it reports `ERR_HTTP_RESPONSE_CODE_FAILURE`, so `page.goto` raises
+instead of returning a response:
+
+```
+403 empty body -> ERR_HTTP_RESPONSE_CODE_FAILURE
+403 with body  -> status=403
+```
+
+The preflight catches every exception and collapses it to
+`EGRESS_PREFLIGHT_FAILED`. So even with the status expectation corrected, both
+probes raise, and the private browser can never start.
+
+Fail-closed, which is the right direction to be broken in. But a boundary that
+can only ever refuse is not a boundary; it is an outage with good manners.
+
+## Why the tests could not see it
+
+The suite drives a `FakePage`. `FakePage.goto` returns a response object where
+real Chromium raises, and its constructor hard-codes `witness_status=502` —
+the status the real gateway never sends. The fake modelled two behaviours the
+real stack does not have, and the tests then verified the fake.
+
+There was no test anywhere that ran this preflight against a real browser.
+
+## The absence that proved nothing
+
+There was a third problem, and it is the one worth remembering.
+
+The subresource half of the proof — fetch, image, WebSocket, worker — runs
+inside a bounded race that swallows each probe's own errors, by design: a probe
+that fails is a probe whose request was correctly refused. Then the sentinel is
+asked whether it accepted any connections, and zero means the browser never
+went direct.
+
+Zero also means the probe never ran. A wrong URL, a blocked API, an `await`
+that resolves on the timer — every one of those produces the same zero as a
+perfectly proxied request. Replacing the entire subresource function with
+`async def noop(): return None` leaves the preflight passing.
+
+An absence is only evidence once the thing that would have produced a presence
+is known to have run. The gateway now counts the requests it has decided, and
+the preflight reads that count before and after: the sentinel's zero means
+something only when the gateway's counter moved.
+
+That is also the fix for a subtler version of the same gap. The old check read
+the counters 1.6 seconds after starting the probes and tore the sentinel down
+immediately after; a leak whose socket landed at two seconds was invisible, and
+worker startup on a cold Chromium can take longer than that. Requiring positive
+evidence removes the dependence on a window.
+
+## What it takes to believe a security check now
+
+Three properties, and each was verified by breaking it:
+
+- remove the positive control → the neutered-probe test goes red
+- remove the gateway-witness header check → the foreign-403 test goes red
+- put the error body back to empty → the real-driver test goes red
+
+And the real-driver test itself runs both ways: it passes against a correct
+launch with all seven probes reaching the gateway, and it still fails when
+`<-loopback>` is replaced with a real loopback bypass. Passing alone would only
+prove the check is lenient.
+
+The preflight was green for its entire life without ever having worked. The
+thing that finally told us was not a better assertion. It was running it.

--- a/tests/e2e/test_native_egress_preflight_real_driver.py
+++ b/tests/e2e/test_native_egress_preflight_real_driver.py
@@ -1,0 +1,112 @@
+"""Real-driver acceptance for the native egress preflight.
+
+Run explicitly (the ordinary matrix deselects slow tests):
+
+    python -m pytest tests/e2e/test_native_egress_preflight_real_driver.py -m slow -q
+
+Everything else that exercises this preflight uses a fake page, and a fake page
+is where its two blocking defects hid: it returned a response object where real
+Chromium raises, and it hard-coded a status the real gateway never sends. The
+preflight was green in every test and could not pass once, against anything.
+
+So this file drives the real thing in both directions. Passing on a correct
+launch is half the proof; the other half is that a genuine leak still fails.
+"""
+
+import asyncio
+import shutil
+from pathlib import Path
+
+import pytest
+
+from connectonion.network.host.egress_gateway import EgressGateway
+from connectonion.network.host.private_browser_runtime import (
+    REMOTE_BROWSER_CHROME_ARGS,
+)
+from connectonion.useful_tools.browser_tools.native_egress import (
+    NativeEgressPreflightError,
+    run_native_egress_preflight,
+)
+
+_CHROME_CANDIDATES = (
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium",
+)
+
+
+def _chrome() -> str | None:
+    for candidate in _CHROME_CANDIDATES:
+        if Path(candidate).exists():
+            return candidate
+    return shutil.which("google-chrome") or shutil.which("chromium")
+
+
+async def _run_preflight(args: tuple[str, ...]) -> tuple[bool, int]:
+    """Launch real Chromium behind a real gateway; report (passed, requests)."""
+    from patchright.async_api import async_playwright
+
+    gateway = EgressGateway()
+    endpoint = await gateway.start()
+    try:
+        async with async_playwright() as driver:
+            browser = await driver.chromium.launch(
+                headless=True,
+                executable_path=_chrome(),
+                args=list(args),
+                proxy={
+                    "server": f"http://127.0.0.1:{endpoint.port}",
+                    "username": endpoint.username,
+                    "password": endpoint.password,
+                },
+            )
+            context = await browser.new_context()
+            try:
+                await run_native_egress_preflight(
+                    "remote-egress-v1", context, gateway=gateway
+                )
+                passed = True
+            except NativeEgressPreflightError:
+                passed = False
+            await context.close()
+            await browser.close()
+    finally:
+        await gateway.stop()
+    return passed, gateway.handled_requests
+
+
+@pytest.mark.slow
+def test_the_preflight_passes_against_a_real_gateway_and_real_chromium():
+    if _chrome() is None:
+        pytest.skip("no Chrome/Chromium on this machine")
+    pytest.importorskip("patchright")
+
+    args = tuple(
+        arg for arg in REMOTE_BROWSER_CHROME_ARGS if not arg.startswith("--user-data-dir")
+    )
+    passed, handled = asyncio.run(_run_preflight(args))
+
+    assert passed, "the preflight cannot pass against the real stack"
+    # Every probe reached the gateway rather than silently doing nothing.
+    assert handled >= 6, handled
+
+
+@pytest.mark.slow
+def test_a_real_loopback_leak_still_fails_the_preflight():
+    """The other direction: without this, passing proves only that it is lenient."""
+    if _chrome() is None:
+        pytest.skip("no Chrome/Chromium on this machine")
+    pytest.importorskip("patchright")
+
+    # `<-loopback>` subtracts Chromium's implicit localhost bypass. Putting the
+    # address back restores a real direct path to the sentinel.
+    leaking = tuple(
+        "--proxy-bypass-list=127.0.0.1"
+        if arg == "--proxy-bypass-list=<-loopback>"
+        else arg
+        for arg in REMOTE_BROWSER_CHROME_ARGS
+        if not arg.startswith("--user-data-dir")
+    )
+    passed, _ = asyncio.run(_run_preflight(leaking))
+
+    assert not passed, "a genuine loopback leak passed the preflight"

--- a/tests/unit/test_remote_browser_native_egress.py
+++ b/tests/unit/test_remote_browser_native_egress.py
@@ -1,0 +1,172 @@
+"""Unit contracts for the effective native egress preflight."""
+
+import asyncio
+
+import pytest
+
+from connectonion.useful_tools.browser_tools.native_egress import (
+    NativeEgressPreflightError,
+    run_native_egress_preflight,
+)
+
+
+class FakeResponse:
+    def __init__(self, status=403):
+        self.status = status
+
+
+class FakePage:
+    def __init__(self, *, status=403, witness_status=502, error=None):
+        self.status = status
+        self.witness_status = witness_status
+        self.error = error
+        self.calls = []
+        self.closed = False
+
+    async def goto(self, url, **options):
+        self.calls.append(("goto", url, options))
+        if self.error is not None:
+            raise self.error
+        status = self.witness_status if url.endswith(".invalid/") else self.status
+        return FakeResponse(status)
+
+    async def set_content(self, html):
+        self.calls.append(("set_content", html))
+
+    async def evaluate(self, script, origin):
+        self.calls.append(("evaluate", script, origin))
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeContext:
+    def __init__(self, page):
+        self.page = page
+
+    async def new_page(self):
+        return self.page
+
+
+def sentinel_factory(*, connections=0, byte_count=0):
+    class FakeSentinel:
+        origin = "http://127.0.0.1:43123"
+        accepted_connections = connections
+        accepted_bytes = byte_count
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return None
+
+    return FakeSentinel
+
+
+@pytest.mark.asyncio
+async def test_preflight_requires_gateway_403_and_exercises_native_paths():
+    page = FakePage()
+    context = FakeContext(page)
+
+    await run_native_egress_preflight(
+        "remote-egress-v1",
+        context,
+        sentinel_factory=sentinel_factory(),
+    )
+
+    assert page.calls[0][0] == "goto"
+    assert page.calls[0][1] == "http://remote-browser-preflight.invalid/"
+    assert page.calls[1][1].endswith("/main-frame")
+    assert [call[0] for call in page.calls] == [
+        "goto",
+        "goto",
+        "set_content",
+        "evaluate",
+    ]
+    assert page.closed is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "connections", "byte_count"),
+    ((204, 1, 20), (407, 0, 0), (502, 0, 0), (403, 1, 0)),
+)
+async def test_preflight_fails_closed_for_direct_auth_or_gateway_uncertainty(
+    status, connections, byte_count
+):
+    page = FakePage(status=status)
+
+    with pytest.raises(
+        NativeEgressPreflightError,
+        match="^EGRESS_PREFLIGHT_FAILED: native browser egress boundary could not be proven$",
+    ):
+        await run_native_egress_preflight(
+            "remote-egress-v1",
+            FakeContext(page),
+            sentinel_factory=sentinel_factory(
+                connections=connections,
+                byte_count=byte_count,
+            ),
+        )
+
+    assert page.closed is True
+
+
+@pytest.mark.asyncio
+async def test_preflight_requires_the_gateway_dns_witness():
+    page = FakePage(witness_status=407)
+
+    with pytest.raises(NativeEgressPreflightError, match="EGRESS_PREFLIGHT_FAILED"):
+        await run_native_egress_preflight(
+            "remote-egress-v1",
+            FakeContext(page),
+            sentinel_factory=sentinel_factory(),
+        )
+
+    assert len(page.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_preflight_collapses_internal_errors_without_leaking_details():
+    page = FakePage(error=RuntimeError("proxy-password=never-print-this"))
+
+    with pytest.raises(NativeEgressPreflightError) as raised:
+        await run_native_egress_preflight(
+            "remote-egress-v1",
+            FakeContext(page),
+            sentinel_factory=sentinel_factory(),
+        )
+
+    assert str(raised.value) == (
+        "EGRESS_PREFLIGHT_FAILED: native browser egress boundary could not be proven"
+    )
+    assert "password" not in str(raised.value)
+    assert page.closed is True
+
+
+@pytest.mark.asyncio
+async def test_preflight_preserves_cancellation_and_closes_probe_page():
+    page = FakePage(error=asyncio.CancelledError())
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_native_egress_preflight(
+            "remote-egress-v1",
+            FakeContext(page),
+            sentinel_factory=sentinel_factory(),
+        )
+
+    assert page.closed is True
+
+
+@pytest.mark.asyncio
+async def test_unknown_preflight_version_fails_closed_before_opening_a_page():
+    page = FakePage()
+
+    with pytest.raises(NativeEgressPreflightError, match="EGRESS_PREFLIGHT_FAILED"):
+        await run_native_egress_preflight(
+            "remote-egress-v2",
+            FakeContext(page),
+            sentinel_factory=sentinel_factory(),
+        )
+
+    assert page.calls == []

--- a/tests/unit/test_remote_browser_native_egress.py
+++ b/tests/unit/test_remote_browser_native_egress.py
@@ -11,15 +11,34 @@ from connectonion.useful_tools.browser_tools.native_egress import (
 
 
 class FakeResponse:
-    def __init__(self, status=403):
+    def __init__(self, status=403, witness="DESTINATION_HOST_DENIED"):
         self.status = status
+        # The real gateway stamps this on every refusal, and it is what the
+        # preflight matches on. A fake that omits it models a response no
+        # gateway produces.
+        self.headers = {"x-connectonion-error": witness} if witness else {}
+
+
+class FakeGateway:
+    """Counts decisions the way EgressGateway does, for the positive control."""
+
+    def __init__(self, per_probe=1):
+        self.handled_requests = 0
+        self.per_probe = per_probe
+
+    def saw_request(self):
+        self.handled_requests += 1
 
 
 class FakePage:
-    def __init__(self, *, status=403, witness_status=502, error=None):
+    def __init__(self, *, status=403, witness_status=403, error=None,
+                 witness=True, gateway=None, evaluate_hits=1):
         self.status = status
         self.witness_status = witness_status
         self.error = error
+        self.witness = witness
+        self.gateway = gateway
+        self.evaluate_hits = evaluate_hits
         self.calls = []
         self.closed = False
 
@@ -27,14 +46,22 @@ class FakePage:
         self.calls.append(("goto", url, options))
         if self.error is not None:
             raise self.error
+        if self.gateway is not None:
+            self.gateway.saw_request()
         status = self.witness_status if url.endswith(".invalid/") else self.status
-        return FakeResponse(status)
+        code = "DESTINATION_HOST_DENIED" if self.witness else None
+        return FakeResponse(status, code)
 
     async def set_content(self, html):
         self.calls.append(("set_content", html))
 
     async def evaluate(self, script, origin):
         self.calls.append(("evaluate", script, origin))
+        # A real subresource probe reaches the gateway; a neutered one does not,
+        # and that difference is what the positive control detects.
+        if self.gateway is not None:
+            for _ in range(self.evaluate_hits):
+                self.gateway.saw_request()
 
     async def close(self):
         self.closed = True
@@ -170,3 +197,58 @@ async def test_unknown_preflight_version_fails_closed_before_opening_a_page():
         )
 
     assert page.calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_subresource_probe_that_does_nothing_fails_the_preflight():
+    """Absence is only evidence once the thing that makes presence has run.
+
+    The subresource probes swallow their own errors inside a bounded race, so
+    a probe that silently no-ops leaves exactly the zero-socket reading that a
+    correctly proxied probe leaves. Neutering the probe must be detectable.
+    """
+    gateway = FakeGateway()
+    # evaluate_hits=0 models a probe that ran but reached nothing: a wrong URL,
+    # a blocked API, an await that resolved on the timer.
+    page = FakePage(gateway=gateway, evaluate_hits=0)
+    context = FakeContext(page)
+
+    with pytest.raises(NativeEgressPreflightError, match="EGRESS_PREFLIGHT_FAILED"):
+        await run_native_egress_preflight(
+            "remote-egress-v1",
+            context,
+            sentinel_factory=sentinel_factory(),
+            gateway=gateway,
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_response_without_the_gateway_witness_fails_the_preflight():
+    """A 403 from something other than this gateway proves nothing."""
+    gateway = FakeGateway()
+    page = FakePage(gateway=gateway, witness=False)
+    context = FakeContext(page)
+
+    with pytest.raises(NativeEgressPreflightError, match="EGRESS_PREFLIGHT_FAILED"):
+        await run_native_egress_preflight(
+            "remote-egress-v1",
+            context,
+            sentinel_factory=sentinel_factory(),
+            gateway=gateway,
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_preflight_passes_when_every_probe_reaches_the_gateway():
+    """The positive case, so the tests above prove a difference, not a floor."""
+    gateway = FakeGateway()
+    page = FakePage(gateway=gateway, evaluate_hits=4)
+    context = FakeContext(page)
+
+    await run_native_egress_preflight(
+        "remote-egress-v1",
+        context,
+        sentinel_factory=sentinel_factory(),
+        gateway=gateway,
+    )
+    assert gateway.handled_requests >= 6

--- a/tests/unit/test_remote_browser_private_runtime.py
+++ b/tests/unit/test_remote_browser_private_runtime.py
@@ -29,6 +29,9 @@ from connectonion.useful_tools.browser_tools.launch_policy import (
     BrowserLaunchPolicy,
     BrowserProxySettings,
 )
+from connectonion.useful_tools.browser_tools.native_egress import (
+    NativeEgressPreflightError,
+)
 
 
 class LifecycleBrowser:
@@ -336,6 +339,17 @@ class FakePlaywright:
         self.stopped = True
 
 
+class FailingLaunchPlaywright(FakePlaywright):
+    def __init__(self, error):
+        super().__init__()
+        self.error = error
+
+    async def launch_persistent_context(self, profile, **options):
+        self.profile = profile
+        self.options = options
+        raise self.error
+
+
 class FakeManager:
     def __init__(self, playwright):
         self.playwright = playwright
@@ -396,7 +410,11 @@ async def test_native_preflight_failure_closes_partial_context_and_driver(
     tmp_path, monkeypatch
 ):
     playwright = FakePlaywright()
-    preflight = AsyncMock(side_effect=RuntimeError("preflight failed"))
+    preflight = AsyncMock(
+        side_effect=RuntimeError(
+            f"driver echoed --connectonion-proxy-auth-file={tmp_path}/proxy-auth.json"
+        )
+    )
     monkeypatch.setattr(async_browser, "ASYNC_BROWSER_AVAILABLE", True)
     monkeypatch.setattr(async_browser, "async_playwright", lambda: FakeManager(playwright))
     monkeypatch.setattr(async_browser, "find_system_chrome", lambda: "/fake/chrome")
@@ -408,13 +426,49 @@ async def test_native_preflight_failure_closes_partial_context_and_driver(
     )
     browser = async_browser.AsyncBrowserCore(headless=True, launch_policy=policy)
 
-    with pytest.raises(RuntimeError, match="preflight failed"):
+    with pytest.raises(NativeEgressPreflightError) as raised:
         await browser.open_browser()
 
+    assert str(raised.value) == (
+        "EGRESS_PREFLIGHT_FAILED: native browser egress boundary could not be proven"
+    )
+    assert str(tmp_path) not in str(raised.value)
     assert browser.browser is None
     assert browser.playwright is None
     assert playwright.context.closed is True
     assert playwright.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_private_driver_launch_error_cannot_echo_auth_path(tmp_path, monkeypatch):
+    auth_file = tmp_path / "proxy-auth.json"
+    playwright = FailingLaunchPlaywright(
+        RuntimeError(f"failed argv --connectonion-proxy-auth-file={auth_file}")
+    )
+    preflight = AsyncMock()
+    monkeypatch.setattr(async_browser, "ASYNC_BROWSER_AVAILABLE", True)
+    monkeypatch.setattr(async_browser, "async_playwright", lambda: FakeManager(playwright))
+    monkeypatch.setattr(async_browser, "find_system_chrome", lambda: "/fake/chrome")
+    monkeypatch.setattr(async_browser, "run_native_egress_preflight", preflight)
+    policy = remote_browser_launch_policy(
+        tmp_path / "private-profile",
+        ProxyEndpoint("127.0.0.1", 43123, "connectonion", "A" * 43),
+        auth_file,
+    )
+    browser = async_browser.AsyncBrowserCore(headless=True, launch_policy=policy)
+
+    with pytest.raises(NativeEgressPreflightError) as raised:
+        await browser.open_browser()
+
+    assert str(raised.value) == (
+        "EGRESS_PREFLIGHT_FAILED: native browser egress boundary could not be proven"
+    )
+    assert str(auth_file) not in str(raised.value)
+    assert browser.browser is None
+    assert browser.playwright is None
+    assert playwright.context.closed is False
+    assert playwright.stopped is True
+    preflight.assert_not_awaited()
 
 
 def test_default_remote_service_targets_private_daemon(tmp_path, monkeypatch):

--- a/tests/unit/test_remote_browser_private_runtime.py
+++ b/tests/unit/test_remote_browser_private_runtime.py
@@ -1,7 +1,9 @@
 """Isolation and launch contracts for the Host-private browser runtime."""
 
 import contextlib
+import json
 import os
+import stat
 import threading
 import time
 from pathlib import Path
@@ -13,9 +15,13 @@ from connectonion.cli.browser_agent import client, transport
 from connectonion.cli.browser_agent.daemon import BrowserDaemon
 from connectonion.network.host.egress_gateway import EgressGateway, ProxyEndpoint
 from connectonion.network.host.private_browser_runtime import (
+    PROXY_AUTH_REALM,
     REMOTE_BROWSER_CHROME_ARGS,
     PrivateBrowserTarget,
+    canonical_proxy_auth,
+    proxy_auth_path_for_profile,
     remote_browser_launch_policy,
+    write_proxy_auth_file,
 )
 from connectonion.network.host.remote_browser import RemoteBrowserService
 from connectonion.useful_tools.browser_tools import _async_browser as async_browser
@@ -46,7 +52,7 @@ class LifecycleBrowser:
 
 
 class RecordingGateway:
-    def __init__(self, events, password="gateway-secret"):
+    def __init__(self, events, password="A" * 43):
         self.events = events
         self.endpoint = ProxyEndpoint("127.0.0.1", 43123, "connectonion", password)
         self.is_running = False
@@ -87,6 +93,7 @@ def test_private_target_is_stable_short_and_separate_from_local(tmp_path, monkey
     assert Path(first.address).is_relative_to(short_root)
     assert first.profile_dir != other.profile_dir
     assert first.log_path.parent == first.authkey_path.parent
+    assert first.proxy_auth_path == first.profile_dir.parent / "proxy-auth.json"
     assert transport.pid_path(first.address) != transport.pid_path(transport.default_address())
     assert transport.lock_path(first.address) != transport.lock_path(transport.default_address())
     if os.name != "nt":
@@ -107,19 +114,18 @@ def test_windows_namespaces_include_user_and_stable_digest(monkeypatch):
 
 
 def test_launch_policy_is_fixed_fail_closed_and_secret_safe(tmp_path):
-    endpoint = ProxyEndpoint("127.0.0.1", 43123, "connectonion", "proxy-secret")
-    policy = remote_browser_launch_policy(tmp_path / "profile", endpoint)
+    password = "A" * 43
+    endpoint = ProxyEndpoint("127.0.0.1", 43123, "connectonion", password)
+    auth_file = tmp_path / "proxy-auth.json"
+    policy = remote_browser_launch_policy(tmp_path / "profile", endpoint, auth_file)
     options = policy.playwright_options()
 
-    assert options["proxy"] == {
-        "server": "http://127.0.0.1:43123",
-        "username": "connectonion",
-        "password": "proxy-secret",
-    }
+    assert options["proxy"] == {"server": "http://127.0.0.1:43123"}
     assert options["service_workers"] == "block"
     assert options["accept_downloads"] is True
     assert policy.native_preflight == "remote-egress-v1"
-    assert tuple(options["args"]) == REMOTE_BROWSER_CHROME_ARGS
+    assert tuple(options["args"][:-1]) == REMOTE_BROWSER_CHROME_ARGS
+    assert options["args"][-1] == f"--connectonion-proxy-auth-file={auth_file}"
     assert "--proxy-bypass-list=<-loopback>" in options["args"]
     assert "--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1" in options["args"]
     assert "--disable-quic" in options["args"]
@@ -129,8 +135,59 @@ def test_launch_policy_is_fixed_fail_closed_and_secret_safe(tmp_path):
     assert not any(arg.startswith("--force-webrtc") for arg in options["args"])
     assert "--disable-extensions" in options["args"]
     assert "direct" not in options["proxy"]["server"].lower()
-    assert "proxy-secret" not in repr(endpoint)
-    assert "proxy-secret" not in repr(policy)
+    assert password not in repr(endpoint)
+    assert password not in repr(policy)
+    assert password not in repr(options)
+
+
+def test_proxy_auth_file_matches_native_contract_and_is_private(tmp_path):
+    password = "A" * 43
+    endpoint = ProxyEndpoint("127.0.0.1", 43123, "connectonion", password)
+    auth_file = tmp_path / "proxy-auth.json"
+
+    written = write_proxy_auth_file(auth_file, endpoint)
+
+    assert written == auth_file
+    assert json.loads(auth_file.read_text(encoding="ascii")) == {
+        "challenger": "127.0.0.1:43123",
+        "password": password,
+        "realm": PROXY_AUTH_REALM,
+        "scheme": "basic",
+        "username": "connectonion",
+        "v": 1,
+    }
+    assert auth_file.read_bytes() == canonical_proxy_auth(endpoint)
+    assert list(tmp_path.iterdir()) == [auth_file]
+    if os.name != "nt":
+        assert stat.S_IMODE(auth_file.stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    (
+        ProxyEndpoint("localhost", 43123, "connectonion", "A" * 43),
+        ProxyEndpoint("127.0.0.1", 0, "connectonion", "A" * 43),
+        ProxyEndpoint("127.0.0.1", 43123, "other", "A" * 43),
+        ProxyEndpoint("127.0.0.1", 43123, "connectonion", "short"),
+    ),
+)
+def test_proxy_auth_file_rejects_noncanonical_native_credentials(tmp_path, endpoint):
+    with pytest.raises(ValueError, match="native proxy credentials are not canonical"):
+        write_proxy_auth_file(tmp_path / "proxy-auth.json", endpoint)
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX private-directory modes")
+def test_proxy_auth_file_rejects_public_parent(tmp_path):
+    os.chmod(tmp_path, 0o755)
+
+    with pytest.raises(ValueError, match="root must be private"):
+        write_proxy_auth_file(
+            tmp_path / "proxy-auth.json",
+            ProxyEndpoint("127.0.0.1", 43123, "connectonion", "A" * 43),
+        )
+
+    assert list(tmp_path.iterdir()) == []
 
 
 @pytest.mark.parametrize(
@@ -144,8 +201,8 @@ def test_launch_policy_is_fixed_fail_closed_and_secret_safe(tmp_path):
     ),
 )
 def test_launch_proxy_rejects_every_noncanonical_or_fallback_server(server):
-    with pytest.raises(ValueError, match="authenticated loopback"):
-        BrowserProxySettings(server, "connectonion", "secret")
+    with pytest.raises(ValueError, match="canonical loopback"):
+        BrowserProxySettings(server)
 
 
 @pytest.mark.asyncio
@@ -171,6 +228,10 @@ async def test_daemon_starts_gateway_before_browser_and_stops_it_after_browser(
     await daemon._prepare_runtime()
     assert events == ["gateway.start", "browser.create"]
     assert daemon.browser.launch_policy.profile_dir == (tmp_path / "profile").resolve()
+    auth_file = proxy_auth_path_for_profile(tmp_path / "profile")
+    assert auth_file.is_file()
+    assert gateway.endpoint.password in auth_file.read_text(encoding="ascii")
+    assert gateway.endpoint.password not in repr(daemon.browser.launch_policy)
     await daemon._prepare_runtime()
     assert events == ["gateway.start", "browser.create"]
     await daemon._shutdown_async()
@@ -180,6 +241,7 @@ async def test_daemon_starts_gateway_before_browser_and_stops_it_after_browser(
         "browser.stop",
         "gateway.stop",
     ]
+    assert not auth_file.exists()
 
 
 @pytest.mark.asyncio
@@ -202,6 +264,7 @@ async def test_browser_construction_failure_closes_gateway_before_ipc_bind(tmp_p
         await daemon._prepare_runtime()
 
     assert events == ["gateway.start", "browser.fail", "gateway.stop"]
+    assert not proxy_auth_path_for_profile(tmp_path / "profile").exists()
     assert not Path(daemon.sock_path).exists()
     assert not Path(transport.pid_path(daemon.sock_path)).exists()
 
@@ -292,7 +355,8 @@ async def test_async_core_uses_private_policy_not_environment_proxy(tmp_path, mo
     monkeypatch.setattr(async_browser, "run_native_egress_preflight", preflight)
     policy = remote_browser_launch_policy(
         tmp_path / "private-profile",
-        ProxyEndpoint("127.0.0.1", 43123, "connectonion", "secret"),
+        ProxyEndpoint("127.0.0.1", 43123, "connectonion", "A" * 43),
+        tmp_path / "proxy-auth.json",
     )
     browser = async_browser.AsyncBrowserCore(headless=True, launch_policy=policy)
 
@@ -339,7 +403,8 @@ async def test_native_preflight_failure_closes_partial_context_and_driver(
     monkeypatch.setattr(async_browser, "run_native_egress_preflight", preflight)
     policy = remote_browser_launch_policy(
         tmp_path / "private-profile",
-        ProxyEndpoint("127.0.0.1", 43123, "connectonion", "secret"),
+        ProxyEndpoint("127.0.0.1", 43123, "connectonion", "A" * 43),
+        tmp_path / "proxy-auth.json",
     )
     browser = async_browser.AsyncBrowserCore(headless=True, launch_policy=policy)
 

--- a/tests/unit/test_remote_browser_private_runtime.py
+++ b/tests/unit/test_remote_browser_private_runtime.py
@@ -5,6 +5,7 @@ import os
 import threading
 import time
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -117,6 +118,7 @@ def test_launch_policy_is_fixed_fail_closed_and_secret_safe(tmp_path):
     }
     assert options["service_workers"] == "block"
     assert options["accept_downloads"] is True
+    assert policy.native_preflight == "remote-egress-v1"
     assert tuple(options["args"]) == REMOTE_BROWSER_CHROME_ARGS
     assert "--proxy-bypass-list=<-loopback>" in options["args"]
     assert "--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1" in options["args"]
@@ -229,6 +231,7 @@ async def test_gateway_loss_rejects_lifecycle_before_browser_mutation(tmp_path):
 class FakeContext:
     def __init__(self):
         self.pages = []
+        self.closed = False
 
     async def cookies(self):
         return []
@@ -239,7 +242,7 @@ class FakeContext:
         return page
 
     async def close(self):
-        return None
+        self.closed = True
 
 
 class FakePage:
@@ -258,6 +261,7 @@ class FakePlaywright:
         self.context = FakeContext()
         self.profile = None
         self.options = None
+        self.stopped = False
         self.chromium = self
 
     async def launch_persistent_context(self, profile, **options):
@@ -266,7 +270,7 @@ class FakePlaywright:
         return self.context
 
     async def stop(self):
-        return None
+        self.stopped = True
 
 
 class FakeManager:
@@ -280,10 +284,12 @@ class FakeManager:
 @pytest.mark.asyncio
 async def test_async_core_uses_private_policy_not_environment_proxy(tmp_path, monkeypatch):
     playwright = FakePlaywright()
+    preflight = AsyncMock()
     monkeypatch.setenv("BROWSER_PROXY", "http://environment.invalid:9999")
     monkeypatch.setattr(async_browser, "ASYNC_BROWSER_AVAILABLE", True)
     monkeypatch.setattr(async_browser, "async_playwright", lambda: FakeManager(playwright))
     monkeypatch.setattr(async_browser, "find_system_chrome", lambda: "/fake/chrome")
+    monkeypatch.setattr(async_browser, "run_native_egress_preflight", preflight)
     policy = remote_browser_launch_policy(
         tmp_path / "private-profile",
         ProxyEndpoint("127.0.0.1", 43123, "connectonion", "secret"),
@@ -296,17 +302,20 @@ async def test_async_core_uses_private_policy_not_environment_proxy(tmp_path, mo
     assert playwright.options["proxy"]["server"] == "http://127.0.0.1:43123"
     assert "environment.invalid" not in repr(playwright.options)
     assert playwright.options["service_workers"] == "block"
+    preflight.assert_awaited_once_with("remote-egress-v1", playwright.context)
     await browser.close()
 
 
 @pytest.mark.asyncio
 async def test_ordinary_async_core_keeps_environment_proxy_compatibility(tmp_path, monkeypatch):
     playwright = FakePlaywright()
+    preflight = AsyncMock()
     monkeypatch.setenv("BROWSER_PROXY", "http://local-proxy.example:8080")
     monkeypatch.setenv("CO_BROWSER_PROFILE_DIR", str(tmp_path / "local-profile"))
     monkeypatch.setattr(async_browser, "ASYNC_BROWSER_AVAILABLE", True)
     monkeypatch.setattr(async_browser, "async_playwright", lambda: FakeManager(playwright))
     monkeypatch.setattr(async_browser, "find_system_chrome", lambda: "/fake/chrome")
+    monkeypatch.setattr(async_browser, "run_native_egress_preflight", preflight)
     browser = async_browser.AsyncBrowserCore(headless=True)
 
     await browser.open_browser()
@@ -314,7 +323,33 @@ async def test_ordinary_async_core_keeps_environment_proxy_compatibility(tmp_pat
     assert playwright.profile == str((tmp_path / "local-profile").resolve())
     assert playwright.options["proxy"]["server"] == "http://local-proxy.example:8080"
     assert "service_workers" not in playwright.options
+    preflight.assert_not_awaited()
     await browser.close()
+
+
+@pytest.mark.asyncio
+async def test_native_preflight_failure_closes_partial_context_and_driver(
+    tmp_path, monkeypatch
+):
+    playwright = FakePlaywright()
+    preflight = AsyncMock(side_effect=RuntimeError("preflight failed"))
+    monkeypatch.setattr(async_browser, "ASYNC_BROWSER_AVAILABLE", True)
+    monkeypatch.setattr(async_browser, "async_playwright", lambda: FakeManager(playwright))
+    monkeypatch.setattr(async_browser, "find_system_chrome", lambda: "/fake/chrome")
+    monkeypatch.setattr(async_browser, "run_native_egress_preflight", preflight)
+    policy = remote_browser_launch_policy(
+        tmp_path / "private-profile",
+        ProxyEndpoint("127.0.0.1", 43123, "connectonion", "secret"),
+    )
+    browser = async_browser.AsyncBrowserCore(headless=True, launch_policy=policy)
+
+    with pytest.raises(RuntimeError, match="preflight failed"):
+        await browser.open_browser()
+
+    assert browser.browser is None
+    assert browser.playwright is None
+    assert playwright.context.closed is True
+    assert playwright.stopped is True
 
 
 def test_default_remote_service_targets_private_daemon(tmp_path, monkeypatch):

--- a/tests/unit/test_remote_browser_private_runtime.py
+++ b/tests/unit/test_remote_browser_private_runtime.py
@@ -35,10 +35,11 @@ from connectonion.useful_tools.browser_tools.native_egress import (
 
 
 class LifecycleBrowser:
-    def __init__(self, *, headless=True, launch_policy=None, events=None):
+    def __init__(self, *, headless=True, launch_policy=None, events=None, egress_gateway=None):
         self._headless = headless
         self.launch_policy = launch_policy
         self.events = events
+        self.egress_gateway = egress_gateway
         self._tab_meta = {}
         self._pages = {}
 
@@ -380,7 +381,9 @@ async def test_async_core_uses_private_policy_not_environment_proxy(tmp_path, mo
     assert playwright.options["proxy"]["server"] == "http://127.0.0.1:43123"
     assert "environment.invalid" not in repr(playwright.options)
     assert playwright.options["service_workers"] == "block"
-    preflight.assert_awaited_once_with("remote-egress-v1", playwright.context)
+    preflight.assert_awaited_once_with(
+        "remote-egress-v1", playwright.context, gateway=None
+    )
     await browser.close()
 
 
@@ -634,23 +637,33 @@ def test_a_policy_missing_any_egress_argument_will_not_construct(tmp_path, dropp
     boundary. Validating only the constant is what let a misspelled WebRTC
     switch — silently ignored by Chromium — read as an enforced control.
     """
-    proxy = BrowserProxySettings(
-        server="http://127.0.0.1:9999", username="connectonion", password="x"
-    )
-    args = tuple(arg for arg in REMOTE_BROWSER_CHROME_ARGS if arg != dropped)
+    proxy = BrowserProxySettings(server="http://127.0.0.1:9999")
+    auth_file = tmp_path / "proxy-auth.json"
+    args = tuple(
+        arg for arg in REMOTE_BROWSER_CHROME_ARGS if arg != dropped
+    ) + (f"--connectonion-proxy-auth-file={auth_file}",)
 
     with pytest.raises(ValueError) as raised:
-        BrowserLaunchPolicy(profile_dir=tmp_path, proxy=proxy, args=args)
+        BrowserLaunchPolicy(
+            profile_dir=tmp_path,
+            proxy=proxy,
+            proxy_auth_file=auth_file,
+            args=args,
+        )
     assert "egress" in str(raised.value)
 
 
 def test_a_bare_proxy_server_argument_is_refused(tmp_path):
-    proxy = BrowserProxySettings(
-        server="http://127.0.0.1:9999", username="connectonion", password="x"
-    )
+    proxy = BrowserProxySettings(server="http://127.0.0.1:9999")
+    auth_file = tmp_path / "proxy-auth.json"
     with pytest.raises(ValueError):
         BrowserLaunchPolicy(
             profile_dir=tmp_path,
             proxy=proxy,
-            args=(*REMOTE_BROWSER_CHROME_ARGS, "--proxy-server=http://127.0.0.1:1"),
+            proxy_auth_file=auth_file,
+            args=(
+                *REMOTE_BROWSER_CHROME_ARGS,
+                f"--connectonion-proxy-auth-file={auth_file}",
+                "--proxy-server=http://127.0.0.1:1",
+            ),
         )


### PR DESCRIPTION
## Problem

The private Remote Browser launch policy requests a loopback proxy, but Chromium launch success alone does not prove that the effective browser process used that gateway. Chromium can silently bypass loopback destinations, and an unauthenticated or system-browser launch must never make Remote Browser page commands available.

## Approach

- add a versioned native egress preflight to the private launch policy
- atomically write browser #105's canonical credential document inside the Host-private runtime root
- pass Playwright only the loopback proxy server and pass the paid browser only a path-only native credential switch
- remove the credential file on browser construction failure and after browser shutdown
- require an owned `.invalid` request to return the gateway DNS witness (502)
- require an owned loopback main-frame request to return the authenticated gateway denial (403)
- exercise fetch, image, WebSocket, and worker paths against a loopback sentinel
- require the sentinel to observe zero accepted sockets and zero bytes
- run the preflight after the real persistent context launches but before seed cookies or user pages
- collapse all uncertainty to one secret-free `EGRESS_PREFLIGHT_FAILED` error and tear down partial browser/driver state
- redact driver-launch failures before they can echo the private credential-file path

## Dependencies and intentional limits

This is a fail-closed checkpoint, not the final installed-artifact acceptance claim.

- Base: #1305 (Host-private runtime)
- Browser revision: openonion/browser#104
- Native scoped proxy credentials: openonion/browser#105
- Host-side credential-file production is included here and matches browser #105; native consumption still depends on that browser patch
- Final integration must stack with the paid Onionwright engine from #1280 and force `engine=onion`; system Chrome is not Remote Browser eligible
- The installed Mac/Linux paid-artifact E2E matrix is intentionally deferred until those stacks meet. No system-Chrome test is presented as equivalent evidence.

Remote Browser page commands remain unavailable until the credential-enabled paid artifact passes the real installed-artifact suite.

## Verification

- `/private/tmp/connectonion310-venv/bin/python -m pytest tests/unit/test_remote_browser_native_egress.py tests/unit/test_remote_browser_private_runtime.py -q` — 33 passed
- Ruff on every changed Python file — passed
- `python -m compileall` on every changed Python file — passed
- `git diff --check` — passed

## Follow-up acceptance matrix

The stacked paid-artifact PR must run in parallel on macOS arm64 and Linux x86_64 and prove positive public navigation, main-frame and redirect denial, iframe/image/script/style/font/media/fetch/XHR/EventSource/worker/WebSocket/popup/download coverage, concurrent allowed/denied tabs, gateway crash/restart behavior, and zero loopback-sentinel sockets/bytes throughout.

**Proposed target version:** 1.8.0 / next alpha

**Estimated release window:** after browser #104/#105 and the stacked paid-engine installed-artifact gate
