### PR TITLE
fix(daemon): bind before preparing the private runtime (credential-file race)

### DIFF
--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -833,8 +833,15 @@ class BrowserDaemon:
     async def serve_async(self):
         self._loop = asyncio.get_running_loop()
         try:
-            await self._prepare_runtime()
+            # Bind before preparing the runtime, not after. `_bind` takes the
+            # singleton lock and a loser exits there; preparing first meant a
+            # loser had already written proxy-auth.json (its path derives from
+            # the shared profile) and started a gateway, and its
+            # `finally: _shutdown_async()` then removed the *winner's* live
+            # credential on the way out — a silent, unattributable 407 for the
+            # daemon that actually owns the socket.
             self._bind()
+            await self._prepare_runtime()
             atexit.register(self._cleanup)
             if threading.current_thread() is threading.main_thread():
                 with contextlib.suppress(NotImplementedError, RuntimeError):

--- a/docs/blog/2026-08-30-bind-first-then-prepare.md
+++ b/docs/blog/2026-08-30-bind-first-then-prepare.md
@@ -1,0 +1,54 @@
+# Bind first, then prepare
+
+A daemon that loses a startup race was deleting the winner's credentials.
+
+Two `co browser` commands in two terminals, cold, at the same moment: both
+spawn a daemon, and both race for the same socket. That race is old and handled
+— an exclusive lock on `<sock>.lock`, held for the daemon's lifetime, and the
+loser calls `sys.exit(0)` the moment it cannot take the lock. The winner keeps
+the socket; the loser goes away. This has been true and tested for a while.
+
+What changed under it is that a private remote-browser daemon now starts a
+gateway and writes a proxy-credential file before it serves. And the startup
+did that *first*:
+
+```python
+await self._prepare_runtime()   # start gateway, write proxy-auth.json
+self._bind()                    # take the lock, or sys.exit(0)
+```
+
+The credential's path derives from the shared profile directory, so both
+daemons write the *same file*. The loser wrote its own credential — for its own
+gateway, with its own password — on top of the winner's. Then it lost the lock,
+exited, and its `finally: _shutdown_async()` did the tidy thing: removed the
+proxy-credential file it had created.
+
+Except the file is shared. It removed the winner's.
+
+The winning daemon is now serving on its socket with a live gateway whose
+credential is gone from disk. Every page command comes back `407`. Nothing
+logged an error; nothing points at the loser, which exited cleanly a moment ago
+having done exactly what its shutdown path says to do. The daemon that owns the
+socket just stops working, for a reason that isn't in front of it.
+
+The fix is one swap:
+
+```python
+self._bind()                    # take the lock, or sys.exit(0)
+await self._prepare_runtime()   # only the winner gets here
+```
+
+The loser now exits at the lock, before it has written or started anything, so
+there is nothing for its shutdown to remove. `_prepare_runtime` runs only for
+the daemon that won the socket.
+
+The regression test holds the singleton lock itself — standing in for the live
+winner — writes a credential, then runs a second daemon's `serve_async` and
+asserts two things: it exits 0, and the credential on disk is byte-for-byte the
+one the winner wrote. Reinstate the old order and the test reddens: the loser
+reaches `_prepare_runtime`, and the winner's bytes are gone.
+
+The bug was not in the race handling, which was careful. It was that a cleanup
+path written for one daemon's private file ran against a file that had quietly
+become shared, because a later feature put the write before the thing that
+decides whether this daemon is allowed to write at all.

--- a/tests/unit/test_remote_browser_private_runtime.py
+++ b/tests/unit/test_remote_browser_private_runtime.py
@@ -806,3 +806,53 @@ def test_a_bare_proxy_server_argument_is_refused(tmp_path):
                 "--proxy-server=http://127.0.0.1:1",
             ),
         )
