### PR TITLE
release: carry 1.8.0a3 into uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.8.0a2"
+version = "1.8.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
The `v1.8.0a3` release run failed before `build`. `uv.lock` still said `1.8.0a2` while `pyproject.toml` said `a3`:

```
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided
E   AssertionError: uv.lock says 1.8.0a2, pyproject.toml says 1.8.0a3
```

**Nothing was published** — `build` was skipped and PyPI has no `1.8.0a3` — so the tag gets repointed at the merge of this PR and the release re-runs cleanly.

The version bump touches four files and #1330 updated three. This is exactly the drift the lockfile gate exists to catch, and it did.

## Labels and target release (required)

- **Suggested labels:** release
- **Proposed target version:** 1.8.0a3
- **Estimated release window:** immediately — this unblocks the tag
- **Milestone:** maintainer assigns
- **Why this release:** the a3 tag cannot build without it; rollback is reverting one generated file
- **Forward-port tracking issue (stable patches only):** N/A — alpha

## How this was written

- [x] Mostly AI-generated