### PR TITLE
1.8 async browser stack: concurrent daemon, sync facade, owner-bound remote browser (#1289 #1290 #1298)

### DIFF
--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -215,18 +215,25 @@ def _ensure_browser_ready(line: str) -> bool:
     return True
 
 
-def _request(line: str, headless: bool = False, tab: str = None,
-             raw_result: bool = False, _provisioned: bool = False) -> tuple:
+def _request_with_identity(
+    line: str,
+    *,
+    caller: str,
+    account: str,
+    headless: bool = False,
+    tab: str = None,
+    raw_result: bool = False,
+    _provisioned: bool = False,
+) -> tuple:
     """Send one short daemon request and return ``(code, payload)``.
 
     ``raw_result`` is for the client-side agent: image data must reach its vision
     formatter, while an interactive shell should still receive a saved-file line.
     The account address is public; the API key never crosses this transport.
     """
-    account = _caller_account()
     request = json.dumps({
         "v": 1,
-        "caller": _caller(),
+        "caller": caller,
         "account": account,
         "tab": tab,
         "line": line,
@@ -314,8 +321,13 @@ def _request(line: str, headless: bool = False, tab: str = None,
     # not something to guess at from a version-numbered cache path.
     if "No browser is installed for this user" in payload and not _provisioned:
         if _ensure_browser_ready(line):
-            return _request(
-                line, headless=headless, tab=tab, raw_result=raw_result,
+            return _request_with_identity(
+                line,
+                caller=caller,
+                account=account,
+                headless=headless,
+                tab=tab,
+                raw_result=raw_result,
                 _provisioned=True,
             )
 
@@ -336,6 +348,50 @@ def _request(line: str, headless: bool = False, tab: str = None,
     parts = header.split()
     code = int(parts[1]) if len(parts) == 2 and parts[1].isdigit() else 1
     return code, payload
+
+
+def _request(
+    line: str,
+    headless: bool = False,
+    tab: str = None,
+    raw_result: bool = False,
+    _provisioned: bool = False,
+) -> tuple:
+    """Send a request owned by this local CLI process."""
+    return _request_with_identity(
+        line,
+        caller=_caller(),
+        account=_caller_account(),
+        headless=headless,
+        tab=tab,
+        raw_result=raw_result,
+        _provisioned=_provisioned,
+    )
+
+
+def request_as(
+    line: str,
+    *,
+    caller: str,
+    account: str,
+    headless: bool = False,
+    tab: str = None,
+) -> tuple:
+    """Host-only daemon seam using an already authenticated remote identity.
+
+    The caller value comes from OIP authentication, never from remote request
+    arguments. Keeping this separate from ``_request`` prevents a local CLI
+    option from spoofing another tab owner.
+    """
+    if not caller or not account:
+        return 3, "authenticated caller and account are required"
+    return _request_with_identity(
+        line,
+        caller=caller,
+        account=account,
+        headless=headless,
+        tab=tab,
+    )
 
 
 def _tool_line(name: str, args: tuple, kwargs: dict) -> str:

--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -264,6 +264,12 @@ def _request(line: str, headless: bool = False, tab: str = None,
         # started replacement is never mistaken for the daemon being closed.
         if transport.IS_WINDOWS and tab is None and line.split() == ["close"]:
             owner_pid = _owner_pid(sock_path)
+            # Embedded users and socket round-trip tests may run the daemon in
+            # another thread of this process. That process cannot exit while the
+            # caller is waiting inside it; production's detached daemon always
+            # has a different pid.
+            if owner_pid == os.getpid():
+                owner_pid = None
     except RuntimeError as exc:
         # Setup failures (authkey mismatch/corruption, daemon didn't start) must exit
         # with a clean one-line error, NEVER a traceback: typer's pretty exceptions

--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -27,13 +27,31 @@ def default_sock_path() -> str:
     return transport.default_address()
 
 
-def _owner_alive(sock_path: str) -> bool:
-    """Read the daemon pid sidecar without importing Playwright or browser tools."""
+def _owner_pid(sock_path: str) -> int | None:
+    """Return the live daemon pid recorded beside the endpoint, if there is one."""
     pid_file = Path(transport.pid_path(sock_path))
     if not pid_file.exists():
-        return False
+        return None
     raw = pid_file.read_text(encoding="utf-8").strip()
-    return raw.isdigit() and transport.pid_alive(int(raw))
+    if not raw.isdigit():
+        return None
+    pid = int(raw)
+    return pid if transport.pid_alive(pid) else None
+
+
+def _owner_alive(sock_path: str) -> bool:
+    """Read the daemon pid sidecar without importing Playwright or browser tools."""
+    return _owner_pid(sock_path) is not None
+
+
+def _wait_for_pid_exit(pid: int, timeout: float = 15.0) -> bool:
+    """Wait for one exact daemon process, never a replacement using its endpoint."""
+    deadline = time.monotonic() + timeout
+    while transport.pid_alive(pid):
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.05)
+    return True
 
 
 def _connect(sock_path: str):
@@ -215,6 +233,7 @@ def _request(line: str, headless: bool = False, tab: str = None,
         "raw": raw_result,
     })
     sock_path = default_sock_path()
+    owner_pid = None
     try:
         conn = _connect(sock_path)
         if conn is None:
@@ -240,6 +259,11 @@ def _request(line: str, headless: bool = False, tab: str = None,
                 return 0, "Browser daemon: not running — the next page command starts one"
             _ensure_browser_ready(line)  # cold start: provision the browser first
             conn = _spawn_daemon(sock_path, headless)
+        # A successful whole-browser close is a lifecycle barrier on Windows.
+        # Record the exact process serving this connection so a concurrently
+        # started replacement is never mistaken for the daemon being closed.
+        if transport.IS_WINDOWS and tab is None and line.split() == ["close"]:
+            owner_pid = _owner_pid(sock_path)
     except RuntimeError as exc:
         # Setup failures (authkey mismatch/corruption, daemon didn't start) must exit
         # with a clean one-line error, NEVER a traceback: typer's pretty exceptions
@@ -271,6 +295,11 @@ def _request(line: str, headless: bool = False, tab: str = None,
 
     header, _, payload = reply.decode().partition("\n")
     if header == "OK":
+        if owner_pid is not None and not _wait_for_pid_exit(owner_pid):
+            return 1, (
+                "Browser closed, but its daemon did not stop within 15 seconds — "
+                "try again"
+            )
         return 0, payload
     # A warm daemon reached the launcher and found no browser. The cold-start
     # provisioning above was skipped because the connect succeeded, so without

--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -6,7 +6,7 @@ LLM-Note:
   State/Effects: may spawn the daemon via `python -m connectonion.cli.browser_agent.daemon <sock> [--headless]` detached (transport.spawn_detached: start_new_session POSIX / DETACHED_PROCESS Windows), logging to ~/.co/browser.log | writes to stdout/stderr
   Integration: exposes _caller() -> str, send(line, headless=False, tab=None) -> int | FIRST-RUN AUTO-INSTALL: on the cold-start path (no daemon yet) AND when a warm daemon answers "No browser is installed for this user" (send retries once), a page-driving verb with no system Chrome triggers `python -m patchright install chromium` right in the user's terminal (chromium: per-user dir, never needs admin — the branded chrome channel runs a system installer) (_ensure_browser_ready) — `co browser` just works with zero setup commands; PAGELESS_VERBS (status/tab/close/...) never provision
   Performance: direct verbs import only the lightweight transport client, then make one connect + request/response; Agent/Playwright and browser tool schemas load only for `do` or inside the daemon | daemon spawn adds browser launch latency on first call | model thinking happens in the caller process and holds no daemon lane
-  Errors: _connect() retries ~2s on a transient connection refusal from a busy single-threaded daemon (does NOT unlink a live-but-busy socket); only a truly stale POSIX socket is unlinked | missing endpoint → spawn daemon and wait until ready or timeout | ALL setup RuntimeErrors (Windows authkey mismatch/corruption, daemon didn't start) are caught in send() → one clean stderr line + exit 1, NEVER a traceback (typer's pretty exceptions would print frame locals, which hold the HMAC secret on the connect path) | daemon dying mid-request → clean stderr line + exit 1
+  Errors: _connect() retries transient refusal/backpressure and never unlinks an endpoint whose recorded owner is alive; only a truly stale POSIX socket is removed | missing endpoint → spawn daemon and wait until ready or timeout | setup RuntimeErrors become one clean stderr line, never a traceback containing HMAC-path locals | daemon death, overload shedding, or disconnect mid-request becomes a clean exit 1
 """
 
 import functools
@@ -38,8 +38,8 @@ def _owner_alive(sock_path: str) -> bool:
 
 def _connect(sock_path: str):
     """Connect to the daemon. Returns a live connection, or None if the daemon is
-    genuinely gone. A busy single-threaded daemon (during a browser action) can momentarily
-    refuse while its accept backlog is full — that is NOT a dead daemon, so retry
+    genuinely gone. A daemon at its bounded connection cap can momentarily refuse —
+    that is NOT a dead daemon, so retry
     while its recorded owner is alive; a dead owner fails fast (the spawned daemon
     replaces it). POSIX uses a raw AF_UNIX socket (unchanged); Windows uses the
     authenticated named-pipe client from `transport`. Raises RuntimeError only for
@@ -123,8 +123,8 @@ def _spawn_daemon(sock_path: str, headless: bool):
         time.sleep(0.1)
     if _owner_alive(sock_path):
         # A daemon IS running — it just can't take our connection right now (its
-        # backlog is full behind a long-running command). "Did not start" would lie.
-        raise RuntimeError("browser daemon is busy (a long command is holding it) — try again")
+        # bounded client capacity is full). "Did not start" would lie.
+        raise RuntimeError("browser daemon is at connection capacity — try again")
     raise RuntimeError(f"browser daemon did not start (see {log_path})")
 
 
@@ -229,14 +229,14 @@ def _request(line: str, headless: bool = False, tab: str = None,
                 # (#356).
                 #
                 # A failed connect is not "nobody listening": a daemon whose
-                # backlog is full behind a long command refuses connections too.
+                # bounded client capacity can refuse connections too.
                 # Saying "not running — the next page command starts one" then
                 # sends the reader in the wrong direction, and every command they
                 # try answers "busy". _owner_alive reads the pidfile and asks
                 # whether that pid lives — no spawn, no log, so the #356
                 # constraint above still holds.
                 if _owner_alive(sock_path):
-                    return 0, "Browser daemon: running, busy with a long command — try again shortly"
+                    return 0, "Browser daemon: running, busy at connection capacity — try again shortly"
                 return 0, "Browser daemon: not running — the next page command starts one"
             _ensure_browser_ready(line)  # cold start: provision the browser first
             conn = _spawn_daemon(sock_path, headless)

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -1,32 +1,39 @@
 """
-Purpose: Persistent browser daemon — owns one BrowserAutomation and dispatches CLI requests to it over the platform transport (POSIX Unix socket / Windows named pipe), arbitrating concurrent agents through per-tab ownership.
+Purpose: Persistent concurrent browser daemon — owns one AsyncBrowserCore/event loop and dispatches authenticated CLI requests over POSIX Unix sockets or Windows named pipes.
 LLM-Note:
-  Dependencies: imports from [socket, os, sys, time, json, shlex, inspect, signal, atexit, threading, datetime, pathlib, useful_tools.browser_tools.BrowserAutomation, useful_tools.browser_tools.browser.driver_stealth_status, useful_tools.browser_tools.browser.installed_browser_path, browser_agent.transport] | imported by [browser_agent.client (spawns via python -m), cli/commands/browser_commands.py (list_functions)] | tested by [tests/e2e/cli/test_browser_daemon.py]
-  Data flow: client sends wire-v1 JSON {v,caller,account,tab,line,raw} (or a legacy plain line) → one short browser verb runs → reply includes process exit code (2 usage, 3 unknown tab, 4 busy); `co browser do` runs its model loop in the client and reaches this daemon only through those short verb requests
-  State/Effects: single-threaded serial server (sync Playwright requires one thread) | owns one BrowserAutomation for daemon lifetime | the tab REGISTRY + claims live on browser._tab_meta[key] (key None = shared 'main'): who/purpose/opened_at/caller/claim_at/last_line/last_at | tracks last_command for `status` | binds the endpoint at default_sock_path() via `transport` — POSIX: a raw AF_UNIX socket (unchanged); Windows: a native named pipe (multiprocessing.connection) with an HMAC authkey — under a lifetime OS lock (transport.lock_path: fcntl.flock POSIX / msvcrt Windows, released by the OS on any death, so simultaneous cold-starts can't both bind) and records its owner pid in transport.pid_path so a refused probe can tell busy from stale; 120s per-connection recv timeout | _cleanup closes the listener (POSIX also unlinks the socket) + pidfile only while the pidfile still names this process (browser teardown is the driver pipe closing on process death — the executor is already gone when atexit runs) | serve() exits (releasing the endpoint) when browser._context_is_alive() goes false or _launch_failed()
-  Integration: exposes default_sock_path(), signature_str(), list_functions(), BrowserDaemon, main() | launched detached via `python -m connectonion.cli.browser_agent.daemon <sock_path> [--headless]` | module helpers _key()/_tab_label()/_held_by_other()/_owner_alive() define the None↔main aliasing, the shared claim-expiry predicate (dispatch, _tab_open, _closetab), and the socket-owner liveness check (client + _bind)
-  Performance: one short browser request at a time | browser launch overhead on first page verb (1-3s) | model latency never occupies the daemon | tab lifecycle/status verbs never launch Chrome
-  Errors: dispatch/handler exceptions are caught at the request boundary in serve() and returned to THAT client (never unwind the loop and kill the shared browser) | a client that vanishes mid-reply is logged to ~/.co/browser.log, not fatal | bind race with a second daemon → loser exits
+  Dependencies: asyncio + bounded Windows transport executor + AsyncBrowserCore + browser_agent.transport; BrowserAutomation is imported only to preserve the public CLI help/schema until #500 installs the sync facade | imported by browser_agent.client and browser_commands | tested by test_async_browser_daemon.py, test_browser_daemon.py, test_transport.py
+  Data flow: wire-v1 JSON {v,caller,account,tab,line,raw} (legacy plain line accepted) → atomic registry/claim admission → request-scoped audit lease → awaited async browser verb → bounded reply with exit code 2 usage / 3 unknown tab / 4 busy; `do` keeps model latency in the client and sends only its short tool calls
+  State/Effects: one asyncio-owned AsyncBrowserCore and persistent context | independent tab tasks interleave; AsyncBrowserCore's per-tab locks serialize one tab | registry lock makes conflicting claims deterministic and clears each request lease in finally | POSIX uses asyncio.start_unix_server with a 1 MiB request cap, absolute 120s read/write deadlines, 32-client cap, and immediate overload shedding | Windows preserves the HMAC named-pipe handshake and bridges accept/read/write through an 8-worker bounded executor into the same loop | lifetime OS lock + pid sidecar preserve cold-start/stale-owner rules | shutdown stops admission, cancels owned connection tasks, closes the runtime, and removes only its own endpoint
+  Integration: exposes default_sock_path(), signature_str(), list_functions(), BrowserDaemon, main(); launched detached via `python -m connectonion.cli.browser_agent.daemon <address> [--headless]`; dispatch() is a non-loop compatibility seam for existing pure tests, production awaits dispatch_async()
+  Performance: page operations on separate tabs overlap; same-tab work queues; browser/model/image blocking work never owns the event-loop thread; first browser launch remains 1-3s
+  Errors: malformed/oversized/stalled clients are bounded at their own connection boundary; cancellation clears only its request lease; vanished readers are logged and cannot stop the daemon; launch failure or closed shared runtime releases the endpoint
 """
 
+import asyncio
+import atexit
+import contextlib
+import inspect
+import json
 import os
 import platform
-import sys
-import time
-import socket
-import json
 import shlex
-import inspect
 import signal
-import atexit
+import socket
+import sys
 import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
 
 from connectonion.useful_tools.browser_tools import BrowserAutomation
+from connectonion.useful_tools.browser_tools._async_browser import AsyncBrowserCore
 from connectonion.useful_tools.browser_tools.browser import (
-    driver_stealth_status, installed_browser_path,
+    driver_stealth_status,
+    installed_browser_path,
 )
+
 from . import transport
 
 
@@ -97,6 +104,12 @@ def list_functions() -> str:
 
 
 GUARD_WINDOW = 120  # seconds a tab's last claim keeps excluding other callers
+
+REQUEST_TIMEOUT = 120.0
+REPLY_TIMEOUT = 120.0
+MAX_REQUEST_BYTES = 1024 * 1024
+MAX_IN_FLIGHT = 32
+WINDOWS_TRANSPORT_WORKERS = 8
 
 # Tabs are closed by the agent that opened them. This is only a janitor for tabs
 # whose opener is never coming back — a crashed process, a machine left running
@@ -208,11 +221,11 @@ def launch_failure_advice(first_line: str) -> str:
 
 
 class BrowserDaemon:
-    """Single-threaded server owning one BrowserAutomation, dispatching verbs to it."""
+    """Concurrent server owning one asyncio-native browser runtime."""
 
     def __init__(self, sock_path: str, headless: bool = False):
         self.sock_path = sock_path
-        self.browser = BrowserAutomation(headless=headless)
+        self.browser = AsyncBrowserCore(headless=headless)
         self._srv = None
         # Set by _cleanup before it closes the listener, so serve() can tell "we are
         # stopping" from "the socket broke while we were meant to be serving".
@@ -221,6 +234,11 @@ class BrowserDaemon:
         self._defer_context_probe = False
         self.last_command = None  # {"line": str, "at": float} of the last real command
         self._next_tab = 1        # id allocator for auto-named tabs
+        self._registry_lock = asyncio.Lock()
+        self._health_lock = asyncio.Lock()
+        self._loop = None
+        self._client_tasks = set()
+        self._transport_pool = None
 
     def _parse_envelope(self, raw: str) -> tuple:
         """Wire v1: JSON {caller,account,tab,line,raw} — quote-safe by construction
@@ -244,8 +262,26 @@ class BrowserDaemon:
     READONLY = ("tab", "status", "use", "switch")
 
     def dispatch(self, raw: str) -> tuple:
-        """Run one request. Returns (ok, payload); ok is True, False, or an int error
-        code the client mirrors into its exit (2 usage · 3 unknown tab · 4 tab busy)."""
+        """Synchronous test/embedding bridge; production uses ``dispatch_async``.
+
+        The daemon process calls the async method on its one owned event loop.  This
+        bridge preserves the long-standing pure-dispatch test seam without creating
+        a second browser worker or being callable from the runtime loop itself.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.dispatch_async(raw))
+        raise RuntimeError("dispatch() cannot run inside an event loop; await dispatch_async()")
+
+    async def dispatch_async(self, raw: str) -> tuple:
+        """Run one request without blocking unrelated tabs.
+
+        Returns ``(ok, payload)``; ok is True, False, or an integer error code
+        mirrored by the client (2 usage · 3 unknown tab · 4 tab busy).
+        Claim admission and active-request audit leases are atomic even though the
+        browser operation itself may overlap work on independent tabs.
+        """
         try:
             caller, _caller_account, tab, line, raw_result = self._parse_envelope(raw)
             tokens = shlex.split(line)
@@ -259,27 +295,28 @@ class BrowserDaemon:
         # command that would DRIVE the tab — read-only/lifecycle verbs may name a tab that
         # is not registered yet (to inspect it, or `tab open` it).
         session = _key(tab)
-        if session is not None and session not in self.browser._tab_meta and verb not in self.READONLY:
-            return 3, self._unknown_tab(session)
+        async with self._registry_lock:
+            if session is not None and session not in self.browser._tab_meta and verb not in self.READONLY:
+                return 3, await self._unknown_tab_async(session)
         self.browser._bind_session(session)
 
         if verb == "tab":  # tab lifecycle: open / ls / close
-            return self._tab(tokens[1:], caller)
+            return await self._tab_async(tokens[1:], caller)
         if verb == "status":  # read-only report; does not count as the last command
-            return self._status()
+            return await self._status_async()
         if verb in ("use", "switch"):  # removed: no server-side cursor, targeting is per-command
             return False, "use/switch removed — target a tab per command instead:  co browser -t <tab> <verb>"
         if verb == "newtab":  # legacy spelling of `tab open` + go_to
             if session is not None:  # it allocates its OWN tab — a -t target would be ignored
                 return 2, "newtab allocates its own tab and ignores -t — use:  co browser tab open <name>, then  co browser -t <name> go_to <url>"
-            return self._newtab(line, tokens, caller)
+            return await self._newtab_async(line, tokens, caller)
         if verb == "closetab":  # legacy spelling of `tab close`
-            return self._closetab(tokens[1:], caller)
+            return await self._closetab_async(tokens[1:], caller)
 
         # `close` with no -t is a deliberate whole-browser shutdown (unguarded). `-t X close`
         # closes ONE tab and so must pass the same ownership guard as any destructive write.
         if verb == "close" and session is None:
-            return self._call_verb("close", tokens[1:])
+            return await self._call_verb_async("close", tokens[1:])
 
         # A command that would execute nothing must not acquire anything: reject an
         # unknown verb BEFORE the claim, or a typo would hold the tab for GUARD_WINDOW.
@@ -298,12 +335,29 @@ class BrowserDaemon:
         # Every page-driving command (and a targeted close) claims its tab: a DIFFERENT
         # agent mid-task there fails loudly (exit 4) and is taught the tab lifecycle —
         # never silent interleaving on one page.
-        meta = self._register_tab(session, caller)
-        if _held_by_other(meta, caller):
-            return 4, self._tab_busy(session, meta)
-        self._stamp_claim(meta, caller, line)
-        self.last_command = {"line": line, "at": time.time()}
-        return self._call_verb(verb, tokens[1:], raw_result=raw_result)
+        request_id = uuid.uuid4().hex
+        async with self._registry_lock:
+            meta = self._register_tab(session, caller)
+            if _held_by_other(meta, caller):
+                return 4, self._tab_busy(session, meta)
+            self._stamp_claim(meta, caller, line)
+            meta.setdefault("active_requests", {})[request_id] = {
+                "caller": caller,
+                "line": line,
+                "started_at": time.time(),
+            }
+            self.last_command = {"line": line, "at": time.time()}
+        try:
+            return await self._call_verb_async(
+                verb, tokens[1:], raw_result=raw_result
+            )
+        finally:
+            async with self._registry_lock:
+                active = meta.get("active_requests")
+                if active is not None:
+                    active.pop(request_id, None)
+                    if not active:
+                        meta.pop("active_requests", None)
 
     def _register_tab(self, key, caller: str) -> dict:
         """Return the tab's board entry, creating the shared main tab's on first use.
@@ -335,7 +389,26 @@ class BrowserDaemon:
         meta["last_line"], meta["last_at"] = line, time.time()
 
     def _call_verb(self, verb: str, raw_args, raw_result: bool = False) -> tuple:
-        """Match the verb to a browser method and execute it with coerced args."""
+        """Synchronous compatibility bridge for pure dispatch tests."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._call_verb_async(verb, raw_args, raw_result))
+        raise RuntimeError("await _call_verb_async() inside an event loop")
+
+    def _launch_failed(self) -> bool:
+        probe = getattr(self.browser, "_launch_failed", None)
+        if callable(probe):
+            return bool(probe())
+        return (
+            getattr(self.browser, "playwright", None) is not None
+            and getattr(self.browser, "browser", None) is None
+        )
+
+    async def _call_verb_async(
+        self, verb: str, raw_args, raw_result: bool = False
+    ) -> tuple:
+        """Match a verb to an async browser method and await its result."""
         method = getattr(self.browser, verb)
         positional, kwargs = _split_tokens(raw_args)
 
@@ -350,8 +423,10 @@ class BrowserDaemon:
 
         try:
             result = method(*args, **kw)
+            if inspect.isawaitable(result):
+                result = await result
         except Exception as exc:  # dispatch boundary: report to client as ERR
-            if self.browser._launch_failed():
+            if self._launch_failed():
                 # Chrome aborted at startup: str(exc) is a huge patchright "Call log".
                 # Keep the first line and point at the full log instead of dumping it.
                 first = str(exc).strip().splitlines()[0] if str(exc).strip() else ""
@@ -371,8 +446,29 @@ class BrowserDaemon:
         return True, payload
 
     def _status(self) -> tuple:
+        """Synchronous compatibility bridge for status tests."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._status_async())
+        raise RuntimeError("await _status_async() inside an event loop")
+
+    async def _browser_is_alive(self) -> bool:
+        probe = getattr(self.browser, "is_alive", None)
+        if probe is None:
+            probe = getattr(self.browser, "_context_is_alive", None)
+        if probe is None:
+            return False
+        result = probe()
+        return bool(await result) if inspect.isawaitable(result) else bool(result)
+
+    async def _browser_tab_status(self) -> str:
+        result = self.browser.tab_status()
+        return await result if inspect.isawaitable(result) else result
+
+    async def _status_async(self) -> tuple:
         """Report browser state, the last command, and the tab board."""
-        open_state = "open" if self.browser._context_is_alive() else "not open"
+        open_state = "open" if await self._browser_is_alive() else "not open"
         headless = str(getattr(self.browser, "_headless", False)).lower()
         lines = [f"Browser: {open_state} · headless={headless} · targeting is per-command (-t <tab>; bare = main)"]
         # Surface stealth-driver health here so a misconfigured driver (webdriver leak) is
@@ -395,26 +491,49 @@ class BrowserDaemon:
         else:
             lines.append("Last command: (none yet)")
         lines.append("")
-        lines.append(self.browser.tab_status())
+        lines.append(await self._browser_tab_status())
         return True, "\n".join(lines)
 
     def _tab(self, args, caller: str = "") -> tuple:
-        """Tab lifecycle: `tab open [NAME] [--who X] [--for "..."]` · `tab ls [--json]` · `tab close NAME`."""
+        """Synchronous compatibility bridge for tab lifecycle tests."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._tab_async(args, caller))
+        raise RuntimeError("await _tab_async() inside an event loop")
+
+    async def _tab_async(self, args, caller: str = "") -> tuple:
+        """Tab lifecycle: open/list/close with atomic registry transitions."""
         if not args:
             return 2, self._tab_usage()
         action, rest = args[0], args[1:]
         if action == "open":
-            return self._tab_open(rest, caller)
+            async with self._registry_lock:
+                return self._tab_open(rest, caller)
         if action in ("ls", "list"):
+            await self._reap_abandoned_tabs()
             if "--json" in rest:
-                board = [
-                    {"tab": _tab_label(k), **{f: m.get(f) for f in ("who", "purpose", "last_line", "last_at")}}
-                    for k, m in self.browser._tab_meta.items()
-                ]
+                async with self._registry_lock:
+                    board = [
+                        {
+                            "tab": _tab_label(k),
+                            **{
+                                field: m.get(field)
+                                for field in ("who", "purpose", "last_line", "last_at")
+                            },
+                            "active_requests": [
+                                {"request_id": request_id, **request}
+                                for request_id, request in m.get(
+                                    "active_requests", {}
+                                ).items()
+                            ],
+                        }
+                        for k, m in self.browser._tab_meta.items()
+                    ]
                 return True, json.dumps(board)
-            return self._status()
+            return await self._status_async()
         if action == "close":
-            return self._closetab(rest, caller)
+            return await self._closetab_async(rest, caller)
         return 2, self._tab_usage()
 
     def _tab_open(self, rest, caller: str = "") -> tuple:
@@ -498,7 +617,7 @@ class BrowserDaemon:
             f"see who owns what:  co browser tab ls"
         )
 
-    def _reap_abandoned_tabs(self) -> None:
+    async def _reap_abandoned_tabs(self) -> None:
         """Close tabs whose opener never came back. Runs before tab listings.
 
         Owner-only closing means a crashed agent's tab would otherwise live as
@@ -507,19 +626,26 @@ class BrowserDaemon:
         for ABANDONED_AFTER (3 days). Every reclamation is logged, so the first
         person surprised by one can find out why.
         """
-        now = time.time()
-        for key, meta in list(self.browser._tab_meta.items()):
-            if key is None:  # main is shared and never reaped
-                continue
-            if _held_by_other(meta, ""):  # someone is actively driving it
-                continue
-            last = meta.get("last_at") or meta.get("claim_at")
-            if not last or now - last < ABANDONED_AFTER:
-                continue
-            owner = meta.get("opened_by") or meta.get("who") or "unknown"
-            self.browser.close_tab(_tab_label(key))
-            print(f"[reap] closed tab '{_tab_label(key)}' opened by {owner} — "
-                  f"idle {_ago(now - last)}", file=sys.stderr, flush=True)
+        async with self._registry_lock:
+            now = time.time()
+            for key, meta in list(self.browser._tab_meta.items()):
+                if key is None:  # main is shared and never reaped
+                    continue
+                if _held_by_other(meta, ""):  # someone is actively driving it
+                    continue
+                last = meta.get("last_at") or meta.get("claim_at")
+                if not last or now - last < ABANDONED_AFTER:
+                    continue
+                owner = meta.get("opened_by") or meta.get("who") or "unknown"
+                result = self.browser.close_tab(_tab_label(key))
+                if inspect.isawaitable(result):
+                    await result
+                print(
+                    f"[reap] closed tab '{_tab_label(key)}' opened by {owner} — "
+                    f"idle {_ago(now - last)}",
+                    file=sys.stderr,
+                    flush=True,
+                )
 
     def _tab_not_yours(self, key, owner: str) -> str:
         """Error-as-documentation: you may close your own tabs, not other agents'."""
@@ -543,154 +669,305 @@ class BrowserDaemon:
             f"when finished:    co browser tab close {name}"
         )
 
+    async def _unknown_tab_async(self, name: str) -> str:
+        board = await self._browser_tab_status()
+        return (
+            f"no tab named '{name}'\n\n"
+            f"{board}\n\n"
+            f"create it first:  co browser tab open {name} --who <your-name> --for \"<one-line purpose>\"\n"
+            f"then target it on every command, including do:\n"
+            f"                  co browser -t {name} <verb> [args]\n"
+            f"when finished:    co browser tab close {name}"
+        )
+
     def _newtab(self, line, tokens, caller: str = "") -> tuple:
-        """Legacy `newtab <url> --purpose=.. --who=..`: register + occupy a fresh tab.
-        Unlike the old behavior it does NOT repoint what bare commands target."""
+        """Synchronous compatibility bridge for the legacy newtab tests."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._newtab_async(line, tokens, caller))
+        raise RuntimeError("await _newtab_async() inside an event loop")
+
+    async def _newtab_async(self, line, tokens, caller: str = "") -> tuple:
+        """Register and occupy a fresh tab without changing bare targeting."""
         # A numeric id can collide with a NAME someone registered via `tab open` —
         # skip taken keys or this would occupy another agent's live tab.
-        while str(self._next_tab) in self.browser._tab_meta:
+        async with self._registry_lock:
+            while str(self._next_tab) in self.browser._tab_meta:
+                self._next_tab += 1
+            key = str(self._next_tab)
             self._next_tab += 1
-        key = str(self._next_tab)
-        self._next_tab += 1
-        self.browser._bind_session(key)
-        self.last_command = {"line": line, "at": time.time()}
-        ok, payload = self._call_verb("newtab", tokens[1:])
-        if not ok:
-            return False, payload
-        meta = self.browser._tab_meta.get(key)
-        if meta is not None and caller:
-            meta["caller"], meta["claim_at"] = caller, time.time()
-        return True, f"[tab {key}] {payload}"
+            self.browser._bind_session(key)
+            self.last_command = {"line": line, "at": time.time()}
+            ok, payload = await self._call_verb_async("newtab", tokens[1:])
+            if not ok:
+                return False, payload
+            meta = self.browser._tab_meta.get(key)
+            if meta is not None and caller:
+                meta["caller"], meta["claim_at"] = caller, time.time()
+            return True, f"[tab {key}] {payload}"
 
     def _closetab(self, args, caller: str = "") -> tuple:
-        """Close ONE tab, leaving the rest of the browser open."""
+        """Synchronous compatibility bridge for close-tab tests."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._closetab_async(args, caller))
+        raise RuntimeError("await _closetab_async() inside an event loop")
+
+    async def _closetab_async(self, args, caller: str = "") -> tuple:
+        """Close one tab atomically with respect to claim admission."""
         if not args:
             return 2, "usage: co browser tab close <tab>   (a name from `co browser tab ls`)"
         target = args[0]
         key = _key(target)
-        meta = self.browser._tab_meta.get(key)
-        if key not in self.browser._pages and meta is None:
-            if key is None:  # main always exists conceptually; nothing to release is fine
-                return True, "main is already free — nothing to close."
-            return 3, self._unknown_tab(target)
-        # Closing someone else's tab is fine once the time they asked for has
-        # passed — every agent here is cooperative, and a declaration that
-        # elapsed with the tab still open means its owner is gone, not busy.
-        # Before that, refuse: 120s of silence is not evidence a task ended.
-        if meta and _held_by_other(meta, caller):
-            return 4, self._tab_busy(key, meta)
-        self.last_command = {"line": "closetab " + target, "at": time.time()}
-        # close_tab releases the page, the registration (claim included), AND the
-        # remembered URL — a later tab reusing this name must start blank, never
-        # on the previous owner's page.
-        message = self.browser.close_tab(_tab_label(key))
-        return True, f"Closed tab {_tab_label(key)}. {message}"
+        async with self._registry_lock:
+            meta = self.browser._tab_meta.get(key)
+            if key not in self.browser._pages and meta is None:
+                if key is None:  # main always exists conceptually; nothing to release is fine
+                    return True, "main is already free — nothing to close."
+                return 3, await self._unknown_tab_async(target)
+            # Closing someone else's tab is fine once the time they asked for has
+            # passed — every agent here is cooperative, and a declaration that
+            # elapsed with the tab still open means its owner is gone, not busy.
+            # Before that, refuse: 120s of silence is not evidence a task ended.
+            if meta and _held_by_other(meta, caller):
+                return 4, self._tab_busy(key, meta)
+            self.last_command = {"line": "closetab " + target, "at": time.time()}
+            # close_tab releases the page, registration/claim, and remembered URL.
+            result = self.browser.close_tab(_tab_label(key))
+            message = await result if inspect.isawaitable(result) else result
+            return True, f"Closed tab {_tab_label(key)}. {message}"
 
     def serve(self):
+        """Own one event loop for the daemon's complete lifetime."""
+        asyncio.run(self.serve_async())
+
+    async def serve_async(self):
+        self._loop = asyncio.get_running_loop()
         self._bind()
         atexit.register(self._cleanup)
         if threading.current_thread() is threading.main_thread():
-            signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+            with contextlib.suppress(NotImplementedError, RuntimeError):
+                self._loop.add_signal_handler(signal.SIGTERM, self._begin_shutdown)
 
+        try:
+            if transport.IS_WINDOWS:
+                self._transport_pool = ThreadPoolExecutor(
+                    max_workers=WINDOWS_TRANSPORT_WORKERS,
+                    thread_name_prefix="browser-transport",
+                )
+                await self._serve_windows()
+            else:
+                raw_listener = self._srv
+                self._srv = await asyncio.start_unix_server(
+                    self._accept_posix_client,
+                    sock=raw_listener,
+                    limit=MAX_REQUEST_BYTES + 1,
+                    backlog=MAX_IN_FLIGHT,
+                )
+                await self._srv.serve_forever()
+        except asyncio.CancelledError:
+            if not self._closing:
+                raise
+        except OSError:
+            if not self._closing:
+                raise
+        finally:
+            await self._shutdown_async()
+
+    def _accept_posix_client(self, reader, writer) -> None:
+        """Admit at most ``MAX_IN_FLIGHT`` clients; shed excess immediately."""
+        if self._closing or len(self._client_tasks) >= MAX_IN_FLIGHT:
+            writer.transport.abort()
+            return
+        task = asyncio.create_task(self._handle_posix_client(reader, writer))
+        self._track_client(task)
+
+    def _track_client(self, task: asyncio.Task) -> None:
+        self._client_tasks.add(task)
+        task.add_done_callback(self._client_done)
+
+    def _client_done(self, task: asyncio.Task) -> None:
+        self._client_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            print(f"browser client task failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+
+    async def _read_posix_request(self, reader) -> str:
+        deadline = asyncio.get_running_loop().time() + REQUEST_TIMEOUT
+        chunks = []
+        size = 0
         while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                raise TimeoutError("request timed out")
             try:
-                conn = self._accept()
+                chunk = await asyncio.wait_for(reader.read(65536), timeout=remaining)
+            except TimeoutError as exc:
+                raise TimeoutError("request timed out") from exc
+            if not chunk:
+                return b"".join(chunks).decode().strip()
+            size += len(chunk)
+            if size > MAX_REQUEST_BYTES:
+                raise ValueError(
+                    f"request exceeds the {MAX_REQUEST_BYTES}-byte limit"
+                )
+            chunks.append(chunk)
+
+    async def _handle_posix_client(self, reader, writer) -> None:
+        request = ""
+        try:
+            request = await self._read_posix_request(reader)
+            ok, payload = await self._dispatch_boundary(request)
+            writer.write(self._reply_bytes(ok, payload))
+            await asyncio.wait_for(writer.drain(), timeout=REPLY_TIMEOUT)
+            if await self._should_stop(ok, payload):
+                self._begin_shutdown()
+        except (BrokenPipeError, ConnectionResetError, TimeoutError):
+            print(f"client vanished before reply: {request[:80]!r}", file=sys.stderr)
+        except ValueError as exc:
+            with contextlib.suppress(BrokenPipeError, ConnectionResetError, TimeoutError):
+                writer.write(self._reply_bytes(2, str(exc)))
+                await asyncio.wait_for(writer.drain(), timeout=REPLY_TIMEOUT)
+        finally:
+            writer.close()
+            with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                await writer.wait_closed()
+
+    async def _serve_windows(self) -> None:
+        slots = asyncio.Semaphore(MAX_IN_FLIGHT)
+        while not self._closing:
+            await slots.acquire()
+            try:
+                conn = await self._transport_call(self._accept)
             except OSError:
-                # Closing the listener is how this daemon is told to stop, and
-                # _accept's docstring says the raise is the mechanism. Letting it
-                # escape is the part that hurt: each serve() thread printed a
-                # traceback on the way out, and several doing that at once while
-                # the interpreter finalised aborted the process --
-                #   Fatal Python error: _enter_buffered_busy: could not acquire
-                #   lock for <_io.BufferedWriter name='<stderr>'> at interpreter
-                #   shutdown, possibly due to daemon threads
-                # -- taking whatever was still buffered with it. Seen at the end
-                # of a full test run: everything passed, exit code 134.
-                #
-                # Only when it is us doing the closing. A listener that breaks
-                # while this is supposed to be serving is a real failure.
+                slots.release()
                 if self._closing:
                     return
                 raise
             if conn is None:
-                continue  # a client that failed the auth handshake (Windows) — keep serving
-            request = ""
-            try:
-                request = self._read_request(conn)  # a client that connects then stalls
-                if request is None:                  # must not wedge the single-threaded daemon
-                    conn.close()
-                    continue
-                ok, payload = self.dispatch(request)
-            except Exception as exc:
-                # Request boundary: one bad request (malformed envelope, encoding, an
-                # unexpected dispatch bug) is reported to ITS client — it must never
-                # unwind serve() and take the shared browser down with it.
-                ok, payload = False, f"{type(exc).__name__}: {exc}"
-            try:
-                # ok is True, False, or an int error code (2/3/4) so orchestrating
-                # agents can branch on the exit code without parsing prose.
-                header = "OK" if ok is True else ("ERR" if ok is False else f"ERR {ok}")
-                self._send_reply(conn, (header + "\n" + payload).encode())
-            except (BrokenPipeError, ConnectionResetError, socket.timeout, EOFError):
-                # The client died or stalled mid-reply (bash timeout, Ctrl-C; on Windows
-                # socket.timeout IS TimeoutError, which bounded_io raises for a reader
-                # that stopped consuming). Its death must not kill the daemon — log the
-                # drop (stderr goes to ~/.co/browser.log) so "my command printed
-                # nothing" stays diagnosable. Any OTHER OSError is a daemon-side fault
-                # and propagates: a broken daemon must die and be respawned, not loop.
-                print(f"client vanished before reply: {request[:80]!r}", file=sys.stderr)
-            finally:
-                conn.close()
+                slots.release()
+                continue
+            task = asyncio.create_task(self._handle_windows_client(conn, slots))
+            self._track_client(task)
 
-            # A Playwright timeout proves the context existed, but not that it is
-            # currently safe to round-trip through. In particular, Page.goto can
-            # time out while Chromium is still trying to settle the navigation.
-            # Calling _context_is_alive() immediately submits context.cookies() to
-            # that same single browser worker and can block the daemon before it
-            # accepts the recovery command (Escape, inspect, screenshot, close).
-            # Keep the request boundary honest: return this timeout to its caller,
-            # remember that a browser did exist, and let the next command recover
-            # it. Launch failures are handled above by _launch_failed().
+    async def _transport_call(self, fn):
+        return await asyncio.get_running_loop().run_in_executor(
+            self._transport_pool, fn
+        )
+
+    async def _handle_windows_client(self, conn, slots) -> None:
+        request = ""
+        try:
+            request = await self._transport_call(lambda: self._read_request(conn))
+            if request is None:
+                return
+            if len(request.encode()) > MAX_REQUEST_BYTES:
+                ok, payload = 2, f"request exceeds the {MAX_REQUEST_BYTES}-byte limit"
+            else:
+                ok, payload = await self._dispatch_boundary(request)
+            await self._transport_call(
+                lambda: self._send_reply(conn, self._reply_bytes(ok, payload))
+            )
+            if await self._should_stop(ok, payload):
+                self._begin_shutdown()
+        except (BrokenPipeError, ConnectionResetError, TimeoutError, EOFError):
+            print(f"client vanished before reply: {request[:80]!r}", file=sys.stderr)
+        except ValueError as exc:
+            message = str(exc)
+            with contextlib.suppress(
+                BrokenPipeError, ConnectionResetError, TimeoutError, EOFError
+            ):
+                await self._transport_call(
+                    lambda: self._send_reply(conn, self._reply_bytes(2, message))
+                )
+        finally:
+            try:
+                conn.close()
+            finally:
+                slots.release()
+
+    async def _dispatch_boundary(self, request: str) -> tuple:
+        try:
+            return await self.dispatch_async(request)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return False, f"{type(exc).__name__}: {exc}"
+
+    @staticmethod
+    def _reply_bytes(ok, payload: str) -> bytes:
+        header = "OK" if ok is True else ("ERR" if ok is False else f"ERR {ok}")
+        return (header + "\n" + payload).encode()
+
+    async def _should_stop(self, ok, payload: str) -> bool:
+        """Serialize shared runtime health transitions after concurrent replies."""
+        async with self._health_lock:
             if ok is False and payload.startswith("TimeoutError:"):
                 self._had_browser = True
                 self._defer_context_probe = True
-                continue
-
-            # Recovery often takes more than one command: Escape, inspect the
-            # URL, screenshot, then query the DOM. Inserting the same synchronous
-            # context probe between any two of them recreates the deadlock. Stay
-            # in this bounded recovery window until a fresh navigation settles.
-            # Explicit closure and a closed-target error still release the socket
-            # immediately without another browser round trip.
-            if self._defer_context_probe:
-                closed = (
-                    payload == "Browser closed"
-                    or (
-                        ok is False
-                        and (
-                            payload.startswith("TargetClosedError:")
-                            or "context or browser has been closed" in payload
-                        )
-                    )
+                return False
+            closed = payload.startswith("Browser closed") or (
+                ok is False
+                and (
+                    payload.startswith("TargetClosedError:")
+                    or "context or browser has been closed" in payload
                 )
-                if self.browser._launch_failed() or closed:
-                    break
+            )
+            if self._defer_context_probe:
+                if self._launch_failed() or closed:
+                    return True
                 if ok is True and payload.startswith("Navigated to "):
                     self._defer_context_probe = False
                 else:
-                    continue
-
-            # Exit (releasing the socket) when the browser can no longer be driven, so the
-            # next command spawns a fresh daemon instead of reusing a dead one. This is a
-            # SHARED-context decision, not a per-session one: a command on a page-less tab
-            # must not be read as "browser dead" and tear down every other session's tabs.
-            alive = self.browser._context_is_alive()
+                    return False
+            if closed:
+                return True
+            if getattr(self.browser, "_closing", False):
+                # A concurrent bare close owns teardown and will stop the server
+                # after its reply. Do not race that teardown with a health probe.
+                return False
+            alive = await self._browser_is_alive()
             self._had_browser = self._had_browser or alive
-            #   - a launch that never produced a context (Chrome aborted at startup) — a
-            #     daemon that can't open a browser must not linger as a socket-holding zombie;
-            #   - a context that was alive and has since closed/crashed.
-            if self.browser._launch_failed() or (self._had_browser and not alive):
-                break
+            return self._launch_failed() or closed or (self._had_browser and not alive)
+
+    def _begin_shutdown(self) -> None:
+        self._closing = True
+        if self._srv:
+            self._srv.close()
+
+    async def _shutdown_async(self) -> None:
+        self._closing = True
+        if self._srv:
+            self._srv.close()
+            wait_closed = getattr(self._srv, "wait_closed", None)
+            if wait_closed is not None:
+                await wait_closed()
+        current = asyncio.current_task()
+        pending = [task for task in self._client_tasks if task is not current]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        self._client_tasks.clear()
+        close = getattr(self.browser, "close", None)
+        if callable(close):
+            try:
+                result = close()
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as exc:
+                print(
+                    f"browser cleanup failed: {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                )
+        if self._transport_pool is not None:
+            self._transport_pool.shutdown(wait=True, cancel_futures=True)
+            self._transport_pool = None
+        self._remove_endpoint()
 
     def _bind(self):
         """Bind the socket, yielding to any daemon that already owns it.
@@ -704,7 +981,7 @@ class BrowserDaemon:
         fresh inode while a second still holds the old one.
 
         A refused probe is ambiguous: the owner died leaving a stale socket, OR the
-        owner is alive with a full backlog (a long browser action while clients hammer it — the
+        owner is alive with a full bounded backlog (many clients arriving together — the
         exact situation that spawns us). Unlinking a BUSY daemon's socket forks the
         world: two daemons, two Chromes fighting over one profile, and the original
         becomes an unreachable zombie. The pid file the owner wrote at bind time
@@ -737,7 +1014,7 @@ class BrowserDaemon:
         self._srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._srv.bind(self.sock_path)
         Path(transport.pid_path(self.sock_path)).write_text(str(os.getpid()), encoding="utf-8")
-        self._srv.listen(8)
+        self._srv.listen(MAX_IN_FLIGHT)
 
     def _bind_windows(self):
         """Named-pipe bind. A pipe vanishes WITH its owning process, so 'no pipe' is
@@ -769,7 +1046,7 @@ class BrowserDaemon:
         """Accept one client. Windows hands back only AUTHENTICATED connections — the
         HMAC challenge runs deadline-bounded in transport.accept_authenticated (mpc's
         own accept()-time handshake blocks forever on a stalled client), and a failed
-        handshake returns None instead of killing the single-threaded loop. A dead
+        handshake returns None instead of killing the asyncio accept loop. A dead
         listener still raises out on both platforms so a dying daemon exits."""
         if transport.IS_WINDOWS:
             return transport.accept_authenticated(self._srv, self._authkey)
@@ -782,7 +1059,11 @@ class BrowserDaemon:
         text, or None when the client stalled or vanished."""
         if transport.IS_WINDOWS:
             try:
-                return transport.bounded_io(conn, conn.recv_bytes, 120).decode().strip()
+                return transport.bounded_io(
+                    conn,
+                    lambda: conn.recv_bytes(MAX_REQUEST_BYTES + 1),
+                    REQUEST_TIMEOUT,
+                ).decode().strip()
             except (TimeoutError, EOFError):
                 return None  # stalled mid-frame, or died before sending
         conn.settimeout(120)
@@ -796,42 +1077,35 @@ class BrowserDaemon:
         native send deadline, so a stalled-but-alive reader (full pipe) is bounded the
         same way — the daemon must never wedge on a client that stopped reading."""
         if transport.IS_WINDOWS:
-            transport.bounded_io(conn, lambda: conn.send_bytes(data), 120)
+            transport.bounded_io(
+                conn, lambda: conn.send_bytes(data), REPLY_TIMEOUT
+            )
         else:
             conn.sendall(data)
 
     def _cleanup(self):
-        self._closing = True   # read by serve() -- see the accept loop
-        # Wake a thread already blocked in accept(). Closing the listener raises
-        # out of accept() on macOS, which is where the abort was seen -- but not
-        # on Linux, where accept() simply keeps blocking and serve() never
-        # notices the flag. CI caught that: this file's own test failed on all
-        # four Linux jobs and passed on macOS and Windows.
-        #
-        # One throwaway connection is enough; connect_ex reports failure as a
-        # return value rather than an exception, and a failure here means the
-        # socket is already gone, which is the outcome we wanted anyway.
-        if self._srv and not transport.IS_WINDOWS and os.path.exists(self.sock_path):
-            waker = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            waker.connect_ex(self.sock_path)
-            waker.close()
-        # Stop accepting FIRST: closing/unlinking the socket before anything slow
-        # means a client connecting during shutdown fails immediately and spawns
-        # a fresh daemon, instead of reaching a daemon that will never accept its request.
+        """Thread-safe shutdown hook used by signals, tests, and ``atexit``."""
+        self._closing = True
+        if self._loop is not None and self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._begin_shutdown)
+            return
         if self._srv:
-            self._srv.close()  # on Windows, mpc.Listener.close() removes the pipe itself
-        # Only remove what is still OURS (pid file names this process): a successor
-        # daemon may already own the path — a late-exiting zombie deleting the live
-        # socket or pid file would re-arm the very bug the pid file exists to prevent.
+            self._srv.close()
+        self._remove_endpoint()
+
+    def _remove_endpoint(self) -> None:
+        """Remove only endpoint state still owned by this process."""
         pid_file = Path(transport.pid_path(self.sock_path))
-        if pid_file.exists() and pid_file.read_text(encoding="utf-8").strip() == str(os.getpid()):
+        try:
+            owner = pid_file.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            return
+        if owner == str(os.getpid()):
             if not transport.IS_WINDOWS and os.path.exists(self.sock_path):
-                os.unlink(self.sock_path)  # POSIX: remove our socket file (mpc did it on Win)
-            pid_file.unlink()
-        # No browser.close() here: by the time atexit runs, the interpreter has
-        # already shut the worker thread's executor down, so an in-process close
-        # can only raise ("cannot schedule new futures after shutdown"). Chrome
-        # exits with us anyway — the Playwright driver pipe closes on our death.
+                with contextlib.suppress(FileNotFoundError):
+                    os.unlink(self.sock_path)  # POSIX: remove our socket file (mpc did it on Win)
+            with contextlib.suppress(FileNotFoundError):
+                pid_file.unlink()
 
 
 def _ago(seconds: float) -> str:

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -807,7 +807,7 @@ class BrowserDaemon:
                 raise TimeoutError("request timed out")
             try:
                 chunk = await asyncio.wait_for(reader.read(65536), timeout=remaining)
-            except TimeoutError as exc:
+            except asyncio.TimeoutError as exc:
                 raise TimeoutError("request timed out") from exc
             if not chunk:
                 return b"".join(chunks).decode().strip()
@@ -827,10 +827,20 @@ class BrowserDaemon:
             await asyncio.wait_for(writer.drain(), timeout=REPLY_TIMEOUT)
             if await self._should_stop(ok, payload):
                 self._begin_shutdown()
-        except (BrokenPipeError, ConnectionResetError, TimeoutError):
+        except (
+            BrokenPipeError,
+            ConnectionResetError,
+            TimeoutError,
+            asyncio.TimeoutError,
+        ):
             print(f"client vanished before reply: {request[:80]!r}", file=sys.stderr)
         except ValueError as exc:
-            with contextlib.suppress(BrokenPipeError, ConnectionResetError, TimeoutError):
+            with contextlib.suppress(
+                BrokenPipeError,
+                ConnectionResetError,
+                TimeoutError,
+                asyncio.TimeoutError,
+            ):
                 writer.write(self._reply_bytes(2, str(exc)))
                 await asyncio.wait_for(writer.drain(), timeout=REPLY_TIMEOUT)
         finally:

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -230,6 +230,7 @@ class BrowserDaemon:
         # Set by _cleanup before it closes the listener, so serve() can tell "we are
         # stopping" from "the socket broke while we were meant to be serving".
         self._closing = False
+        self._shutdown_started = False
         self._had_browser = False
         self._defer_context_probe = False
         self.last_command = None  # {"line": str, "at": float} of the last real command
@@ -943,8 +944,9 @@ class BrowserDaemon:
             return self._launch_failed() or closed or (self._had_browser and not alive)
 
     def _begin_shutdown(self) -> None:
-        if self._closing:
+        if self._shutdown_started:
             return
+        self._shutdown_started = True
         self._closing = True
         if (
             transport.IS_WINDOWS

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -851,6 +851,14 @@ class BrowserDaemon:
             if conn is None:
                 slots.release()
                 continue
+            # Listener.close() does not interrupt an already-blocked Windows
+            # named-pipe accept. Shutdown authenticates one internal connection
+            # to wake it; discard that sentinel instead of starting a request
+            # reader that would keep the transport pool alive for 120 seconds.
+            if self._closing:
+                conn.close()
+                slots.release()
+                return
             task = asyncio.create_task(self._handle_windows_client(conn, slots))
             self._track_client(task)
 
@@ -935,9 +943,38 @@ class BrowserDaemon:
             return self._launch_failed() or closed or (self._had_browser and not alive)
 
     def _begin_shutdown(self) -> None:
+        if self._closing:
+            return
         self._closing = True
-        if self._srv:
+        if (
+            transport.IS_WINDOWS
+            and self._srv
+            and self._loop is not None
+            and self._transport_pool is not None
+        ):
+            # multiprocessing.connection.Listener.close() does not wake a
+            # ConnectNamedPipe already blocked in another thread. Connect with
+            # our own key before closing the listener; _serve_windows discards
+            # this sentinel and can then enter deterministic shutdown.
+            self._loop.run_in_executor(
+                self._transport_pool, self._wake_windows_accept
+            )
+        elif self._srv:
             self._srv.close()
+
+    def _wake_windows_accept(self) -> None:
+        """Authenticate one no-payload client so a blocked pipe accept returns."""
+        try:
+            conn = transport.win_connect(self.sock_path, self._authkey)
+        except (
+            transport.AuthenticationError,
+            EOFError,
+            FileNotFoundError,
+            ConnectionError,
+            OSError,
+        ):
+            return
+        conn.close()
 
     async def _shutdown_async(self) -> None:
         self._closing = True

--- a/connectonion/cli/browser_agent/transport.py
+++ b/connectonion/cli/browser_agent/transport.py
@@ -2,22 +2,22 @@ r"""
 Purpose: Cross-platform IPC primitives for the browser daemon/client so `co browser` runs natively on Windows (named pipes) as well as macOS/Linux (Unix sockets) — no WSL.
 LLM-Note:
   Dependencies: imports from [os, time, getpass, subprocess, tempfile, hashlib, binascii, threading, multiprocessing.connection, pathlib | lazy: fcntl/msvcrt, ctypes] | imported by [browser_agent/daemon.py, browser_agent/client.py] | tested by [tests/unit/test_transport.py, tests/e2e/cli/test_browser_daemon.py]
-  Data flow: daemon/client call default_address() → POSIX returns a Unix-socket filesystem path (unchanged from before), Windows returns a per-user named pipe \\.\pipe\co-browser-<hash> | pid_path()/lock_path() resolve real filesystem sidecars (POSIX: <addr>.pid/.lock exactly as before; Windows: hashed files under %LOCALAPPDATA%/co since a pipe name is not a path) | Windows wire: win_listener() creates the pipe WITHOUT an authkey and the daemon runs the mutual HMAC challenge itself via accept_authenticated() under a hard deadline (mpc's own accept()-time handshake blocks forever on a stalled client — a wedged single-threaded daemon); win_connect() is a normal authenticated mpc.Client | POSIX keeps its raw AF_UNIX socket in daemon.py/client.py untouched
+  Data flow: daemon/client call default_address() → POSIX returns a Unix-socket filesystem path, Windows returns a per-user named pipe \\.\pipe\co-browser-<hash> | pid_path()/lock_path() resolve filesystem sidecars | Windows wire: win_listener() creates the pipe WITHOUT an authkey and accept_authenticated() runs the mutual HMAC challenge under a hard deadline before the daemon submits the connection to its asyncio runtime; win_connect() is a normal authenticated mpc.Client | POSIX binding is handed to asyncio.start_unix_server after the same stale-owner checks
   State/Effects: default_address()/_sidecar_dir() may mkdir the runtime dir (and chmod 0700 on POSIX — the socket dir IS the POSIX trust boundary, so a chmod failure raises loudly) | load_or_create_authkey() creates a 0600 key file in the sidecar dir (only used on Windows) and atomically replaces a persistently-corrupt one | acquire_singleton_lock() holds an OS lock (fcntl.flock POSIX / msvcrt.locking Windows) for the daemon's lifetime, released by the OS on death | spawn_detached() launches the daemon fully detached
-  Integration: exposes IS_WINDOWS, AuthenticationError (= mpc's class), HANDSHAKE_TIMEOUT, default_address(), pid_path(), lock_path(), load_or_create_authkey(), pid_alive(), acquire_singleton_lock(), spawn_detached(), win_listener(), win_connect(), bounded_io(), accept_authenticated() | POSIX behavior is intentionally identical to the pre-existing raw-socket code so existing tests pass unchanged; only the Windows branch is new
+  Integration: exposes IS_WINDOWS, AuthenticationError (= mpc's class), HANDSHAKE_TIMEOUT, default_address(), pid_path(), lock_path(), load_or_create_authkey(), pid_alive(), acquire_singleton_lock(), spawn_detached(), win_listener(), win_connect(), bounded_io(), accept_authenticated() | daemon.py owns asyncio admission/backpressure; this module preserves native platform security and blocking-pipe primitives
   Performance: all helpers are cheap local ops | authkey is a 64-byte file read | bounded_io adds one short-lived thread per bounded pipe operation (handshake/read/reply — never touches Playwright)
   Errors: acquire_singleton_lock returns None when the lock is held (caller exits 0) | pid_alive treats EPERM/access-denied as ALIVE (the pid exists — same lesson as browser.py's _pid_alive) | load_or_create_authkey converges on ONE key under the O_EXCL create race, atomically replaces a file that stays invalid past the writers' microsecond window, and RAISES if no valid key can be produced — it never falls back to a fixed key, which would silently disable authentication | bounded_io raises TimeoutError on deadline (after closing the connection so the helper unblocks) and re-raises the operation's own exception otherwise | accept_authenticated returns None on a bad key, a stalled handshake, or a vanished client (the daemon keeps serving); a closed listener still raises out of accept() so a dying daemon exits instead of spinning
 """
 
-import os
-import time
+import binascii
 import getpass
+import hashlib
+import multiprocessing.connection as mpc
+import os
 import subprocess
 import tempfile
-import hashlib
-import binascii
 import threading
-import multiprocessing.connection as mpc
+import time
 from pathlib import Path
 
 IS_WINDOWS = os.name == "nt"
@@ -271,7 +271,7 @@ def bounded_io(conn, fn, timeout: float):
 
     mpc named-pipe Connections have no native timeouts anywhere — not in the accept
     handshake, not mid-frame in recv_bytes, not in send_bytes against a full pipe with
-    a stalled reader. Any of those would wedge the single-threaded daemon forever
+    a stalled reader. Any of those would exhaust a transport worker indefinitely
     (POSIX gets all of this from one settimeout(120)). The operation runs in a
     short-lived helper thread joined against the deadline; on timeout the connection
     is closed (which errors the helper's blocked syscall, so the thread exits) and
@@ -301,7 +301,7 @@ def accept_authenticated(listener, authkey: bytes, timeout: float = HANDSHAKE_TI
 
     mpc's `Listener(authkey=...)` runs the challenge INSIDE accept() with blocking
     recvs — a client that connects and then stalls mid-handshake would wedge the
-    single-threaded daemon forever, and the request read timeout starts too late to
+    transport worker forever, and the request read timeout starts too late to
     help. So win_listener() creates the pipe without an authkey and the challenge
     runs here, deadline-bounded. A closed/broken listener still raises out of
     accept() — a dying daemon must exit its serve loop, not spin on a dead endpoint.

--- a/connectonion/cli/commands/remote_browser_commands.py
+++ b/connectonion/cli/commands/remote_browser_commands.py
@@ -1,0 +1,149 @@
+"""CLI for typed, owner-bound Remote Browser lifecycle commands."""
+
+import json
+import sys
+
+USAGE = """co remote-browser — manage a browser session on a remote agent.
+
+  co remote-browser [options] <address> start
+  co remote-browser [options] <address> sessions
+  co remote-browser [options] <address> status <session-id>
+  co remote-browser [options] <address> stop <session-id>
+  co remote-browser [options] <address> diagnose <session-id>
+
+Options:
+  --json           emit the complete stable JSON envelope
+  --timeout SEC    seconds to wait (default 60)
+  --relay URL      relay backend used for discovery/fallback
+  --headless       start headless (default)
+  --headed         start with a visible browser
+  --proxy MODE     start proxy mode; 1.8 accepts only direct
+"""
+
+
+def _parse(args):
+    options = {
+        "json_output": False,
+        "timeout": 60.0,
+        "relay_url": None,
+        "headless": True,
+        "proxy": "direct",
+    }
+    positional = []
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token == "--json":
+            options["json_output"] = True
+        elif token == "--headless":
+            options["headless"] = True
+        elif token == "--headed":
+            options["headless"] = False
+        elif token in ("--timeout", "--relay", "--proxy"):
+            if index + 1 >= len(args):
+                raise ValueError(f"{token} needs a value")
+            value = args[index + 1]
+            index += 1
+            if token == "--timeout":
+                try:
+                    options["timeout"] = float(value)
+                except ValueError as exc:
+                    raise ValueError("--timeout needs a number") from exc
+                if options["timeout"] <= 0:
+                    raise ValueError("--timeout must be positive")
+            elif token == "--relay":
+                options["relay_url"] = value
+            else:
+                options["proxy"] = value
+        elif token.startswith("-"):
+            raise ValueError(f"unknown option '{token}'")
+        else:
+            positional.append(token)
+        index += 1
+    return positional, options
+
+
+def _print_human(result):
+    if not result.get("ok"):
+        code = result.get("code", "REMOTE_BROWSER_FAILED")
+        message = result.get("message", "Remote Browser request failed.")
+        print(f"{code}: {message}", file=sys.stderr)
+        return
+    print(result.get("summary", "Remote Browser request completed."))
+    payload = result.get("result") or {}
+    if "session_id" in payload:
+        print(payload["session_id"])
+    for session in payload.get("sessions", []):
+        print(f"{session['session_id']}\t{session['status']}")
+
+
+def handle_remote_browser(args) -> int:
+    args = list(args or [])
+    if not args:
+        print(USAGE, file=sys.stderr)
+        return 2
+    if args[0] in ("help", "--help", "-h"):
+        print(USAGE)
+        return 0
+    try:
+        positional, options = _parse(args)
+    except ValueError as exc:
+        print(f"usage: {exc}", file=sys.stderr)
+        return 2
+
+    if len(positional) < 2:
+        print("usage: co remote-browser <address> <command>", file=sys.stderr)
+        return 2
+    address, command, *rest = positional
+    if command not in {"start", "status", "sessions", "stop", "diagnose"}:
+        print(f"usage: unknown Remote Browser command '{command}'", file=sys.stderr)
+        return 2
+    needs_session = command in {"status", "stop", "diagnose"}
+    if len(rest) != (1 if needs_session else 0):
+        suffix = " <session-id>" if needs_session else ""
+        print(
+            f"usage: co remote-browser <address> {command}{suffix}",
+            file=sys.stderr,
+        )
+        return 2
+
+    from connectonion import connect
+    from connectonion.network.connect import _this_callers_identity
+
+    connect_kwargs = {"keys": _this_callers_identity()}
+    if options["relay_url"]:
+        connect_kwargs["relay_url"] = options["relay_url"]
+    command_args = {}
+    if command == "start":
+        command_args = {
+            "headless": options["headless"],
+            "proxy": options["proxy"],
+        }
+    try:
+        result = connect(address, **connect_kwargs).remote_browser(
+            command,
+            session_id=rest[0] if rest else None,
+            timeout=options["timeout"],
+            **command_args,
+        )
+    except Exception as exc:
+        result = {
+            "schema_version": "1",
+            "ok": False,
+            "command": f"remote-browser.{command}",
+            "request_id": "",
+            "code": "CONNECTION_FAILED",
+            "message": str(exc),
+            "retryable": True,
+            "retry_after_seconds": None,
+            "state": {},
+            "tips": [],
+            "warnings": [],
+            "next_actions": [],
+        }
+
+    if options["json_output"]:
+        print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    else:
+        _print_human(result)
+    return 0 if result.get("ok") else 1

--- a/connectonion/cli/commands/remote_browser_commands.py
+++ b/connectonion/cli/commands/remote_browser_commands.py
@@ -77,8 +77,38 @@ def _print_human(result):
         print(f"{session['session_id']}\t{session['status']}")
 
 
+def _invalid_argument(message):
+    return {
+        "schema_version": "1",
+        "ok": False,
+        "command": "remote-browser",
+        "request_id": "",
+        "code": "INVALID_ARGUMENT",
+        "message": message,
+        "retryable": False,
+        "retry_after_seconds": None,
+        "state": {},
+        "tips": [],
+        "warnings": [],
+        "next_actions": [],
+    }
+
+
+def _print_invalid_argument(message, *, json_output):
+    if json_output:
+        print(
+            json.dumps(
+                _invalid_argument(message), sort_keys=True, separators=(",", ":")
+            )
+        )
+    else:
+        print(f"usage: {message}", file=sys.stderr)
+    return 2
+
+
 def handle_remote_browser(args) -> int:
     args = list(args or [])
+    json_requested = "--json" in args
     if not args:
         print(USAGE, file=sys.stderr)
         return 2
@@ -88,24 +118,26 @@ def handle_remote_browser(args) -> int:
     try:
         positional, options = _parse(args)
     except ValueError as exc:
-        print(f"usage: {exc}", file=sys.stderr)
-        return 2
+        return _print_invalid_argument(str(exc), json_output=json_requested)
 
     if len(positional) < 2:
-        print("usage: co remote-browser <address> <command>", file=sys.stderr)
-        return 2
+        return _print_invalid_argument(
+            "co remote-browser <address> <command>",
+            json_output=options["json_output"],
+        )
     address, command, *rest = positional
     if command not in {"start", "status", "sessions", "stop", "diagnose"}:
-        print(f"usage: unknown Remote Browser command '{command}'", file=sys.stderr)
-        return 2
+        return _print_invalid_argument(
+            f"unknown Remote Browser command '{command}'",
+            json_output=options["json_output"],
+        )
     needs_session = command in {"status", "stop", "diagnose"}
     if len(rest) != (1 if needs_session else 0):
         suffix = " <session-id>" if needs_session else ""
-        print(
-            f"usage: co remote-browser <address> {command}{suffix}",
-            file=sys.stderr,
+        return _print_invalid_argument(
+            f"co remote-browser <address> {command}{suffix}",
+            json_output=options["json_output"],
         )
-        return 2
 
     from connectonion import connect
     from connectonion.network.connect import _this_callers_identity

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -322,6 +322,21 @@ def browser(
     raise typer.Exit(handle_browser(args or [], headless=headless))
 
 
+@app.command(
+    "remote-browser",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def remote_browser(
+    args: List[str] = typer.Argument(
+        None, help="[options] <address> <start|status|sessions|stop|diagnose>"
+    ),
+):
+    """Manage an owner-bound browser session on a remote agent over OIP."""
+    from .commands.remote_browser_commands import handle_remote_browser
+
+    raise typer.Exit(handle_remote_browser(args or []))
+
+
 @app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 def call(
     args: List[str] = typer.Argument(None, help="[--out F] [--timeout S] [--relay U] <address> <command...>"),

--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -509,46 +509,9 @@ class RemoteAgent:
         try:
             async with connection as ws:
                 await ws.send(json.dumps(connect_msg))
-
-                # Wait for CONNECTED (EXEC needs the same auth gate as INPUT).
-                while True:
-                    raw = await asyncio.wait_for(ws.recv(), timeout=30)
-                    event = json.loads(raw)
-                    etype = event.get("type")
-                    if etype == "CONNECTED":
-                        break
-                    if etype == "ONBOARD_REQUIRED":
-                        # The same exchange input() does, on the same socket: submit
-                        # credentials and keep waiting. The host finishes the CONNECT
-                        # its trust gate interrupted (ws_router/session.py pops the
-                        # stashed pending_connect and calls establish_connection), so
-                        # CONNECTED arrives on this loop and the EXEC goes out below.
-                        #
-                        # This used to answer "run input() once to onboard" — the
-                        # Python API, which is no help to whoever typed `co call`.
-                        methods = event.get("methods", [])
-                        if not sys.stdin.isatty():
-                            # A script has no stdin to answer with, and prompting
-                            # would hang it. Fail, but say what the agent asked for.
-                            return ExecResult(
-                                text="", status="error",
-                                error=f"agent requires onboarding ({', '.join(methods) or 'no methods offered'})"
-                                      " — run this from a terminal to enter an invite code")
-                        try:
-                            credentials = self._prompt_onboard(methods, event.get("payment_amount"))
-                        except ValueError as declined:
-                            # Entering nothing is an answer, and a normal one.
-                            # _prompt_onboard raises for it, and every other refusal
-                            # call() can meet — a blacklist, a bad code, a tool that
-                            # is not whitelisted — comes back as an ExecResult. This
-                            # is that same channel, not a swallowed error.
-                            return ExecResult(text="", status="error",
-                                              error=f"onboarding not completed: {declined}")
-                        await ws.send(json.dumps(self._build_onboard_submit(credentials)))
-                        continue
-                    if etype == "ERROR":
-                        return ExecResult(text="", status="error",
-                                          error=event.get("message", "connect failed"))
+                connect_error = await self._wait_for_direct_command_connected(ws)
+                if connect_error:
+                    return ExecResult(text="", status="error", error=connect_error)
 
                 await ws.send(json.dumps(exec_msg))
 
@@ -571,6 +534,154 @@ class RemoteAgent:
                                           error=event.get("message", "exec failed"))
         except asyncio.TimeoutError:
             return ExecResult(text="", status="error", error=f"exec timed out after {timeout}s")
+
+    def remote_browser(
+        self,
+        command: str,
+        *,
+        session_id: str | None = None,
+        timeout: float = 60.0,
+        **args,
+    ) -> Dict[str, Any]:
+        """Run one typed, owner-bound Remote Browser lifecycle command."""
+        try:
+            asyncio.get_running_loop()
+            raise RuntimeError(
+                "remote_browser() cannot be used inside async context. "
+                "Use 'await agent.remote_browser_async()' instead."
+            )
+        except RuntimeError as exc:
+            if "remote_browser() cannot be used" in str(exc):
+                raise
+        return asyncio.run(
+            self.remote_browser_async(
+                command,
+                session_id=session_id,
+                timeout=timeout,
+                **args,
+            )
+        )
+
+    async def remote_browser_async(
+        self,
+        command: str,
+        *,
+        session_id: str | None = None,
+        timeout: float = 60.0,
+        **args,
+    ) -> Dict[str, Any]:
+        """Async Remote Browser lifecycle request over authenticated OIP."""
+        import websockets
+
+        await self._try_resolve_endpoint()
+        request_id = str(uuid.uuid4())
+        request = {
+            "type": "REMOTE_BROWSER",
+            "request_id": request_id,
+            "command": command,
+            "args": args,
+        }
+        if session_id is not None:
+            request["session_id"] = session_id
+
+        try:
+            connection, is_direct = await self._open_best_connection(websockets)
+            async with connection as ws:
+                await ws.send(json.dumps(self._build_connect_message(is_direct)))
+                connect_error = await self._wait_for_direct_command_connected(ws)
+                if connect_error:
+                    return self._remote_browser_client_error(
+                        request_id, command, "CONNECTION_FAILED", connect_error
+                    )
+                await ws.send(json.dumps(
+                    self._build_command_message(request, is_direct)
+                ))
+                while True:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
+                    event = json.loads(raw)
+                    event_type = event.get("type")
+                    if (
+                        event_type == "REMOTE_BROWSER_RESULT"
+                        and event.get("request_id") == request_id
+                    ):
+                        event.pop("type", None)
+                        return event
+                    if event_type == "PING":
+                        await ws.send(json.dumps({"type": "PONG"}))
+                    elif event_type == "ERROR":
+                        return self._remote_browser_client_error(
+                            request_id,
+                            command,
+                            "CONNECTION_FAILED",
+                            event.get("message", "remote browser request failed"),
+                        )
+        except asyncio.TimeoutError:
+            return self._remote_browser_client_error(
+                request_id,
+                command,
+                "TIMEOUT",
+                f"remote browser request timed out after {timeout}s",
+                retryable=True,
+            )
+        except OSError as exc:
+            return self._remote_browser_client_error(
+                request_id,
+                command,
+                "CONNECTION_FAILED",
+                str(exc),
+                retryable=True,
+            )
+
+    async def _wait_for_direct_command_connected(self, ws) -> str | None:
+        """Complete CONNECT/onboarding for non-LLM command APIs."""
+        while True:
+            raw = await asyncio.wait_for(ws.recv(), timeout=30)
+            event = json.loads(raw)
+            event_type = event.get("type")
+            if event_type == "CONNECTED":
+                return None
+            if event_type == "ONBOARD_REQUIRED":
+                methods = event.get("methods", [])
+                if not sys.stdin.isatty():
+                    offered = ", ".join(methods) or "no methods offered"
+                    return (
+                        f"agent requires onboarding ({offered}) — run this from "
+                        "a terminal to enter an invite code"
+                    )
+                try:
+                    credentials = self._prompt_onboard(
+                        methods, event.get("payment_amount")
+                    )
+                except ValueError as declined:
+                    return f"onboarding not completed: {declined}"
+                await ws.send(json.dumps(self._build_onboard_submit(credentials)))
+                continue
+            if event_type == "ERROR":
+                return event.get("message", "connect failed")
+
+    @staticmethod
+    def _remote_browser_client_error(
+        request_id: str,
+        command: str,
+        code: str,
+        message: str,
+        *,
+        retryable: bool = False,
+    ) -> Dict[str, Any]:
+        return {
+            "schema_version": "1",
+            "ok": False,
+            "command": f"remote-browser.{command}",
+            "request_id": request_id,
+            "code": code,
+            "message": message,
+            "retryable": retryable,
+            "retry_after_seconds": None,
+            "state": {},
+            "tips": [],
+            "warnings": [],
+            "next_actions": [],
+        }
 
     def reset(self) -> None:
         """Clear conversation and start fresh."""

--- a/connectonion/network/host/remote_browser.py
+++ b/connectonion/network/host/remote_browser.py
@@ -1,0 +1,365 @@
+"""Owner-bound Remote Browser lifecycle over the existing browser daemon.
+
+This module owns no browser driver. It records OIP session authority and maps
+each session to one named tab in the already-shared daemon. Navigation is
+deliberately absent until the public-destination policy can cover redirects and
+subresources as well as the first URL.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import tempfile
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Callable
+
+SCHEMA_VERSION = "1"
+REQUEST_ID = re.compile(r"[\x21-\x7e]{1,128}")
+SESSION_ID = re.compile(r"rb_[0-9a-f]{32}")
+COMMANDS = frozenset({"start", "status", "sessions", "stop", "diagnose"})
+
+
+def _success(request_id: str, command: str, *, result=None, state=None) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": True,
+        "command": f"remote-browser.{command}",
+        "request_id": request_id,
+        "summary": {
+            "start": "Remote browser session started.",
+            "status": "Remote browser session status loaded.",
+            "sessions": "Remote browser sessions loaded.",
+            "stop": "Remote browser session stopped.",
+            "diagnose": "Remote browser diagnosis completed.",
+        }[command],
+        "result": result or {},
+        "state": state or {},
+        "tips": [],
+        "warnings": [],
+        "next_actions": [],
+    }
+
+
+def _failure(
+    request_id: str,
+    command: str,
+    code: str,
+    message: str,
+    *,
+    retryable: bool = False,
+    state=None,
+    next_actions=None,
+) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": False,
+        "command": f"remote-browser.{command}" if command else "remote-browser",
+        "request_id": request_id,
+        "code": code,
+        "message": message,
+        "retryable": retryable,
+        "retry_after_seconds": None,
+        "state": state or {},
+        "tips": [],
+        "warnings": [],
+        "next_actions": next_actions or [],
+    }
+
+
+class RemoteBrowserService:
+    """Persistent authority registry delegating lifecycle to BrowserDaemon."""
+
+    def __init__(
+        self,
+        state_path: Path,
+        daemon_request: Callable | None = None,
+        clock: Callable[[], float] = time.time,
+    ):
+        self.state_path = Path(state_path)
+        self.clock = clock
+        self._lock = threading.RLock()
+        if daemon_request is None:
+            from ...cli.browser_agent.client import request_as
+
+            daemon_request = request_as
+        self.daemon_request = daemon_request
+
+    def _load(self) -> dict:
+        if not self.state_path.exists():
+            return {"version": 1, "sessions": {}}
+        try:
+            value = json.loads(self.state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError("remote browser session registry is unreadable") from exc
+        if value.get("version") != 1 or not isinstance(value.get("sessions"), dict):
+            raise RuntimeError("remote browser session registry has an unknown format")
+        return value
+
+    def _save(self, value: dict) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temporary = tempfile.mkstemp(
+            prefix=f".{self.state_path.name}.", dir=self.state_path.parent
+        )
+        path = Path(temporary)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(value, handle, sort_keys=True, separators=(",", ":"))
+                handle.flush()
+                os.fsync(handle.fileno())
+            path.chmod(0o600)
+            path.replace(self.state_path)
+        finally:
+            path.unlink(missing_ok=True)
+
+    @staticmethod
+    def _public(session: dict) -> dict:
+        return {
+            key: session[key]
+            for key in (
+                "session_id",
+                "status",
+                "proxy_mode",
+                "created_at",
+                "updated_at",
+            )
+        }
+
+    def _owned(self, state: dict, session_id: str, owner: str) -> dict | None:
+        session = state["sessions"].get(session_id)
+        return session if session and session.get("owner") == owner else None
+
+    def handle(self, request: dict, *, owner: str, transport: str) -> dict:
+        request_id = request.get("request_id")
+        command = request.get("command")
+        if not isinstance(request_id, str) or not REQUEST_ID.fullmatch(request_id):
+            return _failure(
+                "",
+                str(command or ""),
+                "INVALID_ARGUMENT",
+                "request_id must be 1-128 visible ASCII characters.",
+            )
+        if command not in COMMANDS:
+            return _failure(
+                request_id,
+                str(command or ""),
+                "INVALID_ARGUMENT",
+                "Unknown Remote Browser command.",
+            )
+        if not owner:
+            return _failure(
+                request_id,
+                command,
+                "AUTH_REQUIRED",
+                "Remote Browser requires an authenticated caller.",
+            )
+        if transport != "direct":
+            return _failure(
+                request_id,
+                command,
+                "SECURE_CHANNEL_UNAVAILABLE",
+                "Relay Remote Browser control is unavailable until the reviewed OIP secure channel is negotiated.",
+                state={"fallback_applied": False},
+                next_actions=[
+                    {
+                        "id": "use_direct_endpoint",
+                        "command": "co remote-browser <address> status",
+                        "requires_user_approval": False,
+                    }
+                ],
+            )
+        try:
+            if command == "start":
+                return self._start(request_id, request.get("args") or {}, owner)
+            if command == "sessions":
+                return self._sessions(request_id, owner)
+            session_id = request.get("session_id")
+            if not isinstance(session_id, str) or not SESSION_ID.fullmatch(session_id):
+                return _failure(
+                    request_id,
+                    command,
+                    "INVALID_ARGUMENT",
+                    "A canonical rb_ session_id is required.",
+                )
+            if command == "status":
+                return self._status(request_id, session_id, owner)
+            if command == "stop":
+                return self._stop(request_id, session_id, owner)
+            return self._diagnose(request_id, session_id, owner)
+        except (OSError, RuntimeError) as exc:
+            return _failure(
+                request_id,
+                command,
+                "REMOTE_BROWSER_UNAVAILABLE",
+                str(exc),
+                retryable=True,
+                state={"fallback_applied": False},
+            )
+
+    def _start(self, request_id: str, args: dict, owner: str) -> dict:
+        if not isinstance(args, dict):
+            return _failure(
+                request_id, "start", "INVALID_ARGUMENT", "args must be an object."
+            )
+        proxy_mode = args.get("proxy", "direct")
+        if proxy_mode != "direct":
+            return _failure(
+                request_id,
+                "start",
+                "REMOTE_SESSION_PROXY_LOCKED",
+                "This review boundary supports only a direct, session-pinned egress.",
+                state={"fallback_applied": False},
+            )
+        headless = args.get("headless", True)
+        if not isinstance(headless, bool):
+            return _failure(
+                request_id, "start", "INVALID_ARGUMENT", "headless must be boolean."
+            )
+        with self._lock:
+            state = self._load()
+            for session in state["sessions"].values():
+                if (
+                    session.get("owner") == owner
+                    and session.get("start_request_id") == request_id
+                ):
+                    return _success(
+                        request_id,
+                        "start",
+                        result=self._public(session),
+                        state={"session": session["status"], "fallback_applied": False},
+                    )
+            session_id = f"rb_{uuid.uuid4().hex}"
+            tab = f"remote-{session_id[3:19]}"
+            line = shlex.join(
+                ["tab", "open", tab, "--who", owner, "--for", "remote-browser"]
+            )
+            code, payload = self.daemon_request(
+                line, caller=owner, account=owner, headless=headless
+            )
+            if code:
+                raise RuntimeError(payload or "browser daemon rejected session start")
+            if payload.strip() != tab:
+                raise RuntimeError("browser daemon returned an unexpected tab identity")
+            now = int(self.clock())
+            session = {
+                "session_id": session_id,
+                "owner": owner,
+                "tab": tab,
+                "status": "active",
+                "proxy_mode": "direct",
+                "headless": headless,
+                "start_request_id": request_id,
+                "created_at": now,
+                "updated_at": now,
+            }
+            state["sessions"][session_id] = session
+            try:
+                self._save(state)
+            except OSError:
+                # Opening the daemon tab precedes the durable commit. If that
+                # commit fails, release the unowned tab before reporting failure
+                # so a retry cannot accumulate invisible browser sessions.
+                try:
+                    self.daemon_request(
+                        shlex.join(["tab", "close", tab]),
+                        caller=owner,
+                        account=owner,
+                        headless=headless,
+                    )
+                except Exception:
+                    pass
+                raise
+        return _success(
+            request_id,
+            "start",
+            result=self._public(session),
+            state={"session": "active", "fallback_applied": False},
+        )
+
+    def _sessions(self, request_id: str, owner: str) -> dict:
+        with self._lock:
+            state = self._load()
+            sessions = [
+                self._public(session)
+                for session in state["sessions"].values()
+                if session.get("owner") == owner
+            ]
+        sessions.sort(key=lambda item: (item["created_at"], item["session_id"]))
+        return _success(request_id, "sessions", result={"sessions": sessions})
+
+    def _status(self, request_id: str, session_id: str, owner: str) -> dict:
+        with self._lock:
+            session = self._owned(self._load(), session_id, owner)
+            if session is None:
+                return _failure(
+                    request_id,
+                    "status",
+                    "REMOTE_SESSION_NOT_FOUND",
+                    "Remote browser session was not found.",
+                )
+            public = self._public(session)
+        return _success(
+            request_id,
+            "status",
+            result=public,
+            state={"session": session["status"], "fallback_applied": False},
+        )
+
+    def _stop(self, request_id: str, session_id: str, owner: str) -> dict:
+        with self._lock:
+            state = self._load()
+            session = self._owned(state, session_id, owner)
+            if session is None:
+                return _failure(
+                    request_id,
+                    "stop",
+                    "REMOTE_SESSION_NOT_FOUND",
+                    "Remote browser session was not found.",
+                )
+            if session["status"] != "stopped":
+                code, payload = self.daemon_request(
+                    shlex.join(["tab", "close", session["tab"]]),
+                    caller=owner,
+                    account=owner,
+                    headless=session["headless"],
+                )
+                if code not in (0, 3):
+                    raise RuntimeError(
+                        payload or "browser daemon rejected session stop"
+                    )
+                session["status"] = "stopped"
+                session["updated_at"] = int(self.clock())
+                self._save(state)
+            public = self._public(session)
+        return _success(
+            request_id,
+            "stop",
+            result=public,
+            state={"session": "stopped", "fallback_applied": False},
+        )
+
+    def _diagnose(self, request_id: str, session_id: str, owner: str) -> dict:
+        status = self._status(request_id, session_id, owner)
+        if not status["ok"]:
+            return status
+        status["command"] = "remote-browser.diagnose"
+        status["summary"] = "Remote browser diagnosis completed."
+        status["result"] = {
+            **status["result"],
+            "checks": {
+                "authenticated_owner": "ok",
+                "session_registry": "ok",
+                "transport": "direct",
+                "proxy_mode": "direct",
+                "navigation_policy": "not_enabled",
+            },
+        }
+        status["warnings"] = [
+            "Remote navigation remains disabled until the public-destination policy is enforced."
+        ]
+        return status

--- a/connectonion/network/host/remote_browser.py
+++ b/connectonion/network/host/remote_browser.py
@@ -175,7 +175,7 @@ class RemoteBrowserService:
             )
         try:
             if command == "start":
-                return self._start(request_id, request.get("args") or {}, owner)
+                return self._start(request_id, request.get("args", {}), owner)
             if command == "sessions":
                 return self._sessions(request_id, owner)
             session_id = request.get("session_id")

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -68,6 +68,7 @@ from .http_router import (
     admin_admins_remove_handler,
 )
 from .provider_workroom import prepare_provider_workroom_turn
+from .remote_browser import RemoteBrowserService
 
 
 EXEC_REQUIRES = ("admin", "whitelist", "contact")
@@ -109,6 +110,71 @@ def _make_ws_exec(create_agent, exec_permissions, trust_agent):
         return exec_handler(create_agent, exec_permissions, tool_name, args)
 
     return handle_ws_exec
+
+
+def _make_remote_browser(remote_browser_service, trust_agent):
+    """Bind Remote Browser to authenticated contact-or-admin authority."""
+    def handle_remote_browser(request, requester_address=None, transport="unknown"):
+        if not requester_address:
+            return {
+                "schema_version": "1",
+                "ok": False,
+                "command": "remote-browser",
+                "request_id": request.get("request_id", ""),
+                "code": "AUTH_REQUIRED",
+                "message": "Remote Browser requires an authenticated caller.",
+                "retryable": False,
+                "retry_after_seconds": None,
+                "state": {},
+                "tips": [],
+                "warnings": [],
+                "next_actions": [],
+            }
+        level = (
+            "admin"
+            if trust_agent.is_admin(requester_address)
+            else trust_agent.get_level(requester_address)
+        )
+        if level not in EXEC_REQUIRES:
+            return {
+                "schema_version": "1",
+                "ok": False,
+                "command": "remote-browser",
+                "request_id": request.get("request_id", ""),
+                "code": "FORBIDDEN",
+                "message": (
+                    "Remote Browser requires a contact or admin; "
+                    f"the authenticated caller is {level}."
+                ),
+                "retryable": False,
+                "retry_after_seconds": None,
+                "state": {},
+                "tips": [],
+                "warnings": [],
+                "next_actions": [],
+            }
+        if remote_browser_service is None:
+            return {
+                "schema_version": "1",
+                "ok": False,
+                "command": "remote-browser",
+                "request_id": request.get("request_id", ""),
+                "code": "REMOTE_BROWSER_UNAVAILABLE",
+                "message": "Remote Browser is not configured on this host.",
+                "retryable": False,
+                "retry_after_seconds": None,
+                "state": {},
+                "tips": [],
+                "warnings": [],
+                "next_actions": [],
+            }
+        return remote_browser_service.handle(
+            request,
+            owner=requester_address,
+            transport=transport,
+        )
+
+    return handle_remote_browser
 
 
 def _parse_trust_config(trust: Union[str, "Agent"]) -> dict | None:
@@ -227,6 +293,7 @@ def _create_route_handlers(
     exec_permissions: dict | None = None,
     replay_check=None,
     mode_policy: HostPermissionPolicy | None = None,
+    remote_browser_service=None,
 ):
     """Create route handler dict for ASGI app.
 
@@ -287,6 +354,7 @@ def _create_route_handlers(
                              is_admin=bool(requester and requester["level"] == "admin"))
 
     handle_ws_exec = _make_ws_exec(create_agent, exec_permissions, trust_agent)
+    handle_remote_browser = _make_remote_browser(remote_browser_service, trust_agent)
 
     def handle_prepare_provider_workroom_turn(
         storage,
@@ -331,6 +399,7 @@ def _create_route_handlers(
         "replay": replay_check,
         "ws_input": handle_ws_input,
         "ws_exec": handle_ws_exec,
+        "remote_browser": handle_remote_browser,
         "prepare_provider_workroom_turn": handle_prepare_provider_workroom_turn,
         "admin_logs": handle_admin_logs,
         "admin_sessions": admin_sessions_handler,
@@ -1046,10 +1115,14 @@ def host(
     exec_permissions = load_permission_patterns(co_dir)
 
     replay_store = SignatureReplayStore(co_dir / "replay.sqlite3")
+    remote_browser_service = RemoteBrowserService(
+        co_dir / "remote-browser-sessions.json"
+    )
     route_handlers = _create_route_handlers(
         create_agent, agent_metadata, result_ttl, trust_agent, config,
         exec_permissions, replay_store.already_used,
         mode_policy=_host_mode_policy(sample),
+        remote_browser_service=remote_browser_service,
     )
 
     # Parse trust config for /info onboard info
@@ -1183,11 +1256,15 @@ def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl
 
     from ...useful_plugins.tool_approval.approval import load_permission_patterns
     replay_store = SignatureReplayStore(replay_dir / "replay.sqlite3")
+    remote_browser_service = RemoteBrowserService(
+        replay_dir / "remote-browser-sessions.json"
+    )
     route_handlers = _create_route_handlers(
         create_agent, agent_metadata, result_ttl, trust_agent,
         DEFAULT_FILE_LIMITS, load_permission_patterns(),
         replay_store.already_used,
         mode_policy=_host_mode_policy(sample),
+        remote_browser_service=remote_browser_service,
     )
     balance_startup, balance_shutdown = _create_balance_lifespan(
         sample, agent_metadata

--- a/connectonion/network/host/ws_router/remote_browser.py
+++ b/connectonion/network/host/ws_router/remote_browser.py
@@ -1,0 +1,38 @@
+"""Dispatch authenticated Remote Browser lifecycle requests."""
+
+import asyncio
+
+
+async def run_remote_browser(
+    data,
+    send_msg,
+    route_handlers,
+    *,
+    requester_address,
+    transport,
+):
+    """Run one host-owned browser lifecycle request outside the WS read loop."""
+    request_id = data.get("request_id")
+    try:
+        result = await asyncio.to_thread(
+            route_handlers["remote_browser"],
+            data,
+            requester_address,
+            transport,
+        )
+    except Exception as exc:
+        result = {
+            "schema_version": "1",
+            "ok": False,
+            "command": "remote-browser",
+            "request_id": request_id if isinstance(request_id, str) else "",
+            "code": "REMOTE_BROWSER_UNAVAILABLE",
+            "message": f"{type(exc).__name__}: {exc}",
+            "retryable": True,
+            "retry_after_seconds": None,
+            "state": {},
+            "tips": [],
+            "warnings": [],
+            "next_actions": [],
+        }
+    await send_msg({"type": "REMOTE_BROWSER_RESULT", **result})

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -20,6 +20,7 @@ from .connect import establish_connection, handle_authenticated_reconnect, handl
 from .exec import run_exec
 from .mode import handle_mode_change
 from .ping import ping_loop
+from .remote_browser import run_remote_browser
 
 console = Console()
 
@@ -289,6 +290,25 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                     # whitelisted tool (#653).
                     task = asyncio.create_task(
                         run_exec(data, send_msg, route_handlers, conn["agent_address"]))
+                    exec_tasks.add(task)
+                    task.add_done_callback(exec_tasks.discard)
+
+            elif msg_type == "REMOTE_BROWSER":
+                if not conn["authenticated"]:
+                    await send_msg({
+                        "type": "ERROR",
+                        "message": "authenticate first (send CONNECT)",
+                    })
+                else:
+                    task = asyncio.create_task(
+                        run_remote_browser(
+                            data,
+                            send_msg,
+                            route_handlers,
+                            requester_address=conn["agent_address"],
+                            transport=conn["transport"],
+                        )
+                    )
                     exec_tasks.add(task)
                     task.add_done_callback(exec_tasks.discard)
 

--- a/connectonion/useful_plugins/human_jitter.py
+++ b/connectonion/useful_plugins/human_jitter.py
@@ -9,8 +9,8 @@ Use it on sites whose terms permit automation.
 
 Data flow: before_each_tool event -> read agent.current_session['pending_tool'] ->
 if its name starts with 'click', grab the BrowserAutomation instance off the tool
-registry (agent.tools.browserautomation) and dispatch jitter() onto the browser's
-single worker thread (Playwright is not thread-safe).
+registry (agent.tools.browserautomation) and dispatch the async jitter routine onto
+the browser core's owning event loop (Playwright objects are loop-bound).
 
 Why before_each_tool (not after_tools): this is the only hook that fires
 synchronously between "LLM picked a click tool" and "Playwright performs the click",
@@ -25,6 +25,7 @@ if the page is mid-navigation when jitter reads the viewport, the click must sti
 proceed, so that transient failure is caught and logged, never raised.
 """
 
+import asyncio
 import random
 import time
 from typing import TYPE_CHECKING
@@ -38,7 +39,7 @@ if TYPE_CHECKING:
 def jitter(page):
     """Wander the mouse through a few random points on the page.
 
-    Must run on the browser's worker thread (Playwright is single-threaded).
+    Legacy synchronous-driver helper; run it on that driver's owning thread.
     """
     w, h = page.evaluate("() => [window.innerWidth, window.innerHeight]")
     x = random.uniform(w * 0.2, w * 0.8)
@@ -51,15 +52,30 @@ def jitter(page):
         time.sleep(random.uniform(0.03, 0.12))
 
 
+async def _jitter_async(page):
+    """Async-driver variant, run on the browser core's owning event loop."""
+    if page is None:
+        return
+    w, h = await page.evaluate("() => [window.innerWidth, window.innerHeight]")
+    x = random.uniform(w * 0.2, w * 0.8)
+    y = random.uniform(h * 0.2, h * 0.8)
+    await page.mouse.move(x, y, steps=random.randint(8, 16))
+    for _ in range(random.randint(2, 4)):
+        x = min(max(x + random.uniform(-120, 120), 1), w - 1)
+        y = min(max(y + random.uniform(-90, 90), 1), h - 1)
+        await page.mouse.move(x, y, steps=random.randint(6, 14))
+        await asyncio.sleep(random.uniform(0.03, 0.12))
+
+
 def _jitter_before_click(agent: "Agent"):
     pending = agent.current_session.get("pending_tool") or {}
     if not pending.get("name", "").startswith("click"):
         return
     browser = getattr(agent.tools, "browserautomation", None)
-    if browser is None or getattr(browser, "page", None) is None:
+    if browser is None:
         return
     try:
-        browser._executor.submit(jitter, browser.page).result()
+        browser._run_on_runtime(lambda core: _jitter_async(core.page))
     except Exception as e:
         # Jitter is cosmetic; a mid-navigation page (viewport read throws) must not
         # block the click the agent actually asked for.

--- a/connectonion/useful_tools/browser_tools/__init__.py
+++ b/connectonion/useful_tools/browser_tools/__init__.py
@@ -1,10 +1,10 @@
 """
-Purpose: Public entry point for the built-in browser automation tools — exposes BrowserAutomation (Playwright-driven, anti-detection-tuned) and ElementNotFoundError so user agents can `from connectonion.useful_tools.browser_tools import BrowserAutomation`.
+Purpose: Public entry point for browser tools — exposes the synchronous BrowserAutomation facade over the async Patchright core and ElementNotFoundError.
 LLM-Note:
-  Dependencies: re-exports from [.browser.BrowserAutomation, .element_finder.ElementNotFoundError] | imported by [cli/browser_agent/agent.py, cli/templates/browser/agent.py, cli/templates/minimal/agent.py, user code] | sibling modules: browser.py (main automation class), element_finder.py (LLM-aided element locator), browser_config.py (Chrome args), highlight_screenshot.py, scroll.py
+  Dependencies: re-exports from [.browser.BrowserAutomation, .element_finder.ElementNotFoundError] | imported by [cli/browser_agent/agent.py, cli/templates/browser/agent.py, cli/templates/minimal/agent.py, user code] | browser.py copies the 1.7 public signatures/docstrings onto the async-core facade
   Data flow: aggregator only — no logic
   Integration: exposes BrowserAutomation, ElementNotFoundError
 """
 
-from .browser import BrowserAutomation
-from .element_finder import ElementNotFoundError
+from .browser import BrowserAutomation as BrowserAutomation
+from .element_finder import ElementNotFoundError as ElementNotFoundError

--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -4,12 +4,12 @@ LLM-Note:
   Dependencies: imports patchright.async_api, async element finding/humanization, browser_config/chrome_finder, and stdlib | imported by [future async daemon/runtime; tests during migration] | tested by [tests/unit/test_async_browser_core.py, tests/e2e/test_async_browser_core_real_driver.py]
   Data flow: caller binds a session in a ContextVar → each async operation acquires that tab's lock → the shared persistent context lazily creates/restores one page per session → model-selected actions await extraction and worker-thread matching → independent tab operations may interleave on one event loop
   State/Effects: persistent profile at $CO_BROWSER_PROFILE_DIR or ~/.co/browser_profile | one shared BrowserContext | per-session pages/metadata/restore URLs | cancellation-safe context and driver teardown
-  Integration: internal AsyncBrowserCore; the public synchronous BrowserAutomation remains unchanged until #500 adds its compatibility facade
+  Integration: internal AsyncBrowserCore; used directly by the daemon and through the public synchronous BrowserAutomation compatibility facade
   Errors: live profile ownership fails before driver start | launch/cancellation tears down partially-created driver state | destructive keyboard shortcuts fail closed outside editable focus | element ambiguity and non-match errors preserve the synchronous finder contract
 
-This module is deliberately internal while #498 is in progress. It must never
-import or call patchright.sync_api: the old public class remains the compatibility
-implementation until the async contract is complete and #500 installs the facade.
+This module is deliberately internal. It must never import or call
+``patchright.sync_api``: synchronous callers use the compatibility facade, which
+submits work to this core's owned event loop.
 """
 
 import asyncio

--- a/connectonion/useful_tools/browser_tools/_async_humanize.py
+++ b/connectonion/useful_tools/browser_tools/_async_humanize.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: asyncio + stdlib-only humanize rules; no Patchright sync API | imported by [_async_browser.py] | tested by [tests/unit/test_async_browser_humanize.py]
   Data flow: known target → shared geometry/persona rules → awaited mouse/keyboard/CDP events with asyncio sleeps between events
   State/Effects: per-page cursor/CDP state | temporary OS clipboard mutation for CJK paste, serialized by the runtime clipboard lock and restored on cancellation
-  Integration: internal 1.8 async driver only; synchronous BrowserAutomation continues to use humanize.py until #500
+  Integration: internal 1.8 async driver; used by AsyncBrowserCore directly and by synchronous BrowserAutomation through its facade
   Errors: browser/CDP errors bubble; clipboard absence falls back to IME composition
 
 The synchronous input layer intentionally sleeps between low-level events. Calling

--- a/connectonion/useful_tools/browser_tools/_sync_browser_facade.py
+++ b/connectonion/useful_tools/browser_tools/_sync_browser_facade.py
@@ -1,0 +1,347 @@
+"""Synchronous compatibility facade over :class:`AsyncBrowserCore`.
+
+The public ``BrowserAutomation`` API predates asyncio.  Its implementation now
+uses the async browser driver, but callers still receive ordinary return values:
+one private event-loop thread owns the core and every synchronous call is
+submitted to that loop with the caller's tab binding.
+"""
+
+import asyncio
+import functools
+import inspect
+import threading
+from concurrent.futures import Future
+from typing import Any, Optional
+
+from ._async_browser import AsyncBrowserCore
+
+
+class BrowserAutomation:
+    """Backward-compatible synchronous browser automation.
+
+    Calls are safe from normal threads and from threads that already run an
+    asyncio loop.  Calling a synchronous method from this instance's own runtime
+    thread is rejected because waiting there would deadlock the browser loop.
+    """
+
+    def __init__(
+        self,
+        use_chrome_profile: bool = True,
+        headless: bool = False,
+        seed_state: Optional[str] = None,
+        tab_idle_ttl: float = 3600.0,
+        max_tabs: int = 10,
+    ) -> None:
+        self._core_kwargs = {
+            "use_chrome_profile": use_chrome_profile,
+            "headless": headless,
+            "seed_state": seed_state,
+            "tab_idle_ttl": tab_idle_ttl,
+            "max_tabs": max_tabs,
+        }
+        self._runtime_lock = threading.RLock()
+        self._runtime_ready = threading.Event()
+        self._runtime_thread: Optional[threading.Thread] = None
+        self._executor_thread: Optional[threading.Thread] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._core: Optional[AsyncBrowserCore] = None
+        self._runtime_error: Optional[BaseException] = None
+        self._stopping = False
+        self._session_binding = threading.local()
+        self.form_data = {}
+        self._screenshots = []
+        self._ensure_runtime()
+
+    def _run_runtime(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            core = AsyncBrowserCore(**self._core_kwargs)
+            with self._runtime_lock:
+                self._loop = loop
+                self._core = core
+                self._executor_thread = threading.current_thread()
+                self._runtime_ready.set()
+            loop.run_forever()
+        except BaseException as exc:
+            with self._runtime_lock:
+                self._runtime_error = exc
+                self._runtime_ready.set()
+        finally:
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
+
+    def _ensure_runtime(self) -> None:
+        with self._runtime_lock:
+            if self._runtime_thread is not None and self._runtime_thread.is_alive():
+                return
+            self._runtime_ready = threading.Event()
+            self._runtime_error = None
+            thread = threading.Thread(
+                target=self._run_runtime,
+                name=f"browser-async-{id(self):x}",
+                daemon=True,
+            )
+            self._runtime_thread = thread
+            thread.start()
+        self._runtime_ready.wait()
+        if self._runtime_error is not None:
+            raise RuntimeError("browser async runtime failed to start") from self._runtime_error
+
+    def _bound_session_key(self):
+        return getattr(self._session_binding, "key", None)
+
+    def _bind_session(self, session_id) -> None:
+        """Bind subsequent calls on this caller thread to one browser tab."""
+        self._session_binding.key = session_id
+
+    def _submit(self, awaitable) -> Any:
+        self._ensure_runtime()
+        thread, loop = self._runtime_thread, self._loop
+        if threading.current_thread() is thread:
+            if inspect.iscoroutine(awaitable):
+                awaitable.close()
+            raise RuntimeError(
+                "synchronous BrowserAutomation methods cannot run on their own "
+                "async runtime thread"
+            )
+        if loop is None:
+            raise RuntimeError("browser async runtime is not available")
+        future: Future = asyncio.run_coroutine_threadsafe(awaitable, loop)
+        try:
+            return future.result()
+        except BaseException:
+            future.cancel()
+            raise
+
+    def _invoke(self, name: str, *args, _during_stop: bool = False, **kwargs):
+        with self._runtime_lock:
+            if self._stopping and not _during_stop:
+                raise RuntimeError("browser async runtime is closing")
+        session = self._bound_session_key()
+
+        async def call():
+            core = self._core
+            if core is None:
+                raise RuntimeError("browser async runtime is not available")
+            core._bind_session(session)
+            result = getattr(core, name)(*args, **kwargs)
+            return await result if inspect.isawaitable(result) else result
+
+        return self._submit(call())
+
+    def _run_on_runtime(self, callback):
+        """Run an internal diagnostic callback beside the async core.
+
+        Public browser work should use the stable methods. This seam exists for
+        in-repository adapters such as detector harnesses and input plugins that
+        must use driver objects without crossing the event-loop thread boundary.
+        """
+        with self._runtime_lock:
+            if self._stopping:
+                raise RuntimeError("browser async runtime is closing")
+        session = self._bound_session_key()
+
+        async def call():
+            core = self._core
+            if core is None:
+                raise RuntimeError("browser async runtime is not available")
+            core._bind_session(session)
+            result = callback(core)
+            return await result if inspect.isawaitable(result) else result
+
+        return self._submit(call())
+
+    def _read_core_attr(self, name: str, default=None):
+        with self._runtime_lock:
+            live = (
+                not self._stopping
+                and self._runtime_thread is not None
+                and self._runtime_thread.is_alive()
+            )
+        if not live:
+            return default
+
+        async def read():
+            return getattr(self._core, name, default)
+
+        return self._submit(read())
+
+    @property
+    def page(self):
+        session = self._bound_session_key()
+        with self._runtime_lock:
+            live = (
+                not self._stopping
+                and self._runtime_thread is not None
+                and self._runtime_thread.is_alive()
+            )
+        if not live:
+            return None
+
+        async def read():
+            self._core._bind_session(session)
+            return self._core.page
+
+        return self._submit(read())
+
+    @page.setter
+    def page(self, value) -> None:
+        session = self._bound_session_key()
+
+        async def write():
+            self._core._pages[session] = value
+            self._core._page_used[session] = asyncio.get_running_loop().time()
+
+        self._submit(write())
+
+    @property
+    def browser(self):
+        return self._read_core_attr("browser")
+
+    @property
+    def playwright(self):
+        return self._read_core_attr("playwright")
+
+    @property
+    def last_screenshot_path(self):
+        return self._read_core_attr("last_screenshot_path")
+
+    @property
+    def screenshots_dir(self):
+        return self._read_core_attr("screenshots_dir")
+
+    @screenshots_dir.setter
+    def screenshots_dir(self, value) -> None:
+        async def write():
+            self._core.screenshots_dir = value
+
+        self._submit(write())
+
+    @property
+    def _pages(self):
+        return self._read_core_attr("_pages", {})
+
+    @property
+    def _page_used(self):
+        return self._read_core_attr("_page_used", {})
+
+    @property
+    def _page_url(self):
+        return self._read_core_attr("_page_url", {})
+
+    @property
+    def _tab_meta(self):
+        return self._read_core_attr("_tab_meta", {})
+
+    @property
+    def _headless(self):
+        return self._read_core_attr("_headless", self._core_kwargs["headless"])
+
+    @property
+    def use_chrome_profile(self):
+        return self._core_kwargs["use_chrome_profile"]
+
+    def _context_is_alive(self) -> bool:
+        return bool(self._invoke("is_alive"))
+
+    def _browser_is_usable(self) -> bool:
+        return self._context_is_alive() and self.page is not None
+
+    def _launch_failed(self) -> bool:
+        return bool(
+            self._read_core_attr("playwright") is not None
+            and self._read_core_attr("browser") is None
+        )
+
+    def close(self) -> str:
+        """Close the bound tab, or fully stop the unbound browser runtime."""
+        session = self._bound_session_key()
+        with self._runtime_lock:
+            live = self._runtime_thread is not None and self._runtime_thread.is_alive()
+        if not live:
+            return "Browser closed"
+
+        if session is not None:
+            result = self._invoke("close")
+            if result == "Browser tab closed for this session.":
+                return "Closed this session's browser tab."
+            return result
+
+        with self._runtime_lock:
+            self._stopping = True
+        try:
+            result = self._invoke("close", _during_stop=True)
+            with self._runtime_lock:
+                loop, thread = self._loop, self._runtime_thread
+                if loop is not None:
+                    loop.call_soon_threadsafe(loop.stop)
+            if thread is not None and thread is not threading.current_thread():
+                thread.join(timeout=15)
+                if thread.is_alive():
+                    raise RuntimeError(
+                        "browser async runtime did not stop within 15 seconds"
+                    )
+            with self._runtime_lock:
+                self._loop = None
+                self._core = None
+                self._runtime_thread = None
+                self._executor_thread = None
+        finally:
+            with self._runtime_lock:
+                self._stopping = False
+        if result == "Browser closed. Session saved for next time.":
+            return "Browser closed"
+        return result
+
+    def _teardown(self) -> str:
+        return self.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+
+def _install_sync_methods() -> None:
+    """Mirror every public async-core method without duplicating its signature."""
+    for name, method in inspect.getmembers(AsyncBrowserCore, inspect.isfunction):
+        if (
+            name.startswith("_")
+            or name in {"close", "is_alive"}
+            or not inspect.iscoroutinefunction(method)
+        ):
+            continue
+
+        @functools.wraps(method)
+        def call(self, *args, __name=name, **kwargs):
+            return self._invoke(__name, *args, **kwargs)
+
+        setattr(BrowserAutomation, name, call)
+
+
+_install_sync_methods()
+
+
+def adopt_legacy_contract(legacy_class) -> None:
+    """Copy the established public descriptions onto the facade methods.
+
+    Agent tool schemas and ``co browser help`` consume first-line docstrings, so
+    preserving signatures alone is not enough compatibility.
+    """
+    BrowserAutomation.__doc__ = legacy_class.__doc__
+    for name, legacy_method in inspect.getmembers(legacy_class, inspect.isfunction):
+        if name.startswith("_") or not hasattr(BrowserAutomation, name):
+            continue
+        method = getattr(BrowserAutomation, name)
+        method.__doc__ = legacy_method.__doc__
+        method.__signature__ = inspect.signature(legacy_method)

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -2338,3 +2338,14 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         """Context manager exit - ensures browser closes and saves context."""
         self.close()
         return False
+
+
+# Keep the implementation available for one release as an internal comparison
+# oracle while the public name moves to the async-core compatibility facade.
+LegacyBrowserAutomation = BrowserAutomation
+from ._sync_browser_facade import (  # noqa: E402
+    BrowserAutomation,
+    adopt_legacy_contract,
+)
+
+adopt_legacy_contract(LegacyBrowserAutomation)

--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -355,6 +355,14 @@ Planning window: weeks 3–6.
 
 ### Remote Browser service
 
+Implementation checkpoint (2026-08-26): #1296 is the first review boundary.
+It implements typed direct-OIP lifecycle only: `start`, `status`, `sessions`,
+`stop`, and `diagnose`, with authenticated owner binding, idempotent Start/Stop,
+and a persistent Host registry delegated to the existing Browser daemon. Relay
+fails closed until #1172, and navigation remains absent until one destination
+policy covers redirects, DNS changes, and subresources (#1297). See
+[DD-055](design-decisions/055-owner-bound-remote-browser-lifecycle.md).
+
 Build one transport-neutral command service over Browser Core:
 
 ```text

--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -29,9 +29,12 @@ The first vertical slice is implemented but deliberately not released:
   uploads, known-target humanized input, and model-selected element actions. The
   current final #498 slice adds keyboard typing, verified strategy scrolling,
   collision-safe context capture, and cancellable manual-login input. Issue #498
-  remains open until the whole-surface, cancellation, profile, stealth, recovery,
-  native-browser, installed-wheel, and hosted audit is complete; #499 and #500 remain
-  downstream.
+  has now passed the whole-surface, cancellation, profile, stealth, recovery,
+  native-browser, installed-wheel, and hosted audit in PR #1288; merge still needs
+  explicit release-authority approval. The stacked #499 slice replaces serial
+  dispatch with bounded asyncio client tasks, atomic request leases, per-tab
+  scheduling, native POSIX concurrency, and a bounded Windows pipe bridge. #500
+  remains the downstream synchronous-facade boundary.
 
 The next releasable target is `1.8.0a2`, not an artificial merge of individually green
 components. Its entry gate is one exact, immutable artifact flowing through oo-api,
@@ -237,10 +240,9 @@ Planning window: weeks 1–3. Workstreams run in parallel.
 
 Canonical issues: #498, #499, #500, #1151, and the reliability remainder of #1248/#1250.
 
-Current code has a synchronous Patchright core in
-`connectonion/useful_tools/browser_tools/browser.py`, one worker thread, and a serial
-daemon in `connectonion/cli/browser_agent/daemon.py`. Preserve public behavior while
-replacing the bottleneck.
+The public Python class still has a synchronous Patchright worker until #500.
+The internal core is async, and the #499 daemon slice owns it directly on one
+event loop. Preserve public behavior while completing the remaining facade.
 
 Implementation order:
 

--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -240,9 +240,11 @@ Planning window: weeks 1–3. Workstreams run in parallel.
 
 Canonical issues: #498, #499, #500, #1151, and the reliability remainder of #1248/#1250.
 
-The public Python class still has a synchronous Patchright worker until #500.
-The internal core is async, and the #499 daemon slice owns it directly on one
-event loop. Preserve public behavior while completing the remaining facade.
+The internal core and #499 daemon are async. The #500 implementation now places
+the public synchronous `BrowserAutomation` surface over a private owned event-loop
+thread, including defined running-loop behavior, same-signature delegation, and
+deterministic thread shutdown. Hosted cross-platform validation and review remain
+before the slice can be merged.
 
 Implementation order:
 

--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -33,8 +33,9 @@ The first vertical slice is implemented but deliberately not released:
   native-browser, installed-wheel, and hosted audit in PR #1288; merge still needs
   explicit release-authority approval. The stacked #499 slice replaces serial
   dispatch with bounded asyncio client tasks, atomic request leases, per-tab
-  scheduling, native POSIX concurrency, and a bounded Windows pipe bridge. #500
-  remains the downstream synchronous-facade boundary.
+  scheduling, native POSIX concurrency, and a bounded Windows pipe bridge. The
+  stacked #500 slice now places the stable synchronous API over that async core;
+  hosted validation and review remain before either downstream slice can merge.
 
 The next releasable target is `1.8.0a2`, not an artificial merge of individually green
 components. Its entry gate is one exact, immutable artifact flowing through oo-api,

--- a/docs/blog/2026-08-26-a-session-id-is-not-browser-authority.md
+++ b/docs/blog/2026-08-26-a-session-id-is-not-browser-authority.md
@@ -2,42 +2,54 @@
 
 *2026-08-26*
 
-The shortest route to a remote browser already existed: execute `co browser` as
-a remote shell command. It could open a page. It could also skip the contract we
-actually needed.
+The first Remote Browser sketch worked in one terminal. We sent a remote shell
+command to `co browser`, it opened a tab, and it printed an identifier. For a
+demo, that looked finished.
 
-A shell result cannot answer who owns the browser session after reconnect, what
-an idempotent retry means, or whether a copied session ID grants control. Adding
-more verbs to that path would make the demo grow faster than its authority
-model.
+Then we opened a second terminal.
 
-## Bind ownership before adding power
+The first connection was gone, so the next command had only the printed
+identifier. If we accepted it, anyone who copied the identifier could control
+the tab. If we rejected it, the original caller could not reconnect. A Host
+restart made the problem worse: the browser daemon could still be alive while
+the shell command had left no durable record of who owned its tab.
 
-The first Remote Browser OIP frame therefore does less. It starts, lists,
-inspects, diagnoses, and stops an owner-bound session. The Host takes the owner
-from the authenticated connection; the request has no owner field to spoof. The
-session ID locates a record but grants nothing. A different authenticated caller
-gets the same not-found result as an invented ID.
+The identifier told us which browser object we meant. It told us nothing about
+who had authority over it.
 
-The service also refuses to become another browser implementation. It opens a
-named tab in the existing concurrent daemon and records the lifecycle in one
-atomic, private registry. Repeating Start with the same request ID returns the
-same session. Repeating Stop returns the same tombstone. Restarting Host reloads
-the authority instead of manufacturing a new one.
+## The turn was deleting the exciting command
 
-## The missing navigation verb is the feature
+Our first instinct was to keep the demo and add checks around it. Instead, we
+removed navigation and wrote the ownership test first: Alice starts a session,
+Bob obtains its ID, and Bob asks for status, diagnosis, and stop. Every answer
+must look exactly like a nonexistent session. Alice reconnects through a new
+Host service instance and still sees her session. Repeating the same Start must
+not open a second tab; repeating Stop must not fail or close something else.
 
-It is tempting to add `open` next and call direct mode usable. A URL allowlist at
-the command edge would be theatre. The first URL can redirect; its hostname can
-resolve differently; the page can fetch private and link-local subresources.
-Until one policy covers the entire request chain, navigation stays absent and
-diagnosis says so explicitly.
+That test forced the protocol to carry less authority, not more data. The Host
+takes the owner from the authenticated OIP connection. There is no owner field
+in the request for a caller to spoof. The session ID only locates a private
+registry record after the owner matches. The record survives a Host restart and
+maps to a named tab in the existing browser daemon, so Remote Browser does not
+quietly become a second driver.
 
-Relay stays absent for a similar reason. Signed OIP commands authenticate a
-caller, but they do not hide browser-control plaintext from the Relay. The
-service returns a typed secure-channel error instead of silently weakening the
-route.
+Only then did the original one-terminal demo become a real lifecycle:
+start, list, inspect, diagnose, stop, disconnect, and reconnect.
 
-This is a narrow preview, but it establishes the part that is hardest to retrofit:
-identity, authority, retry, reconnect, and refusal semantics. Page actions can be
-added after their network boundary is executable, not merely described.
+## The next shortcut failed for the same reason
+
+With ownership fixed, adding `open` looked trivial. It was not. Checking the
+first URL would still allow a redirect to a private address, a hostname to
+resolve differently on the next request, or a public page to fetch private and
+link-local subresources. An allowlist at the CLI boundary would make the demo
+look safe while the browser crossed a different boundary underneath it.
+
+So diagnosis now reports navigation as unavailable. Relay control also fails
+closed: a signed OIP command authenticates its caller, but without the reviewed
+secure channel it does not hide browser-control plaintext from the Relay.
+
+The useful lesson came from that second terminal. A session ID is a reference,
+not a capability. Once we treated it that way, retries, reconnects, restarts,
+and refusals became part of one authority model. Navigation can arrive later,
+after its whole network path—not just its first URL—can enforce the same kind of
+boundary.

--- a/docs/blog/2026-08-26-a-session-id-is-not-browser-authority.md
+++ b/docs/blog/2026-08-26-a-session-id-is-not-browser-authority.md
@@ -1,0 +1,43 @@
+# A Session ID Is Not Browser Authority
+
+*2026-08-26*
+
+The shortest route to a remote browser already existed: execute `co browser` as
+a remote shell command. It could open a page. It could also skip the contract we
+actually needed.
+
+A shell result cannot answer who owns the browser session after reconnect, what
+an idempotent retry means, or whether a copied session ID grants control. Adding
+more verbs to that path would make the demo grow faster than its authority
+model.
+
+## Bind ownership before adding power
+
+The first Remote Browser OIP frame therefore does less. It starts, lists,
+inspects, diagnoses, and stops an owner-bound session. The Host takes the owner
+from the authenticated connection; the request has no owner field to spoof. The
+session ID locates a record but grants nothing. A different authenticated caller
+gets the same not-found result as an invented ID.
+
+The service also refuses to become another browser implementation. It opens a
+named tab in the existing concurrent daemon and records the lifecycle in one
+atomic, private registry. Repeating Start with the same request ID returns the
+same session. Repeating Stop returns the same tombstone. Restarting Host reloads
+the authority instead of manufacturing a new one.
+
+## The missing navigation verb is the feature
+
+It is tempting to add `open` next and call direct mode usable. A URL allowlist at
+the command edge would be theatre. The first URL can redirect; its hostname can
+resolve differently; the page can fetch private and link-local subresources.
+Until one policy covers the entire request chain, navigation stays absent and
+diagnosis says so explicitly.
+
+Relay stays absent for a similar reason. Signed OIP commands authenticate a
+caller, but they do not hide browser-control plaintext from the Relay. The
+service returns a typed secure-channel error instead of silently weakening the
+route.
+
+This is a narrow preview, but it establishes the part that is hardest to retrofit:
+identity, authority, retry, reconnect, and refusal semantics. Page actions can be
+added after their network boundary is executable, not merely described.

--- a/docs/blog/2026-08-26-sync-on-the-outside-async-on-the-inside.md
+++ b/docs/blog/2026-08-26-sync-on-the-outside-async-on-the-inside.md
@@ -1,36 +1,50 @@
-# Sync on the outside, async on the inside
+# The browser worked until the caller already had a loop
 
-Changing a browser driver from synchronous to asynchronous is easy if every caller
-can change with it. `BrowserAutomation` could not make that bargain. It is already
-used as an Agent tool, in context managers, in scripts, and from server workers.
-Making every method return a coroutine would turn an internal driver migration into
-a public breaking change.
+The async browser migration looked finished. The daemon could keep two tabs moving
+at once, a blocked navigation no longer froze every client, and the old global
+Playwright worker was gone. Then we tried the most ordinary server-side call:
 
-ConnectOnion 1.8 keeps the old surface and changes the ownership underneath it.
-Each `BrowserAutomation` instance owns one private thread, one asyncio event loop,
-and one async browser core. A normal method call captures the caller's session-tab
-binding, submits the matching coroutine to that loop, waits for the result, and
-returns the same ordinary Python value as before.
+```python
+async def handle_request():
+    browser.go_to("https://example.com")
+```
 
-The thread boundary matters most when the caller already has an event loop. Calling
-`asyncio.run()` there would fail with a nested-loop error. Running the browser loop
-in its own thread gives this case defined behavior: the synchronous call blocks its
-caller, while the browser runtime continues normally. The inverse case is rejected.
-If code somehow invokes the synchronous facade from the browser's own runtime
-thread, waiting would deadlock that loop, so the call raises a direct `RuntimeError`.
+`BrowserAutomation` has always been synchronous, so existing applications quite
+reasonably call it from request handlers that already own an asyncio loop. Our first
+facade tried to run the new coroutine with `asyncio.run()`. Python answered with the
+error it reserves for exactly this mistake: an event loop was already running.
 
-Shutdown is part of the compatibility contract, not cleanup trivia. A session-bound
-`close()` releases only that tab and leaves the shared runtime alive. An unbound
-`close()` waits for the async core to finish closing its pages, context, and driver,
-then stops and joins the event-loop thread. Repeated construction and close cycles
-therefore do not accumulate loops or threads, and repeated close calls are harmless.
+Making `go_to()` async would have made the error disappear, but only by handing it to
+every user. Agent tools, scripts, context managers, and server workers would all have
+to change for what was supposed to be an internal driver replacement.
 
-The useful tests operate at the boundary. They compare every public method name and
-signature with the previous class, call the facade from inside an already-running
-event loop, carry a session binding across the thread hop, attempt the forbidden
-same-thread call, and repeat create/close cycles while retaining each old thread so
-the test can prove all of them stopped.
+The turn came from treating the loop as an owned resource instead of something to
+borrow from the caller. Each facade now starts one private thread and one asyncio
+loop. A synchronous call carries its session-tab binding across that boundary,
+submits the core coroutine, waits, and returns the same ordinary value as before.
+The request handler's loop is no longer nested or commandeered.
 
-The public API did not become async. Its implementation did. That distinction lets
-existing code keep working while the daemon and direct Python tools finally share
-one browser architecture.
+That solution created a second trap. We scheduled a facade call from its own browser
+thread to see what would happen. The thread submitted work to its loop and then
+waited for the result; the loop could not run the work because its only thread was
+waiting. Nothing crashed. Nothing timed out. It simply stopped.
+
+The fix is intentionally blunt: a synchronous facade call made from the owned
+runtime thread raises `RuntimeError` before submission. A test schedules that exact
+mistake on the loop and proves it fails instead of deadlocking.
+
+Shutdown exposed the ownership rule one more time. A hosted session's `close()` must
+release one tab, while an unbound `close()` must close the shared browser, stop the
+loop, and join the thread. We retained every thread from repeated create-and-close
+cycles in a test; if even one remained alive, the compatibility layer was not done.
+
+The last surprise came from a repository search after the facade tests were green.
+The stealth detector harness and the opt-in `human_jitter` plugin still reached into
+the deleted private executor. They now use a narrow internal callback that runs
+beside the async core on its owning loop. Driver objects no longer leak across the
+thread boundary just because a diagnostic or plugin needs raw page work.
+
+The lesson was not merely "put asyncio on another thread." Compatibility depends on
+making ownership visible: who owns the loop, which session owns the tab, who may
+block, and who must join at shutdown. Once those answers became executable tests,
+the public API could stay synchronous while its implementation finally became async.

--- a/docs/blog/2026-08-26-sync-on-the-outside-async-on-the-inside.md
+++ b/docs/blog/2026-08-26-sync-on-the-outside-async-on-the-inside.md
@@ -1,0 +1,36 @@
+# Sync on the outside, async on the inside
+
+Changing a browser driver from synchronous to asynchronous is easy if every caller
+can change with it. `BrowserAutomation` could not make that bargain. It is already
+used as an Agent tool, in context managers, in scripts, and from server workers.
+Making every method return a coroutine would turn an internal driver migration into
+a public breaking change.
+
+ConnectOnion 1.8 keeps the old surface and changes the ownership underneath it.
+Each `BrowserAutomation` instance owns one private thread, one asyncio event loop,
+and one async browser core. A normal method call captures the caller's session-tab
+binding, submits the matching coroutine to that loop, waits for the result, and
+returns the same ordinary Python value as before.
+
+The thread boundary matters most when the caller already has an event loop. Calling
+`asyncio.run()` there would fail with a nested-loop error. Running the browser loop
+in its own thread gives this case defined behavior: the synchronous call blocks its
+caller, while the browser runtime continues normally. The inverse case is rejected.
+If code somehow invokes the synchronous facade from the browser's own runtime
+thread, waiting would deadlock that loop, so the call raises a direct `RuntimeError`.
+
+Shutdown is part of the compatibility contract, not cleanup trivia. A session-bound
+`close()` releases only that tab and leaves the shared runtime alive. An unbound
+`close()` waits for the async core to finish closing its pages, context, and driver,
+then stops and joins the event-loop thread. Repeated construction and close cycles
+therefore do not accumulate loops or threads, and repeated close calls are harmless.
+
+The useful tests operate at the boundary. They compare every public method name and
+signature with the previous class, call the facade from inside an already-running
+event loop, carry a session binding across the thread hop, attempt the forbidden
+same-thread call, and repeat create/close cycles while retaining each old thread so
+the test can prove all of them stopped.
+
+The public API did not become async. Its implementation did. That distinction lets
+existing code keep working while the daemon and direct Python tools finally share
+one browser architecture.

--- a/docs/blog/2026-08-26-the-second-tab-was-not-concurrent.md
+++ b/docs/blog/2026-08-26-the-second-tab-was-not-concurrent.md
@@ -37,6 +37,9 @@ bounds would only trade one global queue for an unlimited pile of tasks.
 On Windows, a successful whole-browser `close` also waits for the exact daemon
 PID that served it to exit. The next command can therefore cold-start against a
 new named pipe instead of reaching the old daemon during its shutdown window.
+Because closing a Windows listener does not interrupt an `accept` already
+blocked in a worker, shutdown authenticates one internal wake connection and
+discards it before joining the bounded worker pool.
 
 The useful test is still the original stopwatch. Two independent 200 ms
 operations go through the real local socket and overlap. The same-tab test takes

--- a/docs/blog/2026-08-26-the-second-tab-was-not-concurrent.md
+++ b/docs/blog/2026-08-26-the-second-tab-was-not-concurrent.md
@@ -1,0 +1,47 @@
+# The second tab was not concurrent
+
+We already had one browser tab per agent. That looked like concurrency on the
+board: `research` belonged to one task, `inbox` to another, and neither could
+navigate the other's page.
+
+Then we timed two 200 ms operations.
+
+They took about 400 ms.
+
+The tabs were isolated, but the daemon still accepted one connection, finished
+its browser call, sent the reply, and only then accepted the next connection.
+The browser driver added a second queue of its own: every synchronous Patchright
+call ran through one worker thread. A named tab prevented corruption; it did not
+let the second task move.
+
+The fix was to choose one place that owns concurrency. The daemon now owns one
+asyncio event loop and one async Patchright runtime. Each request is an asyncio
+task. The browser core locks the page for that request's bound tab, not the whole
+browser. Two requests for `research` still run in order. A request for `research`
+and one for `inbox` can overlap.
+
+Claims stay outside that scheduling decision. Before a task touches a page, a
+small registry lock decides whether its caller owns the tab. Two callers racing
+for `main` therefore cannot both pass an asynchronous check-then-write gap: one
+records the claim and the other receives exit code 4. The winner also records a
+request id in the tab metadata. A `finally` block removes that exact request id
+after success, failure, or cancellation without deleting the longer-lived tab
+owner.
+
+We kept the native transports rather than hiding blocking Windows pipes behind
+an unbounded default executor. POSIX connections enter the event loop directly.
+Windows accept, authentication, read, and write calls cross a dedicated bounded
+worker pool and submit to the same async dispatch path. Both sides cap admitted
+clients, request bytes, read time, and reply time. Concurrency without those
+bounds would only trade one global queue for an unlimited pile of tasks.
+
+The useful test is still the original stopwatch. Two independent 200 ms
+operations go through the real local socket and overlap. The same-tab test takes
+roughly 400 ms and proves ordering remains. A third test closes the client before
+the reply, then checks that the request lease and active operation are gone while
+the tab's durable owner is still present.
+
+The lesson was not "replace threads with asyncio." It was that isolation and
+concurrency are different properties. A tab map gave us isolation. Only moving
+the daemon and the driver onto the same owned async runtime made the second tab
+concurrent.

--- a/docs/blog/2026-08-26-the-second-tab-was-not-concurrent.md
+++ b/docs/blog/2026-08-26-the-second-tab-was-not-concurrent.md
@@ -34,6 +34,9 @@ Windows accept, authentication, read, and write calls cross a dedicated bounded
 worker pool and submit to the same async dispatch path. Both sides cap admitted
 clients, request bytes, read time, and reply time. Concurrency without those
 bounds would only trade one global queue for an unlimited pile of tasks.
+On Windows, a successful whole-browser `close` also waits for the exact daemon
+PID that served it to exit. The next command can therefore cold-start against a
+new named pipe instead of reaching the old daemon during its shutdown window.
 
 The useful test is still the original stopwatch. Two independent 200 ms
 operations go through the real local socket and overlap. The same-tab test takes

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -241,6 +241,8 @@ python -m patchright install chrome     # branded Chrome: best stealth, system i
 - The daemon endpoint: a Unix socket under `$XDG_RUNTIME_DIR/co/browser.sock` on macOS/Linux, a per-user named pipe on Windows (native, 1.2.1+ — no WSL). Override with `$CO_BROWSER_SOCK`.
 - Client work is bounded: 1 MiB request cap, 120-second read/reply deadlines,
   32 admitted connections, and eight blocking transport workers on Windows.
+- On Windows, `co browser close` returns only after the serving daemon exits, so
+  an immediate next command can safely start a fresh daemon.
 - For an isolated automation run, set `$CO_BROWSER_PROFILE_DIR` to a dedicated absolute directory and `$CO_BROWSER_SOCK` to a dedicated socket. Keep the real `$HOME`; replacing it can break OS-backed browser behavior and credentials.
 
 ## Error Messages

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -187,6 +187,12 @@ with the tab still open means that agent crashed, not that it is still working.
 A tab opened without `--needs` frees up after ~2 minutes of silence, which is
 wrong whenever you are waiting on a slow page or a human. Say the number.
 
+Named tabs are also the concurrency boundary. The daemon owns one asyncio browser
+runtime: two operations aimed at `scrape` queue behind each other, while `scrape`
+and `inbox` may run at the same time. A registry lock decides claim races before
+either operation touches a page, so concurrency never means two agents silently
+sharing one tab.
+
 Set `CO_WHO` so your commands carry your identity:
 
 ```bash
@@ -231,8 +237,10 @@ python -m patchright install chrome     # branded Chrome: best stealth, system i
 
 ## Sessions & Profile
 
-- One browser per machine, backed by a persistent profile at `~/.co/browser_profile/` — so logins survive restarts.
+- One async browser runtime per machine, backed by a persistent profile at `~/.co/browser_profile/` — so logins survive restarts.
 - The daemon endpoint: a Unix socket under `$XDG_RUNTIME_DIR/co/browser.sock` on macOS/Linux, a per-user named pipe on Windows (native, 1.2.1+ — no WSL). Override with `$CO_BROWSER_SOCK`.
+- Client work is bounded: 1 MiB request cap, 120-second read/reply deadlines,
+  32 admitted connections, and eight blocking transport workers on Windows.
 - For an isolated automation run, set `$CO_BROWSER_PROFILE_DIR` to a dedicated absolute directory and `$CO_BROWSER_SOCK` to a dedicated socket. Keep the real `$HOME`; replacing it can break OS-backed browser behavior and credentials.
 
 ## Error Messages

--- a/docs/co-browser.md
+++ b/docs/co-browser.md
@@ -215,24 +215,32 @@ own flags (`co browser status` shows `headless=true/false`). To switch modes,
   registered before `-t` can drive it.
 - **Scripting:** `TAB=$(co browser tab open --for "job")` captures the tab name
   (that's the only thing `tab open` prints to stdout); branch on the exit code, and
-  read `tab ls --json` to see the shared state.
+  read `tab ls --json` to see the shared state. Its `active_requests` entries carry
+  request id, caller, command, and start time while work is in flight; they disappear
+  on success, failure, disconnect, or cancellation.
 
 ## How It Works
 
-A small **daemon** owns the one browser and listens on a Unix socket; each
+A small **daemon** owns the one browser and listens on a Unix socket (or an
+authenticated named pipe on Windows); each
 `co browser …` invocation is a short-lived client that sends one request and prints
 the reply. Every terminal on the machine talks to the **same** daemon — there is
-one browser, one board, no matter where you type. The daemon serializes commands,
-tracks per-tab ownership, and keeps the browser alive between commands. It starts
-automatically on first use and exits when you `close` it (or when the browser is
-no longer usable).
+one browser, one board, no matter where you type. One asyncio runtime owns that
+browser. Operations on the same tab are serialized; operations on independent
+named tabs can progress together. Claim admission remains atomic, so two agents
+racing for one tab still get one winner and one exit-4 refusal rather than
+interleaved page mutations. It starts automatically on first use and exits when
+you `close` it (or when the browser is no longer usable).
 
 The daemon records its pid next to the socket, so a daemon that is merely **busy**
-(for example, a slow navigation holding the single-threaded browser loop) is never mistaken for a dead one:
-clients wait up to ~15s for it to come free and then say so ("daemon is busy"),
-instead of spawning a rival daemon over a live browser. Startup itself is
-race-proof: a kernel lock makes two terminals' simultaneous first commands elect
-exactly one daemon — the loser exits and its command is served by the winner.
+(for example, its bounded connection capacity is full) is never mistaken for a
+dead one: clients wait briefly and report capacity instead of spawning a rival
+daemon over a live browser. Each request is capped at 1 MiB, reads and replies
+have absolute 120-second deadlines, and at most 32 client tasks are admitted.
+Cancellation or disconnect clears that request's active audit lease without
+erasing another task's tab ownership. Startup itself is race-proof: a kernel lock
+makes two terminals' simultaneous first commands elect exactly one daemon — the
+loser exits and its command is served by the winner.
 
 ### Restart the daemon after an upgrade or downgrade
 
@@ -266,8 +274,9 @@ downgrading so an older client never talks to a newer daemon.
 - **"Chrome failed to start"** — usually running over ssh/cron without a desktop
   session (start from a logged-in Terminal, or use `--headless`), or a leftover
   Chrome still holds the profile. The full launch log is in `~/.co/browser.log`.
-- **"daemon is busy" after ~15s** — a browser action is holding the single-threaded
-  daemon. Wait for it, or find the culprit with `co browser status` once it frees up.
+- **"daemon is … at connection capacity" after ~15s** — 32 clients are already
+  admitted (or all bounded Windows transport workers are occupied). Retry shortly;
+  an unrelated slow browser action on another named tab no longer blocks yours.
 - **Nuclear option** — kill the daemon and let the next command start fresh
   (logins survive: they live in the profile, not the daemon):
 

--- a/docs/design-decisions/054-one-async-browser-runtime.md
+++ b/docs/design-decisions/054-one-async-browser-runtime.md
@@ -56,9 +56,28 @@ The migration has three review boundaries:
    `BrowserAutomation` methods submit to an owned loop thread without nesting a
    caller's running event loop. The facade is compatibility, not a second driver.
 
-The internal core is not exported as a public user API while #498 is incomplete.
-The current synchronous API and daemon remain authoritative until the complete
-contract and cross-platform transport matrices are green.
+The internal core is not exported as a public user API. The daemon now owns it
+directly; the current synchronous Python API remains authoritative until #500's
+facade and cross-platform compatibility matrices are green.
+
+The #499 transport boundary keeps claim admission separate from page execution.
+A registry lock performs unknown-tab validation, claim takeover/refusal, and a
+request-scoped audit lease as one transition. The lease is keyed by a unique
+request id and cleared in `finally`, so cancellation removes only the request
+that was cancelled; it does not erase a durable owner or another in-flight
+request. Once admitted, the async core's tab lock orders that page while other
+tab locks remain free.
+
+POSIX hands the already race-checked AF_UNIX listener to
+`asyncio.start_unix_server`. It admits at most 32 connection tasks, rejects
+excess connections without spawning more tasks, limits each request to 1 MiB,
+and applies absolute 120-second read and reply deadlines. Windows retains the
+authenticated `multiprocessing.connection` named-pipe wire. Its blocking
+accept/read/write calls run through a dedicated eight-worker executor and feed
+the same asyncio dispatch path; a 32-slot admission semaphore bounds queued
+connections. Shutdown stops admission, cancels owned connection tasks, awaits
+the browser runtime cleanup, and removes the endpoint only if its pid sidecar
+still names this process.
 
 The second #498 review boundary ports deterministic contracts that do not depend
 on frames, downloads, humanized input, or model-backed element matching. It covers
@@ -139,11 +158,18 @@ home with the real macOS keychain makes Chrome hang during context shutdown.
 Before #498 closes, the async core must cover every current public browser verb,
 the humanized-input acceptance suite, profile seeding/export, dead-context
 recovery, downloads/uploads, screenshot payload bounds, and stealth checks.
-Before #499 closes, slow-reader/writer, stalled client, cancellation,
-disconnect, same-tab conflict, independent-tab progress, cold-start, and
-shutdown load tests must pass on POSIX and Windows. Before #500 closes, repeated
+Before #499 closes, slow-reader/writer, oversized/stalled client, admission-cap,
+cancellation, disconnect, same-tab conflict, independent-tab progress,
+cold-start, and shutdown load tests must pass on POSIX and Windows. Before #500 closes, repeated
 sync and running-event-loop callers must leave no loop thread, task, page,
 process, socket, or pipe behind.
+
+The #499 native gate exercises the complete path rather than composing two mock
+claims: a real socket client asks the real daemon to hold one real Chrome tab for
+two seconds, then another client must read a second real tab within one second
+and before the hold finishes. The transport-only matrix separately proves
+same-tab ordering, a two-caller claim race, disconnect cleanup, and parallel
+client admission without paying Chrome launch cost in every platform job.
 
 The completed review boundaries additionally run against native Chrome. They
 prove selector counts and text, repeated-item bounds, link filtering, text waits,

--- a/docs/design-decisions/054-one-async-browser-runtime.md
+++ b/docs/design-decisions/054-one-async-browser-runtime.md
@@ -56,9 +56,10 @@ The migration has three review boundaries:
    `BrowserAutomation` methods submit to an owned loop thread without nesting a
    caller's running event loop. The facade is compatibility, not a second driver.
 
-The internal core is not exported as a public user API. The daemon now owns it
-directly; the current synchronous Python API remains authoritative until #500's
-facade and cross-platform compatibility matrices are green.
+The internal core is not exported as a public user API. The daemon owns it
+directly; the synchronous Python API remains authoritative and now delegates
+through #500's facade. That facade still requires green cross-platform matrices
+before merge.
 
 The #499 transport boundary keeps claim admission separate from page execution.
 A registry lock performs unknown-tab validation, claim takeover/refusal, and a

--- a/docs/design-decisions/055-owner-bound-remote-browser-lifecycle.md
+++ b/docs/design-decisions/055-owner-bound-remote-browser-lifecycle.md
@@ -1,0 +1,72 @@
+# DD-055: Remote Browser starts with owner-bound lifecycle, not navigation
+
+**Status:** In progress for 1.8
+
+**Date:** 2026-08-26
+
+**Related:** [#991](https://github.com/openonion/connectonion/issues/991),
+[#1296](https://github.com/openonion/connectonion/issues/1296),
+[#1297](https://github.com/openonion/connectonion/issues/1297),
+[#1036](https://github.com/openonion/connectonion/issues/1036),
+[#1172](https://github.com/openonion/connectonion/issues/1172),
+[DD-053](053-oip-only-browser-and-native-coding-adapters.md),
+[DD-054](054-one-async-browser-runtime.md)
+
+## Context
+
+`co call <host> co browser ...` can execute a shell command remotely, but it is
+not a Remote Browser protocol. It exposes no durable browser-session identity,
+does not bind a session to the authenticated OIP caller, and returns the generic
+EXEC result shape. Building a second remote driver would also bypass the tab
+claims and one async runtime established by DD-054.
+
+Navigation is a separate security boundary. Checking only the submitted URL is
+not sufficient: redirects and subresources can reach loopback, link-local,
+private-network, metadata, or otherwise prohibited destinations after the first
+request appears safe.
+
+Relay adds another boundary. OIP identity signatures authenticate commands but
+do not make the Relay blind to browser-control content. Relay Remote Browser
+therefore depends on the reviewed secure channel tracked in #1172.
+
+## Decision
+
+The first 1.8 slice introduces a typed, signed `REMOTE_BROWSER` OIP frame and a
+stable `REMOTE_BROWSER_RESULT` envelope. It supports only `start`, `status`,
+`sessions`, `stop`, and `diagnose`.
+
+The Host derives the owner from the authenticated OIP connection. A request
+cannot supply or replace it. Only contacts, whitelisted callers, and admins may
+use the service. Session IDs locate records but grant no authority: another
+caller receives the same not-found response as a nonexistent session.
+
+The Host owns one persistent, mode-0600 session registry and delegates tab
+lifecycle to the existing Browser daemon. The authenticated owner is also the
+daemon tab owner. Start is idempotent by owner and request ID; Stop keeps a
+tombstone and is idempotent. Host restart reloads the same registry rather than
+minting new authority.
+
+Only a direct OIP transport and `proxy=direct` are admitted in this slice. Relay
+fails with `SECURE_CHANNEL_UNAVAILABLE`; other proxy modes fail with
+`REMOTE_SESSION_PROXY_LOCKED`. Neither condition silently falls back. Navigation
+is absent, and `diagnose` reports `navigation_policy: not_enabled`.
+
+## Consequences
+
+- Remote Browser is not a wrapper around generic shell execution.
+- The daemon and async core remain the only browser runtime.
+- Lifecycle, identity, retry, reconnect, and Host-restart behavior can be tested
+  before URL access is exposed.
+- The first useful release is deliberately narrower: it cannot yet navigate,
+  capture, act, take over, or release.
+- Navigation may land only with a policy enforced across initial requests,
+  redirects, DNS changes, and subresources.
+- Relay may land only after #1172 supplies the reviewed, downgrade-resistant
+  secure channel.
+
+## Revisit
+
+Extend the command set when #1297 has executable negative
+tests and the same lifecycle conformance suite passes through the installed
+artifact. Enable Relay only after its secure-channel vectors pass in every OIP
+implementation and the Relay sees no command plaintext.

--- a/docs/network/remote-browser.md
+++ b/docs/network/remote-browser.md
@@ -15,7 +15,8 @@ Use `--json` for the complete stable envelope. A successful envelope includes
 `schema_version`, `ok`, `command`, `request_id`, `summary`, `result`, `state`,
 `tips`, `warnings`, and `next_actions`. Failures add a stable `code`, `message`,
 `retryable`, and `retry_after_seconds`; scripts should branch on `ok` and `code`,
-not English text.
+not English text. With `--json`, local validation failures use that envelope too
+and write no human usage text to stderr.
 
 `start` is idempotent for the same authenticated owner and request ID. Session
 IDs are identifiers, not bearer secrets. Status, listing, diagnosis, and Stop
@@ -27,6 +28,11 @@ This preview accepts direct OIP transport and `proxy=direct` only. A Relay path
 returns `SECURE_CHANNEL_UNAVAILABLE` until the reviewed OIP secure channel is
 available. It never downgrades to plaintext browser control. Other proxy modes
 return `REMOTE_SESSION_PROXY_LOCKED`.
+
+The Python async API returns a `TIMEOUT` envelope when its response deadline
+expires. Cancelling the calling task remains normal Python cancellation: it
+raises `asyncio.CancelledError` instead of turning cancellation into a retryable
+remote failure.
 
 Navigation is intentionally unavailable. Validating only the initial URL would
 leave redirects, DNS changes, and subresources able to cross the intended

--- a/docs/network/remote-browser.md
+++ b/docs/network/remote-browser.md
@@ -1,0 +1,39 @@
+# Remote Browser lifecycle (1.8 preview)
+
+Remote Browser is an authenticated OIP service for browser sessions owned by a
+remote caller. The first 1.8 boundary manages lifecycle only:
+
+```bash
+co remote-browser 0xHOST start
+co remote-browser 0xHOST sessions
+co remote-browser 0xHOST status rb_0123456789abcdef0123456789abcdef
+co remote-browser 0xHOST diagnose rb_0123456789abcdef0123456789abcdef
+co remote-browser 0xHOST stop rb_0123456789abcdef0123456789abcdef
+```
+
+Use `--json` for the complete stable envelope. A successful envelope includes
+`schema_version`, `ok`, `command`, `request_id`, `summary`, `result`, `state`,
+`tips`, `warnings`, and `next_actions`. Failures add a stable `code`, `message`,
+`retryable`, and `retry_after_seconds`; scripts should branch on `ok` and `code`,
+not English text.
+
+`start` is idempotent for the same authenticated owner and request ID. Session
+IDs are identifiers, not bearer secrets. Status, listing, diagnosis, and Stop
+are filtered by the OIP identity that completed CONNECT, so copying another
+owner's session ID does not grant access. Stop is idempotent and retains a
+tombstone for retry/reconnect evidence.
+
+This preview accepts direct OIP transport and `proxy=direct` only. A Relay path
+returns `SECURE_CHANNEL_UNAVAILABLE` until the reviewed OIP secure channel is
+available. It never downgrades to plaintext browser control. Other proxy modes
+return `REMOTE_SESSION_PROXY_LOCKED`.
+
+Navigation is intentionally unavailable. Validating only the initial URL would
+leave redirects, DNS changes, and subresources able to cross the intended
+network boundary. `diagnose` therefore reports `navigation_policy: not_enabled`.
+Continue to use local `co browser` for page actions while that policy is being
+specified and tested in
+[#1297](https://github.com/openonion/connectonion/issues/1297).
+
+See [DD-055](../design-decisions/055-owner-bound-remote-browser-lifecycle.md)
+for the decision and follow-up gates.

--- a/docs/useful_plugins/human_jitter.md
+++ b/docs/useful_plugins/human_jitter.md
@@ -20,7 +20,7 @@ agent.input("open the menu and click Settings")
 
 1. On `before_each_tool`, reads `agent.current_session['pending_tool']`.
 2. If its name starts with `click`, grabs the `BrowserAutomation` instance off the tool registry (`agent.tools.browserautomation`).
-3. Dispatches `jitter()` onto the browser's single worker thread: the cursor moves to a random point, then random-walks through a few more, with short pauses.
+3. Dispatches an async jitter routine onto the browser core's owning event loop: the cursor moves to a random point, then random-walks through a few more, with short pauses.
 
 Jitter is best-effort. If the page is mid-navigation when it reads the viewport, the failure is caught and logged so the click the agent asked for can still proceed.
 

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -287,16 +287,14 @@ agent.input("Fill in the contact form on example.com with test data")
 
 One `BrowserAutomation` instance is safe to reuse across turns and concurrent hosted sessions. Public methods are serialized onto one internal browser worker thread, so Playwright's sync API is always called from the thread that owns it. When `bind_browser_session` is enabled, each hosted session gets its own tab in the shared browser context.
 
-That worker-thread behavior remains the public contract during the 1.8 async
-migration. The replacement core is internal until every browser verb and the
-cross-platform daemon have equivalent coverage; do not import it as an
-application API yet. The lifecycle, concurrency, cancellation, and compatibility
-boundaries are recorded in [DD-054](../design-decisions/054-one-async-browser-runtime.md).
-The internal core now covers the deterministic selector, extraction, viewport,
-wait, system-info, tab-status, page/frame-script, and file-upload contracts, but
-click variants, downloads, humanized input, model-backed element finding,
-concurrent IPC, and the synchronous facade are still migration work.
-`BrowserAutomation` remains the supported API.
+That worker-thread behavior remains the public Python contract until #500 adds
+the compatibility facade. The replacement core is still internal; do not import
+it as an application API. The `co browser` daemon now owns that async core
+directly: independent tabs interleave, same-tab operations serialize, and the
+POSIX/Windows transports bound connections, reads, writes, and shutdown. The
+lifecycle, concurrency, cancellation, and compatibility boundaries are recorded
+in [DD-054](../design-decisions/054-one-async-browser-runtime.md).
+`BrowserAutomation` remains the supported Python API.
 
 ## Common Patterns
 

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -304,15 +304,14 @@ agent.input("Navigate to github.com/trending and screenshot the page")
 agent.input("Fill in the contact form on example.com with test data")
 ```
 
-One `BrowserAutomation` instance is safe to reuse across turns and concurrent hosted sessions. Public methods are serialized onto one internal browser worker thread, so Playwright's sync API is always called from the thread that owns it. When `bind_browser_session` is enabled, each hosted session gets its own tab in the shared browser context.
+One `BrowserAutomation` instance is safe to reuse across turns and concurrent hosted sessions. Public calls remain synchronous, but the facade submits them to one owned async browser runtime. When `bind_browser_session` is enabled, each hosted session gets its own tab in the shared browser context.
 
-That worker-thread behavior remains the public Python contract until #500 adds
-the compatibility facade. The replacement core is still internal; do not import
-it as an application API. The `co browser` daemon now owns that async core
-directly: independent tabs interleave, same-tab operations serialize, and the
-POSIX/Windows transports bound connections, reads, writes, and shutdown. The
-lifecycle, concurrency, cancellation, and compatibility boundaries are recorded
-in [DD-054](../design-decisions/054-one-async-browser-runtime.md).
+The async core remains internal; do not import it as an application API. Both the
+facade and `co browser` daemon use that core: independent tabs interleave,
+same-tab operations serialize, and the POSIX/Windows transports bound
+connections, reads, writes, and shutdown. The lifecycle, concurrency,
+cancellation, and compatibility boundaries are recorded in
+[DD-054](../design-decisions/054-one-async-browser-runtime.md).
 `BrowserAutomation` remains the supported Python API.
 
 ## Common Patterns

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -34,6 +34,25 @@ with BrowserAutomation() as browser:
     browser.close()
 ```
 
+### Synchronous API, async runtime
+
+`BrowserAutomation` remains synchronous in 1.8: existing calls, context managers,
+method names, signatures, and return values do not require an `await`. Internally,
+the class owns one async browser core on a private event-loop thread. This removes
+the old synchronous Patchright implementation from the execution path while
+preserving existing Python and Agent integrations.
+
+Calling these synchronous methods from a thread that already runs an asyncio loop
+is supported; the call blocks that caller until its browser operation completes.
+Calling from the browser's own private runtime thread raises a clear `RuntimeError`
+instead of deadlocking. An unbound `close()` closes the shared browser and joins the
+runtime thread; a session-bound `close()` releases only that session's tab.
+
+Compatibility policy for 1.8: no public `BrowserAutomation` method is deprecated,
+and the async core remains internal. `LegacyBrowserAutomation` is an internal test
+oracle for comparing the 1.7 contract; it is not a supported import and may be
+removed after the 1.8 transition without a deprecation period.
+
 ## Persistent Profile
 
 Browser state (cookies, sessions, localStorage) is saved automatically to `~/.co/browser_profile/`. On subsequent runs the browser is already logged into any site you've previously authenticated.

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -14,8 +14,10 @@ Strategy: a StubBrowser stands in for BrowserAutomation so no real Chrome/Playwr
 or network is needed. The daemon's lazy BrowserAutomation is swapped for the stub.
 """
 
+import asyncio
 import contextlib
 import io
+import json as _json
 import os
 import shlex
 import socket
@@ -27,9 +29,10 @@ from unittest.mock import Mock
 
 import pytest
 
-from connectonion.cli.browser_agent import daemon as d
 from connectonion.cli.browser_agent import client as c
+from connectonion.cli.browser_agent import daemon as d
 from connectonion.cli.browser_agent import transport as tp
+from connectonion.useful_tools.browser_tools._async_browser import AsyncBrowserCore
 
 IS_WINDOWS = tp.IS_WINDOWS
 posix_only = pytest.mark.skipif(IS_WINDOWS, reason="exercises the raw AF_UNIX socket mechanism (POSIX)")
@@ -437,6 +440,7 @@ def test_handle_browser_help_needs_no_browser(capsys):
 def test_next_tip_rotates(tmp_path, monkeypatch):
     """Each run surfaces the next tip; the index wraps around and persists in ~/.co."""
     import pathlib
+
     from connectonion.cli.commands import browser_commands as bc
 
     monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
@@ -464,6 +468,7 @@ def test_tip_hidden_when_not_a_tty(monkeypatch, capsys):
 def test_tip_shown_on_success_tty(tmp_path, monkeypatch, capsys):
     """On an interactive terminal a successful command appends a rotating tip."""
     import pathlib
+
     from connectonion.cli.commands import browser_commands as bc
 
     monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
@@ -542,6 +547,22 @@ def test_socket_round_trip(short_sock, monkeypatch, capsys):
     assert code == 0
     assert out == "Navigated to example.com"
     assert daemon.browser.calls == [("go_to", "example.com")]
+
+
+def test_close_stops_a_fresh_async_daemon_without_launching_chrome(short_sock, monkeypatch):
+    """The real async core returns a longer close message than the old stub."""
+    monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
+    daemon = d.BrowserDaemon(short_sock, headless=True)
+    server = threading.Thread(target=daemon.serve, daemon=True)
+    server.start()
+    _wait_until_listening(short_sock)
+
+    code, payload = c._request("close", headless=True)
+
+    assert code == 0
+    assert payload.startswith("Browser closed")
+    server.join(timeout=2)
+    assert not server.is_alive()
 
 
 def test_do_model_wait_does_not_hold_the_daemon_lane(short_sock, monkeypatch):
@@ -700,8 +721,6 @@ def test_launch_failure_message_is_actionable(short_sock, monkeypatch, capsys):
 
 
 # --- the -t / tab noun grammar (one task = one tab) ---
-
-import json as _json
 
 
 def _env(line, caller="", tab=None, account=""):
@@ -999,6 +1018,7 @@ def test_do_instruction_is_not_quote_mangled(monkeypatch):
     """Fix: the NL instruction was re-derived from the shlex-joined line, leaking quotes.
     A multi-word instruction must reach the agent as clean text."""
     import shlex as _shlex
+
     from connectonion.cli.browser_agent import agent as agent_module
 
     captured = {}
@@ -1163,7 +1183,8 @@ def test_close_reserved_tab_before_browser_launch_forgets_it(tmp_path):
 
     ok, _ = daemon.dispatch(_env("tab open research", caller="agent-b"))
     assert ok is True                                       # name free immediately
-    daemon.browser._executor.shutdown(wait=False)
+    # The 1.8 daemon owns the asyncio core directly; there is deliberately no
+    # synchronous one-worker executor left to shut down in this no-launch test.
 
 
 def test_newtab_with_tab_target_is_rejected(tmp_path):
@@ -1196,11 +1217,11 @@ def test_bind_holds_an_exclusive_lock_for_life(short_sock):
     fresh_lock.close()
 
 
-# ---- concurrency: many clients, one single-threaded daemon ----------------
+# ---- concurrency: many clients, one asyncio-owned daemon ------------------
 
 def test_concurrent_clients_are_all_served(short_sock, monkeypatch):
-    """8 clients firing at once against the single-threaded daemon: every request
-    must be served (queued, not dropped or deadlocked) and every reply delivered.
+    """8 clients firing at once against the asyncio daemon: every request
+    must be served (bounded, not dropped or deadlocked) and every reply delivered.
     On Windows this drives real named-pipe contention (mpc PIPE_BUSY waits); on
     POSIX the AF_UNIX accept backlog. This is the multi-agent daily reality."""
     monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
@@ -1220,6 +1241,153 @@ def test_concurrent_clients_are_all_served(short_sock, monkeypatch):
 
     assert len(codes) == 8 and all(code == 0 for code in codes)
     assert len(daemon.browser.calls) == 8  # nothing dropped under contention
+
+
+class AsyncSocketBrowser(AsyncBrowserCore):
+    """Real per-tab scheduling, with no Chrome needed for transport E2E."""
+
+    def __init__(self):
+        super().__init__(headless=True)
+        self.intervals = []
+        self.started = threading.Event()
+
+    async def slow(self, seconds: float = 0.2) -> str:
+        async with self._tab_operation(ensure_page=False):
+            key = self._bound_session_key()
+            start = time.monotonic()
+            self.started.set()
+            try:
+                await asyncio.sleep(seconds)
+            finally:
+                self.intervals.append((key, start, time.monotonic()))
+            return f"finished {key}"
+
+
+def test_independent_tabs_overlap_through_the_native_transport(short_sock, monkeypatch):
+    """The issue's end-to-end claim: concurrency survives the actual IPC boundary."""
+    monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
+    monkeypatch.setattr(c, "_caller", lambda: threading.current_thread().name)
+    daemon = make_daemon(short_sock, stub=AsyncSocketBrowser())
+    assert daemon.dispatch(_env("tab open left", caller="left-agent"))[0] is True
+    assert daemon.dispatch(_env("tab open right", caller="right-agent"))[0] is True
+    server = threading.Thread(target=daemon.serve, daemon=True)
+    server.start()
+    _wait_until_listening(short_sock)
+
+    replies = []
+
+    def drive(tab):
+        replies.append(c._request("slow 0.2", headless=True, tab=tab))
+
+    workers = [
+        threading.Thread(target=drive, name="left-agent", args=("left",)),
+        threading.Thread(target=drive, name="right-agent", args=("right",)),
+    ]
+    started = time.monotonic()
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=3)
+    elapsed = time.monotonic() - started
+
+    assert sorted(code for code, _ in replies) == [0, 0]
+    assert elapsed < 1.5, "parallel clients did not finish promptly"
+    left, right = daemon.browser.intervals
+    assert min(left[2], right[2]) > max(left[1], right[1])
+    daemon._cleanup()
+    server.join(timeout=2)
+
+
+def test_same_tab_stays_ordered_through_the_native_transport(short_sock, monkeypatch):
+    monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
+    monkeypatch.setattr(c, "_caller", lambda: "owner")
+    daemon = make_daemon(short_sock, stub=AsyncSocketBrowser())
+    assert daemon.dispatch(_env("tab open work", caller="owner"))[0] is True
+    server = threading.Thread(target=daemon.serve, daemon=True)
+    server.start()
+    _wait_until_listening(short_sock)
+
+    replies = []
+    workers = [
+        threading.Thread(
+            target=lambda: replies.append(
+                c._request("slow 0.08", headless=True, tab="work")
+            )
+        )
+        for _ in range(2)
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=2)
+
+    assert sorted(code for code, _ in replies) == [0, 0]
+    first, second = daemon.browser.intervals
+    assert first[2] <= second[1]
+    daemon._cleanup()
+    server.join(timeout=2)
+
+
+def test_claim_race_through_native_transport_has_one_winner(short_sock, monkeypatch):
+    monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
+    monkeypatch.setattr(c, "_caller", lambda: threading.current_thread().name)
+    daemon = make_daemon(short_sock, stub=AsyncSocketBrowser())
+    server = threading.Thread(target=daemon.serve, daemon=True)
+    server.start()
+    _wait_until_listening(short_sock)
+    gate = threading.Barrier(3)
+    replies = []
+
+    def contend():
+        gate.wait(timeout=2)
+        replies.append(c._request("slow 0.05", headless=True))
+
+    workers = [
+        threading.Thread(target=contend, name="agent-a"),
+        threading.Thread(target=contend, name="agent-b"),
+    ]
+    for worker in workers:
+        worker.start()
+    gate.wait(timeout=2)
+    for worker in workers:
+        worker.join(timeout=2)
+
+    assert sorted(code for code, _ in replies) == [0, 4]
+    assert len(daemon.browser.intervals) == 1
+    assert daemon.browser._tab_meta[None]["caller"] in {"agent-a", "agent-b"}
+    assert "active_requests" not in daemon.browser._tab_meta[None]
+    daemon._cleanup()
+    server.join(timeout=2)
+
+
+def test_disconnect_does_not_orphan_the_active_request_lease(short_sock, monkeypatch):
+    monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
+    browser = AsyncSocketBrowser()
+    daemon = make_daemon(short_sock, stub=browser)
+    assert daemon.dispatch(_env("tab open work", caller="owner"))[0] is True
+    server = threading.Thread(target=daemon.serve, daemon=True)
+    server.start()
+    _wait_until_listening(short_sock)
+
+    conn = c._connect(short_sock)
+    request = _env("slow 0.05", caller="owner", tab="work").encode()
+    if IS_WINDOWS:
+        conn.send_bytes(request)
+    else:
+        conn.sendall(request)
+        conn.shutdown(socket.SHUT_WR)
+    conn.close()  # disappear before the reply
+
+    assert browser.started.wait(timeout=1)
+    deadline = time.time() + 2
+    while time.time() < deadline and "active_requests" in browser._tab_meta["work"]:
+        time.sleep(0.01)
+    meta = browser._tab_meta["work"]
+    assert "active_requests" not in meta
+    assert meta["caller"] == "owner"
+    assert browser._active_operations == 0
+    daemon._cleanup()
+    server.join(timeout=2)
 
 
 def test_second_daemon_yields_at_the_singleton_lock(short_sock, monkeypatch):

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -36,6 +36,30 @@ from connectonion.useful_tools.browser_tools._async_browser import AsyncBrowserC
 
 IS_WINDOWS = tp.IS_WINDOWS
 posix_only = pytest.mark.skipif(IS_WINDOWS, reason="exercises the raw AF_UNIX socket mechanism (POSIX)")
+_CREATED_DAEMONS = []
+
+
+@pytest.fixture(autouse=True)
+def stop_created_daemons():
+    """Every test-created daemon must release its loop and Windows worker pool.
+
+    The server thread is daemonized in these socket tests, but the bounded named-
+    pipe executor deliberately is not. Letting a test return without stopping its
+    daemon therefore leaves pytest alive forever on Windows even though all tests
+    passed. Keep cleanup centralized so assertion failures take the same path.
+    """
+    start = len(_CREATED_DAEMONS)
+    yield
+    created = _CREATED_DAEMONS[start:]
+    del _CREATED_DAEMONS[start:]
+    for daemon in reversed(created):
+        daemon._cleanup()
+    deadline = time.time() + 5
+    while time.time() < deadline and any(
+        daemon._transport_pool is not None for daemon in created
+    ):
+        time.sleep(0.01)
+    assert all(daemon._transport_pool is None for daemon in created)
 
 
 @pytest.fixture
@@ -159,6 +183,7 @@ def make_daemon(sock_path, stub=None):
     """Build a daemon whose lazy BrowserAutomation is replaced by a stub."""
     daemon = d.BrowserDaemon(sock_path, headless=True)
     daemon.browser = stub or StubBrowser()
+    _CREATED_DAEMONS.append(daemon)
     return daemon
 
 

--- a/tests/e2e/cli/test_browser_stealth_e2e.py
+++ b/tests/e2e/cli/test_browser_stealth_e2e.py
@@ -13,8 +13,8 @@ skip cleanly in a plain CI shell with no DISPLAY, and skip an individual site if
 third party is down (5xx / unreachable) rather than failing on someone else's outage.
 """
 
-import os
 import json
+import os
 import platform
 import re
 import statistics
@@ -56,8 +56,8 @@ def stealth_browser():
 
 
 def _eval(browser, js):
-    """Evaluate JS on the browser worker thread (the page is thread-bound)."""
-    return browser._executor.submit(lambda: browser.page.evaluate(js)).result()
+    """Evaluate JS on the async-core runtime thread (the page is loop-bound)."""
+    return browser._run_on_runtime(lambda core: core.page.evaluate(js))
 
 
 def _text(browser):

--- a/tests/e2e/cli/test_cli_help.py
+++ b/tests/e2e/cli/test_cli_help.py
@@ -58,6 +58,7 @@ class TestCliHelp:
         assert "status" in result.output
         assert "reset" in result.output
         assert "browser" in result.output
+        assert "remote-browser" in result.output
         assert "Commands" in result.output
 
     def test_version_flag(self):

--- a/tests/e2e/cli/test_remote_browser_daemon.py
+++ b/tests/e2e/cli/test_remote_browser_daemon.py
@@ -1,14 +1,20 @@
 """Remote Browser lifecycle through the real native daemon transport."""
 
+import asyncio
 import contextlib
+import json
 import os
 import threading
 import time
 
+from connectonion import address
 from connectonion.cli.browser_agent import transport
 from connectonion.cli.browser_agent.client import request_as
 from connectonion.cli.browser_agent.daemon import BrowserDaemon
+from connectonion.network.connect import RemoteAgent
 from connectonion.network.host.remote_browser import RemoteBrowserService
+from connectonion.network.host.server import _make_remote_browser
+from connectonion.network.host.ws_router import session as ws_session
 
 
 class LifecycleBrowser:
@@ -27,6 +33,70 @@ class LifecycleBrowser:
 
     def close(self):
         return "Browser closed"
+
+
+class ContactTrust:
+    def is_admin(self, owner):
+        return False
+
+    def get_level(self, owner):
+        return "contact"
+
+
+async def _signed_start(service, monkeypatch):
+    keys = address.generate()
+    host = "0x" + "12" * 20
+    command = RemoteAgent(host, keys=keys)._build_command_message(
+        {
+            "type": "REMOTE_BROWSER",
+            "request_id": "native-start",
+            "command": "start",
+            "args": {"headless": True, "proxy": "direct"},
+        },
+        is_direct=True,
+    )
+    frames = [{"type": "CONNECT", "from": keys["address"]}, command]
+    result_sent = asyncio.Event()
+    sent = []
+
+    async def fake_connect(data, send, conn, *args):
+        conn.update(
+            authenticated=True,
+            agent_address=keys["address"],
+            signed_commands=True,
+            recipient_address=host,
+            session_id="native-oip",
+        )
+
+    async def recv():
+        if frames:
+            return frames.pop(0)
+        await result_sent.wait()
+        return None
+
+    async def send(message):
+        sent.append(message)
+        if message.get("type") == "REMOTE_BROWSER_RESULT":
+            result_sent.set()
+
+    monkeypatch.setattr(ws_session, "handle_connect", fake_connect)
+    await ws_session.run_ws_session(
+        send,
+        recv,
+        route_handlers={
+            "remote_browser": _make_remote_browser(service, ContactTrust()),
+        },
+        storage=None,
+        registry=None,
+        trust=None,
+        enable_ping=False,
+        transport="direct",
+    )
+    result = next(
+        message for message in sent if message.get("type") == "REMOTE_BROWSER_RESULT"
+    )
+    assert json.loads(json.dumps(result))["request_id"] == "native-start"
+    return result, keys["address"]
 
 
 def _wait_for_daemon(socket_path):
@@ -51,18 +121,11 @@ def test_remote_lifecycle_uses_one_native_daemon_and_survives_host_restart(
         _wait_for_daemon(socket_path)
         state_path = tmp_path / "remote-browser-sessions.json"
         service = RemoteBrowserService(state_path, daemon_request=request_as)
-        started = service.handle(
-            {
-                "request_id": "native-start",
-                "command": "start",
-                "args": {"headless": True, "proxy": "direct"},
-            },
-            owner="0xowner",
-            transport="direct",
-        )
+        started, owner = asyncio.run(_signed_start(service, monkeypatch))
         assert started["ok"] is True
         session_id = started["result"]["session_id"]
         assert len(daemon.browser._tab_meta) == 1
+        assert next(iter(daemon.browser._tab_meta.values()))["opened_by"] == owner
 
         restarted_host_service = RemoteBrowserService(
             state_path, daemon_request=request_as
@@ -73,7 +136,7 @@ def test_remote_lifecycle_uses_one_native_daemon_and_survives_host_restart(
                 "command": "status",
                 "session_id": session_id,
             },
-            owner="0xowner",
+            owner=owner,
             transport="direct",
         )
         assert status["state"]["session"] == "active"
@@ -84,7 +147,7 @@ def test_remote_lifecycle_uses_one_native_daemon_and_survives_host_restart(
                 "command": "stop",
                 "session_id": session_id,
             },
-            owner="0xowner",
+            owner=owner,
             transport="direct",
         )
         assert stopped["state"]["session"] == "stopped"

--- a/tests/e2e/cli/test_remote_browser_daemon.py
+++ b/tests/e2e/cli/test_remote_browser_daemon.py
@@ -1,0 +1,102 @@
+"""Remote Browser lifecycle through the real native daemon transport."""
+
+import contextlib
+import os
+import threading
+import time
+
+from connectonion.cli.browser_agent import transport
+from connectonion.cli.browser_agent.client import request_as
+from connectonion.cli.browser_agent.daemon import BrowserDaemon
+from connectonion.network.host.remote_browser import RemoteBrowserService
+
+
+class LifecycleBrowser:
+    """Small runtime seam: the test targets transport/claims, not Chrome."""
+
+    def __init__(self):
+        self._tab_meta = {}
+        self._pages = {}
+
+    def _bind_session(self, session):
+        self.session = session
+
+    def close_tab(self, name):
+        self._tab_meta.pop(name, None)
+        return f"Closed tab {name}"
+
+    def close(self):
+        return "Browser closed"
+
+
+def _wait_for_daemon(socket_path):
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        if os.path.exists(transport.pid_path(socket_path)):
+            return
+        time.sleep(0.02)
+    raise RuntimeError("daemon did not bind in time")
+
+
+def test_remote_lifecycle_uses_one_native_daemon_and_survives_host_restart(
+    tmp_path, monkeypatch
+):
+    socket_path = f"/tmp/co_remote_{os.getpid()}_{time.time_ns()}.sock"
+    monkeypatch.setenv("CO_BROWSER_SOCK", socket_path)
+    daemon = BrowserDaemon(socket_path, headless=True)
+    daemon.browser = LifecycleBrowser()
+    thread = threading.Thread(target=daemon.serve, daemon=True)
+    thread.start()
+    try:
+        _wait_for_daemon(socket_path)
+        state_path = tmp_path / "remote-browser-sessions.json"
+        service = RemoteBrowserService(state_path, daemon_request=request_as)
+        started = service.handle(
+            {
+                "request_id": "native-start",
+                "command": "start",
+                "args": {"headless": True, "proxy": "direct"},
+            },
+            owner="0xowner",
+            transport="direct",
+        )
+        assert started["ok"] is True
+        session_id = started["result"]["session_id"]
+        assert len(daemon.browser._tab_meta) == 1
+
+        restarted_host_service = RemoteBrowserService(
+            state_path, daemon_request=request_as
+        )
+        status = restarted_host_service.handle(
+            {
+                "request_id": "native-status",
+                "command": "status",
+                "session_id": session_id,
+            },
+            owner="0xowner",
+            transport="direct",
+        )
+        assert status["state"]["session"] == "active"
+
+        stopped = restarted_host_service.handle(
+            {
+                "request_id": "native-stop",
+                "command": "stop",
+                "session_id": session_id,
+            },
+            owner="0xowner",
+            transport="direct",
+        )
+        assert stopped["state"]["session"] == "stopped"
+        assert daemon.browser._tab_meta == {}
+    finally:
+        daemon._cleanup()
+        thread.join(timeout=2)
+        for path in (
+            socket_path,
+            transport.pid_path(socket_path),
+            transport.lock_path(socket_path),
+        ):
+            with contextlib.suppress(OSError):
+                if os.path.exists(path):
+                    os.unlink(path)

--- a/tests/e2e/test_a_dead_context_is_not_reported_open.py
+++ b/tests/e2e/test_a_dead_context_is_not_reported_open.py
@@ -49,7 +49,9 @@ closes it.
 
 import pytest
 
-from connectonion.useful_tools.browser_tools.browser import BrowserAutomation
+from connectonion.useful_tools.browser_tools.browser import (
+    LegacyBrowserAutomation as BrowserAutomation,
+)
 
 
 try:

--- a/tests/e2e/test_async_browser_daemon_real_driver.py
+++ b/tests/e2e/test_async_browser_daemon_real_driver.py
@@ -1,0 +1,116 @@
+"""Installed/native acceptance for #499's complete daemon-to-driver path.
+
+Run explicitly with the slow gate:
+
+    python -m pytest tests/e2e/test_async_browser_daemon_real_driver.py -m slow -q
+"""
+
+import contextlib
+import json
+import os
+import shlex
+import threading
+import time
+import urllib.parse
+
+import pytest
+
+from connectonion.cli.browser_agent import client, daemon, transport
+from connectonion.useful_tools.browser_tools._async_browser import (
+    ASYNC_BROWSER_AVAILABLE,
+    AsyncBrowserCore,
+)
+
+
+def endpoint() -> str:
+    nonce = f"{os.getpid()}_{time.time_ns()}"
+    if transport.IS_WINDOWS:
+        return rf"\\.\pipe\co_async_native_{nonce}"
+    return f"/tmp/co_async_native_{nonce}.sock"
+
+
+@pytest.mark.slow
+def test_real_daemon_keeps_a_second_tab_live_during_a_long_operation(
+    tmp_path, monkeypatch
+):
+    if not ASYNC_BROWSER_AVAILABLE:
+        pytest.skip("patchright async API is not installed")
+
+    address = endpoint()
+    monkeypatch.setenv("CO_BROWSER_SOCK", address)
+    monkeypatch.setenv("CO_BROWSER_PROFILE_DIR", str(tmp_path / "profile"))
+    monkeypatch.setattr(client, "_caller", lambda: "native-owner")
+    server = daemon.BrowserDaemon(address, headless=True)
+    server.browser = AsyncBrowserCore(
+        headless=True,
+        use_mock_keychain=True,
+    )
+    thread = threading.Thread(target=server.serve, daemon=True)
+    thread.start()
+
+    try:
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            if os.path.exists(transport.pid_path(address)):
+                break
+            time.sleep(0.02)
+        else:
+            raise AssertionError("daemon did not bind")
+
+        for tab, marker in (("slow", "alpha"), ("live", "beta")):
+            assert client._request(f"tab open {tab}", headless=True)[0] == 0
+            url = "data:text/html," + urllib.parse.quote(
+                f"<title>{marker}</title><main>{marker} page</main>"
+            )
+            code, payload = client._request(
+                shlex.join(["go_to", url]), headless=True, tab=tab
+            )
+            assert code == 0, payload
+
+        waiting = []
+        worker = threading.Thread(
+            target=lambda: waiting.append(
+                client._request("wait 2", headless=True, tab="slow")
+            )
+        )
+        worker.start()
+
+        deadline = time.time() + 2
+        while time.time() < deadline:
+            code, payload = client._request("tab ls --json", headless=True)
+            assert code == 0, payload
+            slow = next(item for item in json.loads(payload) if item["tab"] == "slow")
+            if slow["active_requests"]:
+                break
+            time.sleep(0.02)
+        else:
+            raise AssertionError("long operation never became active")
+
+        started = time.monotonic()
+        code, payload = client._request("get_text", headless=True, tab="live")
+        elapsed = time.monotonic() - started
+
+        assert code == 0, payload
+        assert "beta page" in payload
+        assert elapsed < 1.0
+        assert (
+            worker.is_alive()
+        ), "the live-tab read waited for the two-second operation"
+        worker.join(timeout=3)
+        assert waiting == [(0, "Waited for 2.0 seconds")]
+
+        code, payload = client._request("close", headless=True)
+        assert code == 0, payload
+        thread.join(timeout=3)
+        assert not thread.is_alive()
+    finally:
+        server._cleanup()
+        thread.join(timeout=3)
+        for path in (
+            address,
+            transport.pid_path(address),
+            transport.lock_path(address),
+        ):
+            with contextlib.suppress(OSError):
+                if os.path.exists(path):
+                    os.unlink(path)

--- a/tests/unit/test_a_server_with_no_display_runs_headless.py
+++ b/tests/unit/test_a_server_with_no_display_runs_headless.py
@@ -94,7 +94,7 @@ class TestTheBrowserItselfHonoursIt:
         try:
             assert automation._headless is True
         finally:
-            automation._executor.shutdown(wait=False)
+            automation.close()
 
     @pytest.mark.skipif(platform.system() != "Darwin", reason="desktop-only claim")
     def test_a_desktop_still_gets_a_window(self):
@@ -102,7 +102,7 @@ class TestTheBrowserItselfHonoursIt:
         try:
             assert automation._headless is False
         finally:
-            automation._executor.shutdown(wait=False)
+            automation.close()
 
 
 # The advice for a launch failure is not tested here. It moved to

--- a/tests/unit/test_async_browser_core.py
+++ b/tests/unit/test_async_browser_core.py
@@ -1,8 +1,8 @@
 """Contract tests for the internal 1.8 Patchright async browser core.
 
-The public synchronous BrowserAutomation remains unchanged until #500. These
-tests prove the new core itself is genuinely async, preserves per-session tabs,
-and cleans up deterministically before #499 puts concurrent IPC in front of it.
+The public synchronous BrowserAutomation delegates through the #500 facade. These
+tests prove the underlying core itself is genuinely async, preserves per-session
+tabs, and cleans up deterministically behind #499's concurrent IPC.
 """
 
 import ast

--- a/tests/unit/test_async_browser_daemon.py
+++ b/tests/unit/test_async_browser_daemon.py
@@ -229,3 +229,59 @@ async def test_connection_cap_sheds_excess_without_spawning_more_work(daemon):
     for task in blockers:
         task.cancel()
     await asyncio.gather(*blockers, return_exceptions=True)
+
+
+class WakeConnection:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_windows_shutdown_discards_the_connection_that_wakes_accept(
+    daemon, monkeypatch
+):
+    connection = WakeConnection()
+
+    async def accepted(_fn):
+        daemon._closing = True
+        return connection
+
+    monkeypatch.setattr(daemon, "_transport_call", accepted)
+
+    await daemon._serve_windows()
+
+    assert connection.closed is True
+    assert daemon._client_tasks == set()
+
+
+def test_windows_shutdown_wakes_accept_before_closing_the_listener(
+    daemon, monkeypatch
+):
+    submitted = []
+
+    class Loop:
+        def run_in_executor(self, pool, fn):
+            submitted.append((pool, fn))
+
+    class Listener:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    listener = Listener()
+    pool = object()
+    daemon._loop = Loop()
+    daemon._transport_pool = pool
+    daemon._srv = listener
+    monkeypatch.setattr(daemon_module.transport, "IS_WINDOWS", True)
+
+    daemon._begin_shutdown()
+
+    assert daemon._closing is True
+    assert listener.closed is False
+    assert submitted == [(pool, daemon._wake_windows_accept)]

--- a/tests/unit/test_async_browser_daemon.py
+++ b/tests/unit/test_async_browser_daemon.py
@@ -1,0 +1,231 @@
+"""Concurrency contract for the 1.8 browser daemon.
+
+The wire may accept many clients at once, but one asyncio-owned browser runtime
+decides what can overlap: independent tabs progress together, one tab is ordered,
+and a claim race has exactly one winner.  Cancellation must remove only the
+request-scoped audit lease; durable tab ownership remains governed by the
+existing guard/declared-hold rules.
+"""
+
+import asyncio
+import json
+import time
+
+import pytest
+
+from connectonion.cli.browser_agent import daemon as daemon_module
+from connectonion.cli.browser_agent.daemon import BrowserDaemon
+from connectonion.useful_tools.browser_tools._async_browser import AsyncBrowserCore
+
+
+def envelope(line: str, *, caller: str, tab: str | None = None) -> str:
+    return json.dumps(
+        {"v": 1, "caller": caller, "account": "", "tab": tab, "line": line}
+    )
+
+
+class TimedBrowser(AsyncBrowserCore):
+    """No-driver probe that uses the real core's operation and tab locks."""
+
+    def __init__(self):
+        super().__init__(headless=True)
+        self.intervals: list[tuple[str | None, float, float]] = []
+        self.started = asyncio.Event()
+
+    async def slow(self, seconds: float = 0.1) -> str:
+        async with self._tab_operation(ensure_page=False):
+            key = self._bound_session_key()
+            start = time.monotonic()
+            self.started.set()
+            try:
+                await asyncio.sleep(seconds)
+            finally:
+                self.intervals.append((key, start, time.monotonic()))
+            return f"finished {key}"
+
+
+@pytest.fixture
+def daemon(tmp_path):
+    server = BrowserDaemon(str(tmp_path / "browser.sock"), headless=True)
+    server.browser = TimedBrowser()
+    return server
+
+
+def test_daemon_owns_async_core_without_global_browser_executor(tmp_path):
+    server = BrowserDaemon(str(tmp_path / "browser.sock"), headless=True)
+
+    assert isinstance(server.browser, AsyncBrowserCore)
+    assert not hasattr(server.browser, "_executor")
+
+
+async def open_tab(server: BrowserDaemon, name: str, caller: str) -> None:
+    ok, payload = await server.dispatch_async(
+        envelope(f"tab open {name} --who {caller}", caller=caller)
+    )
+    assert ok is True, payload
+
+
+@pytest.mark.asyncio
+async def test_independent_tabs_make_progress_concurrently(daemon):
+    await open_tab(daemon, "left", "left-agent")
+    await open_tab(daemon, "right", "right-agent")
+
+    started = time.monotonic()
+    results = await asyncio.gather(
+        daemon.dispatch_async(envelope("slow 0.15", caller="left-agent", tab="left")),
+        daemon.dispatch_async(envelope("slow 0.15", caller="right-agent", tab="right")),
+    )
+    elapsed = time.monotonic() - started
+
+    assert [result[0] for result in results] == [True, True]
+    assert elapsed < 0.26, "independent tabs were serialized by a global lane"
+    left, right = daemon.browser.intervals
+    assert min(left[2], right[2]) > max(left[1], right[1]), "operations did not overlap"
+
+
+@pytest.mark.asyncio
+async def test_same_tab_operations_are_serialized(daemon):
+    await open_tab(daemon, "only", "agent")
+
+    started = time.monotonic()
+    results = await asyncio.gather(
+        daemon.dispatch_async(envelope("slow 0.1", caller="agent", tab="only")),
+        daemon.dispatch_async(envelope("slow 0.1", caller="agent", tab="only")),
+    )
+    elapsed = time.monotonic() - started
+
+    assert [result[0] for result in results] == [True, True]
+    assert elapsed >= 0.18
+    first, second = daemon.browser.intervals
+    assert first[2] <= second[1]
+
+
+@pytest.mark.asyncio
+async def test_two_callers_racing_for_main_have_one_auditable_winner(daemon):
+    gate = asyncio.Event()
+
+    async def contend(caller: str):
+        await gate.wait()
+        return await daemon.dispatch_async(envelope("slow 0.05", caller=caller))
+
+    tasks = [
+        asyncio.create_task(contend("agent-a")),
+        asyncio.create_task(contend("agent-b")),
+    ]
+    gate.set()
+    results = await asyncio.gather(*tasks)
+
+    outcomes = [0 if result[0] is True else result[0] for result in results]
+    assert sorted(outcomes) == [0, 4]
+    assert len(daemon.browser.intervals) == 1
+    meta = daemon.browser._tab_meta[None]
+    assert meta["caller"] in {"agent-a", "agent-b"}
+    assert meta["last_line"] == "slow 0.05"
+    assert "active_requests" not in meta
+
+
+@pytest.mark.asyncio
+async def test_cancelled_request_clears_only_its_active_lease(daemon):
+    task = asyncio.create_task(
+        daemon.dispatch_async(envelope("slow 30", caller="owner"))
+    )
+    await daemon.browser.started.wait()
+
+    meta = daemon.browser._tab_meta[None]
+    assert len(meta["active_requests"]) == 1
+    ok, payload = await daemon.dispatch_async(
+        envelope("tab ls --json", caller="observer")
+    )
+    assert ok is True
+    active = json.loads(payload)[0]["active_requests"]
+    assert len(active) == 1
+    assert active[0]["caller"] == "owner"
+    assert active[0]["line"] == "slow 30"
+    assert active[0]["request_id"]
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert "active_requests" not in meta
+    assert meta["caller"] == "owner", "cancellation erased durable ownership"
+    assert daemon.browser._active_operations == 0
+    assert daemon.browser._operations_idle.is_set()
+
+
+@pytest.mark.asyncio
+async def test_request_reader_rejects_oversized_payload(daemon, monkeypatch):
+    monkeypatch.setattr(daemon_module, "MAX_REQUEST_BYTES", 32)
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"x" * 33)
+    reader.feed_eof()
+
+    with pytest.raises(ValueError, match="32-byte limit"):
+        await daemon._read_posix_request(reader)
+
+
+@pytest.mark.asyncio
+async def test_request_deadline_bounds_a_stalled_client(daemon, monkeypatch):
+    monkeypatch.setattr(daemon_module, "REQUEST_TIMEOUT", 0.02)
+    reader = asyncio.StreamReader()
+
+    with pytest.raises(TimeoutError, match="request timed out"):
+        await daemon._read_posix_request(reader)
+
+
+class FakeTransport:
+    def __init__(self):
+        self.aborted = False
+
+    def abort(self):
+        self.aborted = True
+
+
+class BlockingWriter:
+    def __init__(self):
+        self.transport = FakeTransport()
+        self.payload = b""
+        self.closed = False
+
+    def write(self, payload: bytes):
+        self.payload += payload
+
+    async def drain(self):
+        await asyncio.Future()
+
+    def close(self):
+        self.closed = True
+
+    async def wait_closed(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_slow_reader_cannot_hold_a_connection_forever(daemon, monkeypatch):
+    monkeypatch.setattr(daemon_module, "REPLY_TIMEOUT", 0.02)
+    reader = asyncio.StreamReader()
+    reader.feed_data(envelope("status", caller="observer").encode())
+    reader.feed_eof()
+    writer = BlockingWriter()
+
+    await daemon._handle_posix_client(reader, writer)
+
+    assert writer.payload.startswith(b"OK\n")
+    assert writer.closed is True
+
+
+@pytest.mark.asyncio
+async def test_connection_cap_sheds_excess_without_spawning_more_work(daemon):
+    blockers = {
+        asyncio.create_task(asyncio.sleep(30))
+        for _ in range(daemon_module.MAX_IN_FLIGHT)
+    }
+    daemon._client_tasks.update(blockers)
+    writer = BlockingWriter()
+
+    daemon._accept_posix_client(asyncio.StreamReader(), writer)
+
+    assert writer.transport.aborted is True
+    assert daemon._client_tasks == blockers
+    for task in blockers:
+        task.cancel()
+    await asyncio.gather(*blockers, return_exceptions=True)

--- a/tests/unit/test_browser_automation.py
+++ b/tests/unit/test_browser_automation.py
@@ -95,7 +95,7 @@ def test_open_browser_is_noop_when_context_is_already_open(monkeypatch, tmp_path
     monkeypatch.setattr(browser_mod, "sync_playwright", lambda: FakeSyncPlaywright())
     monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
 
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
 
     first_result = browser.open_browser()
     first_context = contexts[0]
@@ -142,7 +142,7 @@ def test_open_browser_force_reopens_existing_context(monkeypatch, tmp_path):
     monkeypatch.setattr(browser_mod, "sync_playwright", lambda: FakeSyncPlaywright())
     monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
 
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
     browser.open_browser()
     first_context = contexts[0]
     first_page = first_context.page
@@ -187,7 +187,7 @@ def test_open_browser_reopens_stale_context(monkeypatch, tmp_path):
     monkeypatch.setattr(browser_mod, "sync_playwright", lambda: FakeSyncPlaywright())
     monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
 
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
     browser.open_browser()
     first_context = contexts[0]
     first_page = first_context.page
@@ -205,7 +205,7 @@ def test_open_browser_reopens_stale_context(monkeypatch, tmp_path):
 
 
 def test_close_reports_cleanup_warnings_and_clears_state():
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
     page = FakePage()
     page.close()
     context = FakeContext()
@@ -272,7 +272,7 @@ def test_seed_state_injects_exported_cookies(monkeypatch, tmp_path):
     monkeypatch.setattr(browser_mod, "sync_playwright", lambda: _recording_playwright(contexts))
     monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
 
-    browser = browser_mod.BrowserAutomation(headless=True, seed_state=str(state))
+    browser = browser_mod.LegacyBrowserAutomation(headless=True, seed_state=str(state))
     browser.open_browser()
 
     assert contexts[0].added_cookies == cookies
@@ -284,7 +284,7 @@ def test_no_seed_state_injects_nothing(monkeypatch, tmp_path):
     monkeypatch.setattr(browser_mod, "sync_playwright", lambda: _recording_playwright(contexts))
     monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
 
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
     browser.open_browser()
 
     assert contexts[0].added_cookies is None
@@ -296,7 +296,7 @@ def test_save_state_exports_storage_state_to_path(monkeypatch, tmp_path):
     monkeypatch.setattr(browser_mod, "sync_playwright", lambda: _recording_playwright(contexts))
     monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
 
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
     browser.open_browser()
     out = tmp_path / "exported.json"
     result = browser.save_state(str(out))
@@ -306,7 +306,7 @@ def test_save_state_exports_storage_state_to_path(monkeypatch, tmp_path):
 
 
 def test_save_state_without_browser_reports_not_open():
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
 
     assert browser.save_state("/tmp/whatever.json") == "Browser not open"
 
@@ -321,7 +321,7 @@ def test_wait_for_manual_login_refuses_without_tty(monkeypatch):
 
     monkeypatch.setattr(browser_mod.sys, "stdin", _NoTTY())
 
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
     browser.browser = FakeContext()
     try:
         result = browser.wait_for_manual_login("Example")

--- a/tests/unit/test_browser_close_is_a_lifecycle_barrier.py
+++ b/tests/unit/test_browser_close_is_a_lifecycle_barrier.py
@@ -1,0 +1,70 @@
+"""A successful whole-browser close waits until that daemon has actually exited."""
+
+from connectonion.cli.browser_agent import client
+
+
+class _ReplyConnection:
+    def __init__(self, reply=b"OK\nBrowser closed. Session saved for next time."):
+        self.reply = reply
+
+    def send_bytes(self, request):
+        self.request = request
+
+    def recv_bytes(self):
+        return self.reply
+
+    def close(self):
+        pass
+
+
+def _windows_client(monkeypatch):
+    connection = _ReplyConnection()
+    monkeypatch.setattr(client.transport, "IS_WINDOWS", True)
+    monkeypatch.setattr(client, "default_sock_path", lambda: "pipe")
+    monkeypatch.setattr(client, "_connect", lambda _path: connection)
+    monkeypatch.setattr(client, "_caller_account", lambda: "")
+    monkeypatch.setattr(client, "_owner_pid", lambda _path: 4242)
+    return connection
+
+
+def test_whole_browser_close_waits_for_the_old_daemon_pid(monkeypatch):
+    _windows_client(monkeypatch)
+    alive = iter((True, True, False))
+    checked = []
+    sleeps = []
+
+    def pid_alive(pid):
+        checked.append(pid)
+        return next(alive)
+
+    monkeypatch.setattr(client.transport, "pid_alive", pid_alive)
+    monkeypatch.setattr(client.time, "sleep", sleeps.append)
+
+    assert client._request("close") == (
+        0,
+        "Browser closed. Session saved for next time.",
+    )
+    assert checked == [4242, 4242, 4242]
+    assert sleeps == [0.05, 0.05]
+
+
+def test_targeted_tab_close_does_not_wait_for_daemon_exit(monkeypatch):
+    _windows_client(monkeypatch)
+    checked = []
+    monkeypatch.setattr(
+        client.transport, "pid_alive", lambda pid: checked.append(pid) or True
+    )
+
+    assert client._request("close", tab="work")[0] == 0
+    assert checked == []
+
+
+def test_other_successful_commands_do_not_wait_for_daemon_exit(monkeypatch):
+    _windows_client(monkeypatch)
+    checked = []
+    monkeypatch.setattr(
+        client.transport, "pid_alive", lambda pid: checked.append(pid) or True
+    )
+
+    assert client._request("status")[0] == 0
+    assert checked == []

--- a/tests/unit/test_browser_close_is_a_lifecycle_barrier.py
+++ b/tests/unit/test_browser_close_is_a_lifecycle_barrier.py
@@ -1,5 +1,7 @@
 """A successful whole-browser close waits until that daemon has actually exited."""
 
+import os
+
 from connectonion.cli.browser_agent import client
 
 
@@ -56,6 +58,18 @@ def test_targeted_tab_close_does_not_wait_for_daemon_exit(monkeypatch):
     )
 
     assert client._request("close", tab="work")[0] == 0
+    assert checked == []
+
+
+def test_in_process_embedded_daemon_does_not_wait_for_its_caller(monkeypatch):
+    _windows_client(monkeypatch)
+    monkeypatch.setattr(client, "_owner_pid", lambda _path: os.getpid())
+    checked = []
+    monkeypatch.setattr(
+        client.transport, "pid_alive", lambda pid: checked.append(pid) or True
+    )
+
+    assert client._request("close")[0] == 0
     assert checked == []
 
 

--- a/tests/unit/test_browser_session_pages.py
+++ b/tests/unit/test_browser_session_pages.py
@@ -13,7 +13,9 @@ import threading
 
 import pytest
 
-from connectonion.useful_tools.browser_tools.browser import BrowserAutomation
+from connectonion.useful_tools.browser_tools.browser import (
+    LegacyBrowserAutomation as BrowserAutomation,
+)
 
 # No reset fixture needed: the session binding is owned by each BrowserAutomation
 # instance (per instance, per thread), so a fresh instance per test starts unbound.

--- a/tests/unit/test_browser_tools.py
+++ b/tests/unit/test_browser_tools.py
@@ -1,7 +1,9 @@
 from types import SimpleNamespace
 
 from connectonion.useful_tools.browser_tools import browser as browser_module
-from connectonion.useful_tools.browser_tools.browser import BrowserAutomation
+from connectonion.useful_tools.browser_tools.browser import (
+    LegacyBrowserAutomation as BrowserAutomation,
+)
 
 
 class FakePage:

--- a/tests/unit/test_cli_remote_browser.py
+++ b/tests/unit/test_cli_remote_browser.py
@@ -1,0 +1,99 @@
+"""CLI contract tests for ``co remote-browser``."""
+
+import json
+import importlib
+
+from connectonion.cli.commands.remote_browser_commands import handle_remote_browser
+
+
+class FakeRemote:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    def remote_browser(self, command, **kwargs):
+        self.calls.append((command, kwargs))
+        return self.result
+
+
+def _result(ok=True, **extra):
+    value = {
+        "schema_version": "1",
+        "ok": ok,
+        "command": "remote-browser.start",
+        "request_id": "req-1",
+        "summary": "Remote browser session started.",
+        "result": {"session_id": "rb_" + "1" * 32, "status": "active"},
+        "state": {"session": "active"},
+        "tips": [],
+        "warnings": [],
+        "next_actions": [],
+    }
+    value.update(extra)
+    return value
+
+
+def _install(monkeypatch, result):
+    remote = FakeRemote(result)
+    monkeypatch.setattr("connectonion.connect", lambda address, **kwargs: remote)
+    connect_module = importlib.import_module("connectonion.network.connect")
+    monkeypatch.setattr(
+        connect_module, "_this_callers_identity", lambda: {"address": "0xme"}
+    )
+    return remote
+
+
+def test_start_forwards_only_typed_start_options(monkeypatch, capsys):
+    remote = _install(monkeypatch, _result())
+
+    assert handle_remote_browser(["--headed", "--timeout", "5", "0xhost", "start"]) == 0
+
+    assert remote.calls == [
+        (
+            "start",
+            {
+                "session_id": None,
+                "timeout": 5.0,
+                "headless": False,
+                "proxy": "direct",
+            },
+        )
+    ]
+    assert "rb_" in capsys.readouterr().out
+
+
+def test_json_is_the_stable_envelope(monkeypatch, capsys):
+    expected = _result()
+    _install(monkeypatch, expected)
+
+    assert handle_remote_browser(["--json", "0xhost", "start"]) == 0
+
+    assert json.loads(capsys.readouterr().out) == expected
+
+
+def test_session_command_requires_exactly_one_session_id(capsys):
+    assert handle_remote_browser(["0xhost", "status"]) == 2
+    assert "session-id" in capsys.readouterr().err
+
+
+def test_failure_is_exit_one_and_preserves_code(monkeypatch, capsys):
+    _install(
+        monkeypatch,
+        _result(
+            ok=False,
+            code="SECURE_CHANNEL_UNAVAILABLE",
+            message="direct endpoint required",
+        ),
+    )
+
+    assert handle_remote_browser(["0xhost", "sessions"]) == 1
+
+    assert "SECURE_CHANNEL_UNAVAILABLE" in capsys.readouterr().err
+
+
+def test_proxy_option_is_not_accepted_by_non_start_command(monkeypatch):
+    remote = _install(monkeypatch, _result())
+
+    handle_remote_browser(["--proxy", "direct", "0xhost", "sessions"])
+
+    assert remote.calls == [("sessions", {"session_id": None, "timeout": 60.0})]

--- a/tests/unit/test_cli_remote_browser.py
+++ b/tests/unit/test_cli_remote_browser.py
@@ -71,6 +71,16 @@ def test_json_is_the_stable_envelope(monkeypatch, capsys):
     assert json.loads(capsys.readouterr().out) == expected
 
 
+def test_json_validation_failure_emits_only_one_json_envelope(capsys):
+    assert handle_remote_browser(["--json", "0xhost", "status"]) == 2
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+    assert result["ok"] is False
+    assert result["code"] == "INVALID_ARGUMENT"
+    assert captured.err == ""
+
+
 def test_session_command_requires_exactly_one_session_id(capsys):
     assert handle_remote_browser(["0xhost", "status"]) == 2
     assert "session-id" in capsys.readouterr().err

--- a/tests/unit/test_human_jitter.py
+++ b/tests/unit/test_human_jitter.py
@@ -1,0 +1,49 @@
+"""Compatibility tests for human_jitter on the async browser runtime."""
+
+import asyncio
+import importlib
+from types import SimpleNamespace
+
+jitter_module = importlib.import_module("connectonion.useful_plugins.human_jitter")
+
+
+def test_jitter_runs_page_work_on_browser_runtime(monkeypatch):
+    moves = []
+
+    class Mouse:
+        async def move(self, x, y, steps):
+            moves.append((x, y, steps))
+
+    class Page:
+        mouse = Mouse()
+
+        async def evaluate(self, script):
+            assert script == "() => [window.innerWidth, window.innerHeight]"
+            return [1000, 800]
+
+    class Browser:
+        def __init__(self):
+            self.core = SimpleNamespace(page=Page())
+            self.callbacks = 0
+
+        def _run_on_runtime(self, callback):
+            self.callbacks += 1
+            return asyncio.run(callback(self.core))
+
+    async def no_sleep(_delay):
+        pass
+
+    monkeypatch.setattr(jitter_module.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(jitter_module.random, "uniform", lambda start, end: start)
+    monkeypatch.setattr(jitter_module.random, "randint", lambda start, end: start)
+    browser = Browser()
+    agent = SimpleNamespace(
+        current_session={"pending_tool": {"name": "click"}},
+        tools=SimpleNamespace(browserautomation=browser),
+        logger=SimpleNamespace(print=lambda message: None),
+    )
+
+    jitter_module._jitter_before_click(agent)
+
+    assert browser.callbacks == 1
+    assert len(moves) == 3

--- a/tests/unit/test_remote_browser_client.py
+++ b/tests/unit/test_remote_browser_client.py
@@ -47,6 +47,12 @@ class WaitingConnection(FakeConnection):
         super().__init__()
         self.waiting = asyncio.Event()
 
+    async def send(self, raw):
+        frame = json.loads(raw)
+        self.sent.append(frame)
+        if frame["type"] == "CONNECT":
+            self.replies.append({"type": "CONNECTED", "session_id": "oip-1"})
+
     async def recv(self):
         if self.replies:
             return json.dumps(self.replies.pop(0))

--- a/tests/unit/test_remote_browser_client.py
+++ b/tests/unit/test_remote_browser_client.py
@@ -1,5 +1,6 @@
 """RemoteAgent's typed Remote Browser request/response contract."""
 
+import asyncio
 import json
 
 import pytest
@@ -39,6 +40,17 @@ class FakeConnection:
 
     async def __aexit__(self, *args):
         return False
+
+
+class WaitingConnection(FakeConnection):
+    def __init__(self):
+        super().__init__()
+        self.waiting = asyncio.Event()
+
+    async def recv(self):
+        if self.replies:
+            return json.dumps(self.replies.pop(0))
+        await self.waiting.wait()
 
 
 @pytest.mark.asyncio
@@ -87,3 +99,46 @@ async def test_connection_failure_returns_stable_error_envelope(monkeypatch):
     assert result["code"] == "CONNECTION_FAILED"
     assert result["retryable"] is True
     assert result["warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_response_timeout_returns_stable_error_envelope(monkeypatch):
+    remote = RemoteAgent("0x" + "12" * 20, keys=address.generate())
+    connection = WaitingConnection()
+
+    async def no_resolve():
+        return None
+
+    async def open_connection(websockets):
+        return connection, True
+
+    monkeypatch.setattr(remote, "_try_resolve_endpoint", no_resolve)
+    monkeypatch.setattr(remote, "_open_best_connection", open_connection)
+
+    result = await remote.remote_browser_async("sessions", timeout=0.01)
+
+    assert result["ok"] is False
+    assert result["code"] == "TIMEOUT"
+    assert result["retryable"] is True
+
+
+@pytest.mark.asyncio
+async def test_python_cancellation_propagates_without_becoming_a_retry(monkeypatch):
+    remote = RemoteAgent("0x" + "12" * 20, keys=address.generate())
+    connection = WaitingConnection()
+
+    async def no_resolve():
+        return None
+
+    async def open_connection(websockets):
+        return connection, True
+
+    monkeypatch.setattr(remote, "_try_resolve_endpoint", no_resolve)
+    monkeypatch.setattr(remote, "_open_best_connection", open_connection)
+    task = asyncio.create_task(remote.remote_browser_async("sessions", timeout=60))
+    while len(connection.sent) < 2:
+        await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/unit/test_remote_browser_client.py
+++ b/tests/unit/test_remote_browser_client.py
@@ -1,0 +1,89 @@
+"""RemoteAgent's typed Remote Browser request/response contract."""
+
+import json
+
+import pytest
+
+from connectonion import address
+from connectonion.network.connect import RemoteAgent
+
+
+class FakeConnection:
+    def __init__(self):
+        self.sent = []
+        self.replies = []
+
+    async def send(self, raw):
+        frame = json.loads(raw)
+        self.sent.append(frame)
+        if frame["type"] == "CONNECT":
+            self.replies.append({"type": "CONNECTED", "session_id": "oip-1"})
+        elif frame["type"] == "REMOTE_BROWSER":
+            request = frame["payload"]
+            self.replies.append(
+                {
+                    "type": "REMOTE_BROWSER_RESULT",
+                    "schema_version": "1",
+                    "ok": True,
+                    "command": "remote-browser.start",
+                    "request_id": request["request_id"],
+                    "result": {"session_id": "rb_" + "1" * 32},
+                }
+            )
+
+    async def recv(self):
+        return json.dumps(self.replies.pop(0))
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_client_signs_and_correlates_typed_remote_browser_request(monkeypatch):
+    remote = RemoteAgent("0x" + "12" * 20, keys=address.generate())
+    connection = FakeConnection()
+
+    async def no_resolve():
+        return None
+
+    async def open_connection(websockets):
+        return connection, True
+
+    monkeypatch.setattr(remote, "_try_resolve_endpoint", no_resolve)
+    monkeypatch.setattr(remote, "_open_best_connection", open_connection)
+
+    result = await remote.remote_browser_async(
+        "start", timeout=1, headless=True, proxy="direct"
+    )
+
+    request = connection.sent[1]
+    assert request["type"] == request["payload"]["type"] == "REMOTE_BROWSER"
+    assert request["payload"]["command"] == "start"
+    assert request["payload"]["args"] == {"headless": True, "proxy": "direct"}
+    assert request["signature"]
+    assert result["ok"] is True
+    assert result["request_id"] == request["payload"]["request_id"]
+
+
+@pytest.mark.asyncio
+async def test_connection_failure_returns_stable_error_envelope(monkeypatch):
+    remote = RemoteAgent("0x" + "12" * 20, keys=address.generate())
+
+    async def no_resolve():
+        return None
+
+    async def fail_connection(websockets):
+        raise ConnectionRefusedError("host is offline")
+
+    monkeypatch.setattr(remote, "_try_resolve_endpoint", no_resolve)
+    monkeypatch.setattr(remote, "_open_best_connection", fail_connection)
+
+    result = await remote.remote_browser_async("sessions", timeout=1)
+
+    assert result["ok"] is False
+    assert result["code"] == "CONNECTION_FAILED"
+    assert result["retryable"] is True
+    assert result["warnings"] == []

--- a/tests/unit/test_remote_browser_service.py
+++ b/tests/unit/test_remote_browser_service.py
@@ -1,0 +1,186 @@
+import json
+
+from connectonion.network.host.remote_browser import RemoteBrowserService
+
+
+class Daemon:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, line, **identity):
+        self.calls.append((line, identity))
+        tokens = line.split()
+        if tokens[:2] == ["tab", "open"]:
+            return 0, tokens[2]
+        if tokens[:2] == ["tab", "close"]:
+            return 0, f"Closed tab {tokens[2]}"
+        raise AssertionError(line)
+
+
+def service(tmp_path, daemon=None):
+    daemon = daemon or Daemon()
+    return (
+        RemoteBrowserService(
+            tmp_path / "sessions.json", daemon_request=daemon, clock=lambda: 1000
+        ),
+        daemon,
+    )
+
+
+def request(command, request_id="req-1", session_id=None, args=None):
+    value = {"request_id": request_id, "command": command}
+    if session_id is not None:
+        value["session_id"] = session_id
+    if args is not None:
+        value["args"] = args
+    return value
+
+
+def test_start_is_idempotent_and_uses_authenticated_owner(tmp_path):
+    remote, daemon = service(tmp_path)
+    first = remote.handle(
+        request("start", args={"proxy": "direct", "headless": True}),
+        owner="0xalice",
+        transport="direct",
+    )
+    retry = remote.handle(
+        request("start", args={"proxy": "direct", "headless": True}),
+        owner="0xalice",
+        transport="direct",
+    )
+
+    assert first == retry
+    assert first["ok"] is True
+    assert first["result"]["session_id"].startswith("rb_")
+    assert first["result"]["proxy_mode"] == "direct"
+    assert len(daemon.calls) == 1
+    _, identity = daemon.calls[0]
+    assert identity["caller"] == identity["account"] == "0xalice"
+    saved = json.loads((tmp_path / "sessions.json").read_text())
+    assert len(saved["sessions"]) == 1
+    assert "0xalice" not in repr(first)
+
+
+def test_session_id_is_not_authority(tmp_path):
+    remote, _ = service(tmp_path)
+    started = remote.handle(request("start"), owner="0xalice", transport="direct")
+    session_id = started["result"]["session_id"]
+
+    for command in ("status", "diagnose", "stop"):
+        result = remote.handle(
+            request(command, request_id=f"req-{command}", session_id=session_id),
+            owner="0xbob",
+            transport="direct",
+        )
+        assert result["code"] == "REMOTE_SESSION_NOT_FOUND"
+        assert session_id not in repr(result)
+
+    listed = remote.handle(
+        request("sessions", request_id="req-list"),
+        owner="0xbob",
+        transport="direct",
+    )
+    assert listed["result"]["sessions"] == []
+
+
+def test_owner_can_reconnect_from_a_new_service_instance(tmp_path):
+    first, daemon = service(tmp_path)
+    started = first.handle(request("start"), owner="0xalice", transport="direct")
+    session_id = started["result"]["session_id"]
+
+    reconnected = RemoteBrowserService(
+        tmp_path / "sessions.json", daemon_request=daemon, clock=lambda: 1001
+    )
+    status = reconnected.handle(
+        request("status", request_id="req-status", session_id=session_id),
+        owner="0xalice",
+        transport="direct",
+    )
+    assert status["ok"] is True
+    assert status["state"]["session"] == "active"
+
+
+def test_stop_is_idempotent_and_keeps_a_tombstone(tmp_path):
+    remote, daemon = service(tmp_path)
+    started = remote.handle(request("start"), owner="0xalice", transport="direct")
+    session_id = started["result"]["session_id"]
+
+    first = remote.handle(
+        request("stop", request_id="req-stop-1", session_id=session_id),
+        owner="0xalice",
+        transport="direct",
+    )
+    retry = remote.handle(
+        request("stop", request_id="req-stop-2", session_id=session_id),
+        owner="0xalice",
+        transport="direct",
+    )
+    assert first["state"]["session"] == retry["state"]["session"] == "stopped"
+    assert len([call for call in daemon.calls if call[0].startswith("tab close")]) == 1
+
+
+def test_relay_fails_before_daemon_or_registry_mutation(tmp_path):
+    remote, daemon = service(tmp_path)
+    result = remote.handle(request("start"), owner="0xalice", transport="relay")
+    assert result["code"] == "SECURE_CHANNEL_UNAVAILABLE"
+    assert result["state"]["fallback_applied"] is False
+    assert daemon.calls == []
+    assert not (tmp_path / "sessions.json").exists()
+
+
+def test_non_direct_proxy_and_navigation_are_not_silently_enabled(tmp_path):
+    remote, daemon = service(tmp_path)
+    shared = remote.handle(
+        request("start", args={"proxy": "shared"}),
+        owner="0xalice",
+        transport="direct",
+    )
+    navigation = remote.handle(
+        request("open", request_id="req-open"),
+        owner="0xalice",
+        transport="direct",
+    )
+    assert shared["code"] == "REMOTE_SESSION_PROXY_LOCKED"
+    assert navigation["code"] == "INVALID_ARGUMENT"
+    assert daemon.calls == []
+
+
+def test_diagnose_states_the_incomplete_navigation_boundary(tmp_path):
+    remote, _ = service(tmp_path)
+    started = remote.handle(request("start"), owner="0xalice", transport="direct")
+    result = remote.handle(
+        request(
+            "diagnose",
+            request_id="req-diagnose",
+            session_id=started["result"]["session_id"],
+        ),
+        owner="0xalice",
+        transport="direct",
+    )
+    assert result["result"]["checks"]["navigation_policy"] == "not_enabled"
+    assert result["warnings"]
+
+
+def test_success_and_failure_envelopes_keep_stable_common_fields(tmp_path):
+    remote, _ = service(tmp_path)
+    success = remote.handle(
+        request("sessions"), owner="0xalice", transport="direct"
+    )
+    failure = remote.handle(
+        request("sessions", request_id="req-relay"),
+        owner="0xalice",
+        transport="relay",
+    )
+
+    common = {
+        "schema_version",
+        "ok",
+        "command",
+        "request_id",
+        "state",
+        "tips",
+        "warnings",
+        "next_actions",
+    }
+    assert common <= success.keys()
+    assert common <= failure.keys()

--- a/tests/unit/test_remote_browser_service.py
+++ b/tests/unit/test_remote_browser_service.py
@@ -2,6 +2,8 @@ import json
 
 from connectonion.network.host.remote_browser import RemoteBrowserService
 
+UNSET = object()
+
 
 class Daemon:
     def __init__(self):
@@ -27,11 +29,11 @@ def service(tmp_path, daemon=None):
     )
 
 
-def request(command, request_id="req-1", session_id=None, args=None):
+def request(command, request_id="req-1", session_id=None, args=UNSET):
     value = {"request_id": request_id, "command": command}
     if session_id is not None:
         value["session_id"] = session_id
-    if args is not None:
+    if args is not UNSET:
         value["args"] = args
     return value
 
@@ -143,6 +145,59 @@ def test_non_direct_proxy_and_navigation_are_not_silently_enabled(tmp_path):
     assert shared["code"] == "REMOTE_SESSION_PROXY_LOCKED"
     assert navigation["code"] == "INVALID_ARGUMENT"
     assert daemon.calls == []
+
+
+def test_explicit_non_object_args_are_rejected(tmp_path):
+    remote, daemon = service(tmp_path)
+
+    for index, args in enumerate((None, [], "", 0, False)):
+        result = remote.handle(
+            request("start", request_id=f"req-invalid-{index}", args=args),
+            owner="0xalice",
+            transport="direct",
+        )
+        assert result["code"] == "INVALID_ARGUMENT"
+    assert daemon.calls == []
+
+
+def test_different_owners_receive_distinct_daemon_tabs(tmp_path):
+    remote, daemon = service(tmp_path)
+
+    alice = remote.handle(
+        request("start", request_id="req-alice"),
+        owner="0xalice",
+        transport="direct",
+    )
+    bob = remote.handle(
+        request("start", request_id="req-bob"),
+        owner="0xbob",
+        transport="direct",
+    )
+
+    assert alice["result"]["session_id"] != bob["result"]["session_id"]
+    opened = [line for line, _ in daemon.calls if line.startswith("tab open")]
+    assert len(opened) == 2
+    assert opened[0].split()[2] != opened[1].split()[2]
+
+    remote.handle(
+        request(
+            "stop",
+            request_id="req-stop-alice",
+            session_id=alice["result"]["session_id"],
+        ),
+        owner="0xalice",
+        transport="direct",
+    )
+    bob_status = remote.handle(
+        request(
+            "status",
+            request_id="req-status-bob",
+            session_id=bob["result"]["session_id"],
+        ),
+        owner="0xbob",
+        transport="direct",
+    )
+    assert bob_status["state"]["session"] == "active"
 
 
 def test_diagnose_states_the_incomplete_navigation_boundary(tmp_path):

--- a/tests/unit/test_remote_browser_ws.py
+++ b/tests/unit/test_remote_browser_ws.py
@@ -1,0 +1,207 @@
+"""OIP transport and authorization tests for Remote Browser."""
+
+import asyncio
+
+import pytest
+
+from connectonion.network.host.server import _make_remote_browser
+from connectonion.network.host.ws_router.remote_browser import run_remote_browser
+
+
+class FakeTrust:
+    def __init__(self, level="contact", admin=False):
+        self.level = level
+        self.admin = admin
+
+    def is_admin(self, address):
+        return self.admin
+
+    def get_level(self, address):
+        return self.level
+
+
+class RecordingService:
+    def __init__(self):
+        self.calls = []
+
+    def handle(self, request, *, owner, transport):
+        self.calls.append((request, owner, transport))
+        if transport != "direct":
+            return {
+                "schema_version": "1",
+                "ok": False,
+                "command": "remote-browser.status",
+                "request_id": request["request_id"],
+                "code": "SECURE_CHANNEL_UNAVAILABLE",
+                "message": "secure channel unavailable",
+            }
+        return {
+            "schema_version": "1",
+            "ok": True,
+            "command": "remote-browser.status",
+            "request_id": request["request_id"],
+            "result": {},
+        }
+
+
+def test_contact_direct_request_uses_authenticated_owner():
+    service = RecordingService()
+    handler = _make_remote_browser(service, FakeTrust())
+    request = {"request_id": "req-1", "command": "status"}
+
+    result = handler(request, "0xauthenticated", "direct")
+
+    assert result["ok"] is True
+    assert service.calls == [(request, "0xauthenticated", "direct")]
+
+
+def test_stranger_is_rejected_before_browser_service():
+    service = RecordingService()
+    handler = _make_remote_browser(service, FakeTrust(level="stranger"))
+
+    result = handler({"request_id": "req-2"}, "0xstranger", "direct")
+
+    assert result["code"] == "FORBIDDEN"
+    assert service.calls == []
+
+
+def test_relay_reaches_service_as_relay_and_fails_closed():
+    service = RecordingService()
+    handler = _make_remote_browser(service, FakeTrust())
+    request = {"request_id": "req-3", "command": "status"}
+
+    result = handler(request, "0xowner", "relay")
+
+    assert result["code"] == "SECURE_CHANNEL_UNAVAILABLE"
+    assert service.calls == [(request, "0xowner", "relay")]
+
+
+@pytest.mark.asyncio
+async def test_router_returns_stable_result_frame():
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    service = RecordingService()
+    handler = _make_remote_browser(service, FakeTrust())
+    await run_remote_browser(
+        {"type": "REMOTE_BROWSER", "request_id": "req-4", "command": "status"},
+        send,
+        {"remote_browser": handler},
+        requester_address="0xowner",
+        transport="direct",
+    )
+
+    assert sent[0]["type"] == "REMOTE_BROWSER_RESULT"
+    assert sent[0]["request_id"] == "req-4"
+    assert sent[0]["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_session_dispatch_uses_connection_identity(monkeypatch):
+    from connectonion.network.host.ws_router import session
+
+    result_sent = asyncio.Event()
+    sent = []
+    frames = [
+        {"type": "CONNECT", "from": "0xowner"},
+        {"type": "REMOTE_BROWSER", "request_id": "req-5", "command": "sessions"},
+    ]
+
+    async def fake_connect(data, send, conn, *args):
+        conn.update(
+            authenticated=True,
+            agent_address="0xowner",
+            signed_commands=False,
+            session_id="oip-session",
+        )
+
+    async def recv():
+        if frames:
+            return frames.pop(0)
+        await result_sent.wait()
+        return None
+
+    async def send(message):
+        sent.append(message)
+        if message.get("type") == "REMOTE_BROWSER_RESULT":
+            result_sent.set()
+
+    service = RecordingService()
+    monkeypatch.setattr(session, "handle_connect", fake_connect)
+    await session.run_ws_session(
+        send,
+        recv,
+        route_handlers={
+            "remote_browser": _make_remote_browser(service, FakeTrust()),
+        },
+        storage=None,
+        registry=None,
+        trust=None,
+        enable_ping=False,
+        transport="direct",
+    )
+
+    assert sent[-1]["type"] == "REMOTE_BROWSER_RESULT"
+    assert service.calls[0][1:] == ("0xowner", "direct")
+
+
+@pytest.mark.asyncio
+async def test_session_executes_signed_payload_not_tampered_top_level(monkeypatch):
+    from connectonion import address
+    from connectonion.network.connect import RemoteAgent
+    from connectonion.network.host.ws_router import session
+
+    keys = address.generate()
+    host = "0x" + "12" * 20
+    signed = RemoteAgent(host, keys=keys)._build_command_message(
+        {
+            "type": "REMOTE_BROWSER",
+            "request_id": "req-signed",
+            "command": "sessions",
+            "args": {},
+        }
+    )
+    signed["command"] = "stop"
+    frames = [{"type": "CONNECT", "from": keys["address"]}, signed]
+    result_sent = asyncio.Event()
+    sent = []
+
+    async def fake_connect(data, send, conn, *args):
+        conn.update(
+            authenticated=True,
+            agent_address=keys["address"],
+            signed_commands=True,
+            recipient_address=host,
+            session_id="oip-session",
+        )
+
+    async def recv():
+        if frames:
+            return frames.pop(0)
+        await result_sent.wait()
+        return None
+
+    async def send(message):
+        sent.append(message)
+        if message.get("type") == "REMOTE_BROWSER_RESULT":
+            result_sent.set()
+
+    service = RecordingService()
+    monkeypatch.setattr(session, "handle_connect", fake_connect)
+    await session.run_ws_session(
+        send,
+        recv,
+        route_handlers={
+            "remote_browser": _make_remote_browser(service, FakeTrust()),
+        },
+        storage=None,
+        registry=None,
+        trust=None,
+        enable_ping=False,
+        transport="direct",
+    )
+
+    assert sent[-1]["type"] == "REMOTE_BROWSER_RESULT"
+    assert service.calls[0][0]["command"] == "sessions"

--- a/tests/unit/test_sync_browser_facade.py
+++ b/tests/unit/test_sync_browser_facade.py
@@ -1,0 +1,145 @@
+"""Contract tests for the public sync facade over the async browser core."""
+
+import asyncio
+import contextvars
+import inspect
+import threading
+
+import pytest
+
+from connectonion.useful_tools.browser_tools import BrowserAutomation as PublicBrowserAutomation
+from connectonion.useful_tools.browser_tools import _sync_browser_facade as facade
+from connectonion.useful_tools.browser_tools.browser import LegacyBrowserAutomation
+
+
+class FakeAsyncCore:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.session = contextvars.ContextVar("fake_browser_session", default=None)
+        self.calls = []
+        self.browser = object()
+        self.playwright = object()
+        self._pages = {}
+        self._page_used = {}
+        self._page_url = {}
+        self._tab_meta = {}
+        self._headless = kwargs["headless"]
+        self.screenshots_dir = ".tmp"
+        self.last_screenshot_path = None
+
+    def _bind_session(self, session):
+        self.session.set(session)
+
+    async def tab_status(self):
+        await asyncio.sleep(0)
+        call = (self.session.get(), threading.current_thread())
+        self.calls.append(call)
+        return f"tab:{call[0]}"
+
+    async def close(self):
+        await asyncio.sleep(0)
+        if self.session.get() is not None:
+            return "Browser tab closed for this session."
+        self.browser = None
+        self.playwright = None
+        return "Browser closed. Session saved for next time."
+
+
+@pytest.fixture
+def browser(monkeypatch):
+    monkeypatch.setattr(facade, "AsyncBrowserCore", FakeAsyncCore)
+    value = facade.BrowserAutomation(headless=True)
+    try:
+        yield value
+    finally:
+        value._bind_session(None)
+        value.close()
+
+
+def test_public_surface_and_signatures_stay_identical():
+    assert PublicBrowserAutomation is facade.BrowserAutomation
+    legacy = {
+        name: method
+        for name, method in inspect.getmembers(
+            LegacyBrowserAutomation, inspect.isfunction
+        )
+        if not name.startswith("_")
+    }
+    public = {
+        name: method
+        for name, method in inspect.getmembers(facade.BrowserAutomation, inspect.isfunction)
+        if not name.startswith("_")
+    }
+
+    assert set(public) == set(legacy)
+    for name, method in public.items():
+        assert inspect.signature(method) == inspect.signature(legacy[name]), name
+
+
+def test_sync_call_from_running_event_loop_is_defined(browser):
+    async def caller():
+        return browser.tab_status()
+
+    assert asyncio.run(caller()) == "tab:None"
+    assert browser._core.calls[0][1] is browser._runtime_thread
+
+
+def test_session_binding_crosses_the_thread_boundary(browser):
+    browser._bind_session("checkout")
+
+    assert browser.tab_status() == "tab:checkout"
+
+
+def test_internal_detector_callback_stays_on_the_runtime(browser):
+    browser._bind_session("detector")
+
+    session, thread = browser._run_on_runtime(
+        lambda core: (core.session.get(), threading.current_thread())
+    )
+
+    assert session == "detector"
+    assert thread is browser._runtime_thread
+
+
+def test_call_from_owned_runtime_thread_fails_instead_of_deadlocking(browser):
+    done = threading.Event()
+    outcome = []
+
+    def call_on_runtime():
+        try:
+            browser.tab_status()
+        except Exception as exc:
+            outcome.append(exc)
+        finally:
+            done.set()
+
+    browser._loop.call_soon_threadsafe(call_on_runtime)
+
+    assert done.wait(2)
+    assert isinstance(outcome[0], RuntimeError)
+    assert "own async runtime thread" in str(outcome[0])
+
+
+def test_bound_close_keeps_runtime_and_unbound_close_stops_it(browser):
+    thread = browser._runtime_thread
+    browser._bind_session("one")
+
+    assert browser.close() == "Closed this session's browser tab."
+    assert thread.is_alive()
+
+    browser._bind_session(None)
+    assert browser.close() == "Browser closed"
+    assert not thread.is_alive()
+    assert browser.close() == "Browser closed"
+
+
+def test_repeated_create_and_close_leaves_no_runtime_thread(monkeypatch):
+    monkeypatch.setattr(facade, "AsyncBrowserCore", FakeAsyncCore)
+    threads = []
+
+    for _ in range(5):
+        browser = facade.BrowserAutomation()
+        threads.append(browser._runtime_thread)
+        assert browser.close() == "Browser closed"
+
+    assert all(not thread.is_alive() for thread in threads)

--- a/tests/unit/test_the_browser_daemon_shuts_down_quietly.py
+++ b/tests/unit/test_the_browser_daemon_shuts_down_quietly.py
@@ -29,7 +29,6 @@ supposed to be serving is a real failure and must not be swallowed.
 """
 
 import shutil
-import socket
 import tempfile
 import threading
 from pathlib import Path
@@ -93,11 +92,11 @@ class TestClosingTheListenerStopsIt:
 class TestARealFailureStillRaises:
     """Swallowing every socket error would hide a daemon that broke while serving."""
 
-    def test_an_accept_error_while_serving_is_not_swallowed(self, server):
+    def test_a_bind_error_while_serving_is_not_swallowed(self, server):
         def explode():
             raise OSError("the listener broke while we were serving")
 
-        server._accept = explode
+        server._bind = explode
 
         with pytest.raises(OSError):
             server.serve()
@@ -106,7 +105,7 @@ class TestARealFailureStillRaises:
         def explode():
             raise ValueError("something else entirely")
 
-        server._accept = explode
+        server._bind = explode
 
         with pytest.raises(ValueError):
             server.serve()


### PR DESCRIPTION
Consolidated merge of the stacked ready chain after #1288 landed and GitHub
closed the dependent PRs instead of retargeting them (their base branch was
deleted). This head (`c2d02adf`) contains exactly the reviewed content of:

- **#1289** — concurrent browser daemon sessions (ends the serial-loop era)
- **#1290** — synchronous BrowserAutomation API preserved over the async core (#500)
- **#1298** — owner-bound Remote Browser lifecycle over OIP

Ancestry verified: both intermediate branch heads are ancestors of this head
(`git merge-base --is-ancestor` both ✓). CI ran green on this chain during
the stack's own runs; the fresh run on this PR revalidates against current main.

This is the **1.8.0a2 candidate content**. The paid-engine/egress draft stack
(#1280/#1299–#1316, candidate `bacd0c54`) is deliberately NOT included — it
stays for explicit design sign-off and targets a3.

Tracker: #1154.

**Proposed target version:** 1.8.0a2
**Estimated release window:** immediately — this PR is the a2 candidate content
**Forward-port tracking issue (stable patches only):** not applicable