### PR TITLE
harden(destination-policy): complete the suffix list, check the tables against the registry

### DIFF
--- a/connectonion/network/host/destination_policy.py
+++ b/connectonion/network/host/destination_policy.py
@@ -44,6 +44,19 @@ _SPECIAL_SUFFIXES = (
     ".invalid",
     ".test",
     ".example",
+    # Reserved for special use, so a split-horizon name under one of these can
+    # resolve to an address the frozen tables cannot judge — which is the case
+    # the suffix list exists to cover, not the address layer.
+    ".arpa",  # RFC 3172 — includes in-addr.arpa, ip6.arpa, home.arpa (RFC 8375)
+    ".alt",  # RFC 9476 — non-DNS namespaces
+    ".onion",  # RFC 7686 — Tor; must never hit the public resolver
+    # Commonly squatted for internal networks; not reserved by the IETF, but a
+    # remote caller has no business reaching a host named this way through a
+    # shared connection.
+    ".corp",
+    ".home",
+    ".lan",
+    ".intranet",
 )
 
 # Conservative frozen policy derived from the IANA IPv4 special-purpose

--- a/docs/blog/2026-08-30-the-suffix-list-and-the-table-that-checked-itself.md
+++ b/docs/blog/2026-08-30-the-suffix-list-and-the-table-that-checked-itself.md
@@ -1,0 +1,56 @@
+# The suffix list, and the table that checked itself
+
+Two small holes in the destination policy, found by the review that also found
+the two real bypasses. Neither was exploitable the day it was noted, and both
+are the kind that becomes exploitable quietly.
+
+## A suffix list is only as good as the names it lists
+
+The policy denies special-use hostnames by suffix: `.localhost`, `.local`,
+`.internal`, `.invalid`, `.test`, `.example`. That list is the *only* thing that
+can stop a split-horizon name — a name that resolves, inside some network, to
+an address the frozen IP tables would happily allow because it looks public.
+That is exactly why `metadata.google.internal` was dangerous, and why the
+earlier UTS-46 bug that let you smuggle it past the list mattered.
+
+So the list has to be complete, and it was missing entries that resolve
+split-horizon by design:
+
+- `.arpa` — RFC 3172, and `home.arpa` under it (RFC 8375) is what an ordinary
+  home router hands out
+- `.alt` — RFC 9476, reserved for non-DNS namespaces
+- `.onion` — RFC 7686; a name that must never reach the public resolver at all
+- `.corp`, `.home`, `.lan`, `.intranet` — not reserved by anyone, which is
+  precisely the problem: they are squatted for internal networks constantly,
+  and a remote caller sharing your connection has no business reaching a host
+  named that way
+
+None of these had a test, so none were denied. Now they are, and the test that
+proves it goes red on the code that shipped without them.
+
+## A table that agrees with itself proves nothing
+
+The frozen IPv4 and IPv6 tables are the deny-list of address ranges. There was
+a test that walked them — before, inside, and after every network — and checked
+the classifier agreed. It passed. It could not have failed for the reason that
+matters, because it built its expected answer from the same tables the
+classifier reads. Two uses of one list agreeing tells you they are the same
+list. It cannot tell you the list is missing a range.
+
+The fixture pins a registry snapshot date in a comment and cites the IANA
+special-purpose registries by URL, which reads like a claim that the tables
+match the registry. Nothing checked that claim.
+
+So there is now a second list, transcribed from the IANA registries by hand and
+kept in the fixture rather than derived from the code: every special-purpose
+block that must be denied. The test asserts each one is covered by some frozen
+network. Drop `198.18.0.0/15` from the table — the benchmarking range, easy to
+think is harmless — and the test names it. It is still a hand-maintained list,
+so it can drift too; the point is that it drifts *independently*, and a bug has
+to be made in two places at once to hide.
+
+Both fixes are the same shape as the bugs the review found in the code: a check
+that measures the wrong thing looks exactly like a check that passes. The only
+way to know the difference is to break the thing on purpose and watch the check
+go red — which is what the mutation runs in this change do, once each, before
+the fix goes in.

--- a/tests/fixtures/remote_browser_destination_vectors.json
+++ b/tests/fixtures/remote_browser_destination_vectors.json
@@ -78,7 +78,7 @@
       "port": 8443
     },
     {
-      "url": "https://BÜCHER.de/",
+      "url": "https://B\u00dcCHER.de/",
       "ok": true,
       "scheme": "https",
       "host": "xn--bcher-kva.de",
@@ -184,41 +184,41 @@
       "code": "DESTINATION_INVALID"
     },
     {
-      "url": "http://localhost。/",
+      "url": "http://localhost\u3002/",
       "ok": false,
       "code": "DESTINATION_HOST_DENIED"
     },
     {
-      "url": "http://metadata.google.internal。/",
+      "url": "http://metadata.google.internal\u3002/",
       "ok": false,
       "code": "DESTINATION_HOST_DENIED"
     },
     {
-      "url": "http://api.svc.cluster.local．/",
+      "url": "http://api.svc.cluster.local\uff0e/",
       "ok": false,
       "code": "DESTINATION_HOST_DENIED"
     },
     {
-      "url": "http://anything.internal｡/",
+      "url": "http://anything.internal\uff61/",
       "ok": false,
       "code": "DESTINATION_HOST_DENIED"
     },
     {
-      "url": "http://127。0。0。1/",
+      "url": "http://127\u30020\u30020\u30021/",
       "ok": true,
       "scheme": "http",
       "host": "127.0.0.1",
       "port": 80
     },
     {
-      "url": "http://０x７f.１/",
+      "url": "http://\uff10x\uff17f.\uff11/",
       "ok": true,
       "scheme": "http",
       "host": "127.0.0.1",
       "port": 80
     },
     {
-      "url": "http://２１３０７０６４３３/",
+      "url": "http://\uff12\uff11\uff13\uff10\uff17\uff10\uff16\uff14\uff13\uff13/",
       "ok": true,
       "scheme": "http",
       "host": "127.0.0.1",
@@ -420,5 +420,40 @@
       "ok": false,
       "code": "DESTINATION_ADDRESS_DENIED"
     }