+
+
+@pytest.mark.asyncio
+async def test_a_losing_daemon_never_touches_the_winners_credential(tmp_path):
+    """The loser of the singleton race must not write or remove proxy-auth.json.
+
+    Its path derives from the shared profile, so a loser that prepared the
+    runtime before contesting the lock wrote the file and started a gateway,
+    and its shutdown then removed the *winner's* live credential — a silent
+    407 for the daemon that owns the socket. Binding first makes the loser
+    exit before it can prepare anything.
+    """
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    if os.name != "nt":
+        os.chmod(profile, 0o700)
+    sock = str(tmp_path / "private.sock")
+
+    # The winner: hold the singleton lock for the whole test, as a live daemon
+    # would for its lifetime.
+    transport.ensure_endpoint_parent(sock)
+    winner_lock = transport.acquire_singleton_lock(transport.lock_path(sock))
+    assert winner_lock is not None
+
+    # The winner's credential is on disk and must survive the loser.
+    from connectonion.network.host.egress_gateway import ProxyEndpoint
+    from connectonion.network.host.private_browser_runtime import write_proxy_auth_file
+
+    auth_path = proxy_auth_path_for_profile(profile)
+    write_proxy_auth_file(auth_path, ProxyEndpoint("127.0.0.1", 5000, "connectonion", "B" * 43))
+    winner_bytes = auth_path.read_bytes()
+
+    prepared = []
+    loser = BrowserDaemon(
+        sock,
+        engine_mode="onion",
+        profile_dir=profile,
+        remote_egress=True,
+        gateway_factory=lambda: (_ for _ in ()).throw(
+            AssertionError("loser started a gateway")
+        ),
+        browser_factory=lambda **_k: prepared.append("browser"),
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await loser.serve_async()
+
+    assert exit_info.value.code == 0
+    assert prepared == [], "the loser prepared a runtime it should never reach"
+    assert auth_path.read_bytes() == winner_bytes, "the loser touched the winner's credential"


### PR DESCRIPTION
#1326 problem 1 — the confirmed one.

A private remote-browser daemon that **loses** the singleton startup race deleted the **winner's** proxy credential.

`serve_async` prepared the runtime — start gateway, write `proxy-auth.json` — *before* `_bind` took the lock:

```python
await self._prepare_runtime()   # start gateway, write proxy-auth.json
self._bind()                    # take the lock, or sys.exit(0)
```

The credential path derives from the shared profile, so both daemons write the same file. A loser wrote the shared file with its own gateway's password, lost the lock, exited, and its `finally: _shutdown_async()` removed the file — the **winner's** live credential. The owning daemon then answered `407` on every command, nothing logged, the loser already gone having done exactly what its shutdown says to do.

Fix is one swap:

```python
self._bind()                    # take the lock, or sys.exit(0)
await self._prepare_runtime()   # only the winner reaches this
```

A loser now exits at the lock before writing or starting anything.

## Verified by mutation

The regression test holds the singleton lock (standing in for the live winner), writes a credential, runs a second daemon's `serve_async`, and asserts it exits 0 with the winner's bytes intact. Reinstating the old order reddens it.

## Scope

Problem 2 on #1326 — a preflight failure leaves the gateway up — is **fail-closed** (nothing can use the gateway without the credential, and the failed browser is torn down) and a daemon-lifecycle design question: the gateway must stay up while the daemon serves, so "stop it on a browser preflight failure" needs a deliberate call about whether the daemon should exit. Left open on the issue rather than rushed in here.

34 tests pass; ruff clean.

## Labels and target release (required)

- **Suggested labels:** browser, tests
- **Proposed target version:** 1.8.0a4
- **Estimated release window:** next alpha
- **Milestone:** maintainer assigns
- **Why this release:** a wedged daemon answering 407 with nothing logged is a bad operator experience on the merged private-runtime path. Rollback is swapping two lines back.
- **Forward-port tracking issue (stable patches only):** N/A — alpha

## How this was written

- [x] Mostly AI-generated