-  ]
+  ],
+  "registry_must_deny": {
+    "ipv4": [
+      "0.0.0.0/8",
+      "10.0.0.0/8",
+      "100.64.0.0/10",
+      "127.0.0.0/8",
+      "169.254.0.0/16",
+      "172.16.0.0/12",
+      "192.0.0.0/24",
+      "192.0.2.0/24",
+      "192.31.196.0/24",
+      "192.52.193.0/24",
+      "192.88.99.0/24",
+      "192.168.0.0/16",
+      "192.175.48.0/24",
+      "198.18.0.0/15",
+      "198.51.100.0/24",
+      "203.0.113.0/24",
+      "240.0.0.0/4",
+      "255.255.255.255/32"
+    ],
+    "ipv6": [
+      "::1/128",
+      "::/128",
+      "64:ff9b:1::/48",
+      "100::/64",
+      "2001::/23",
+      "2001:db8::/32",
+      "2620:4f:8000::/48",
+      "3fff::/20",
+      "5f00::/16",
+      "fc00::/7",
+      "fe80::/10"
+    ]
+  }
 }

--- a/tests/unit/test_remote_browser_destination_policy.py
+++ b/tests/unit/test_remote_browser_destination_policy.py
@@ -337,3 +337,51 @@ def test_operator_deny_generator_survives_transition_recursion(address):
 
     assert result.allowed is False
     assert result.address_class.endswith("operator_denied")
+
+
+# The frozen tables were only ever compared to themselves, which proves the two
+# uses of one table agree but can never detect a MISSING range. These vectors
+# are transcribed from the IANA registries independently of the code, so a
+# special-purpose block the table forgets shows up here.
+@pytest.mark.parametrize("block", VECTORS["registry_must_deny"]["ipv4"])
+def test_every_registry_ipv4_block_is_covered_by_the_frozen_table(block):
+    network = ipaddress.ip_network(block)
+    covered = any(
+        network.subnet_of(frozen)
+        for frozen in policy._FORBIDDEN_V4
+        if frozen.version == 4
+    )
+    assert covered, f"{block} is in the IANA registry but no frozen network covers it"
+
+
+@pytest.mark.parametrize("block", VECTORS["registry_must_deny"]["ipv6"])
+def test_every_registry_ipv6_block_is_covered(block):
+    network = ipaddress.ip_network(block)
+    covered = network.subnet_of(policy._GLOBAL_V6) is False or any(
+        network.subnet_of(frozen)
+        for frozen in policy._FORBIDDEN_V6
+        if frozen.version == 6
+    )
+    # Everything outside 2000::/3 is denied by the global catch-all; everything
+    # inside must be named in the frozen table.
+    assert covered, f"{block} is in the IANA registry but nothing denies it"
+
+
+# Special-use TLDs that resolve split-horizon: the address layer cannot judge
+# them, so the suffix list is the only thing that can.
+@pytest.mark.parametrize(
+    "host",
+    [
+        "server.corp",
+        "printer.home",
+        "nas.lan",
+        "wiki.intranet",
+        "1.0.0.127.in-addr.arpa",
+        "service.alt",
+        "facebookcorewwwi.onion",
+    ],
+)
+def test_reserved_and_squatted_tlds_are_denied(host):
+    with pytest.raises(policy.DestinationPolicyError) as raised:
+        policy.normalize_web_destination(f"http://{host}/")
+    assert raised.value.code == policy.HOST_DENIED


### PR DESCRIPTION
Closes #1323 — the two lower-severity follow-ups from the destination-policy review.

## 1. The suffix list was missing split-horizon TLDs

The policy denies special-use hostnames by suffix. That list is the only thing that can stop a name which resolves, inside some network, to an address the frozen IP tables would allow because it looks public — the `metadata.google.internal` case. Absent, and now added:

- `.arpa` (RFC 3172; `home.arpa` under it, RFC 8375 — what a home router hands out)
- `.alt` (RFC 9476)
- `.onion` (RFC 7686 — must never reach the public resolver)
- `.corp` `.home` `.lan` `.intranet` — squatted for internal networks constantly

## 2. The frozen table only agreed with itself

`test_before_inside_and_after_every_frozen_network_match_the_frozen_table` built its expected answers from the same tables the classifier reads, so it could prove the two uses agree but never that a range is **missing**. The fixture cited the IANA registries but nothing checked against them.

There is now a second list — transcribed from the IANA special-purpose registries into the fixture, not derived from the code — asserted to be covered by the frozen tables. It drifts independently, so a bug has to be made in two places to hide.

## Verified by mutation

| mutation | result |
|---|---|
| revert the suffix additions | reserved-TLD test goes **red** (7 fail) |
| drop `198.18.0.0/15` from the table | registry-coverage test goes **red** |

281 tests pass; ruff clean.

## Labels and target release (required)

- **Suggested labels:** browser, tests
- **Proposed target version:** 1.8.0a4
- **Estimated release window:** next alpha
- **Milestone:** maintainer assigns
- **Why this release:** hardening on the merged egress boundary; both are cases that become exploitable quietly. Rollback is reverting one tuple and one test file.
- **Forward-port tracking issue (stable patches only):** N/A — alpha

## How this was written

- [x] Mostly AI-generated