### PR TITLE
fix(paid): a terminated session must stop serving pages

### DIFF
--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -47,6 +47,14 @@ except ImportError:
     ASYNC_BROWSER_AVAILABLE = False
 
 
+class PaidSessionEndedError(RuntimeError):
+    """A paid session ended upstream; its browser must not keep serving."""
+
+    def __init__(self, reason: str):
+        super().__init__(f"paid browser session ended: {reason}")
+        self.reason = reason
+
+
 _FOCUSED_ELEMENT_SCRIPT = """
 (previewLimit) => {
     let element = document.activeElement;
@@ -379,6 +387,22 @@ class AsyncBrowserCore:
             self._tab_locks[key] = lock
         return lock
 
+    def _require_live_paid_session(self) -> None:
+        """Refuse page commands once the paid session has been terminated.
+
+        Onionwright reports `terminal_reason` when a session ends upstream —
+        expiry, revocation, non-payment. The browser context can outlive that,
+        and serving page verbs against it is an unpaid browser treated as paid.
+        The reason is only ever surfaced in status today; here it gates the
+        commands that would otherwise keep running for free.
+        """
+        run = self._paid_run
+        if run is None:
+            return
+        reason = getattr(run, "terminal_reason", None)
+        if reason:
+            raise PaidSessionEndedError(reason)
+
     @asynccontextmanager
     async def _tab_operation(self, *, ensure_page: bool = True):
         """Serialize one tab while allowing independent tabs to make progress."""
@@ -387,6 +411,7 @@ class AsyncBrowserCore:
             yield
             return
 
+        self._require_live_paid_session()
         key = self._bound_session_key()
         async with self._tab_lock(key):
             async with self._operation_state_lock:

--- a/docs/blog/2026-08-30-a-reason-that-nothing-read.md
+++ b/docs/blog/2026-08-30-a-reason-that-nothing-read.md
@@ -1,0 +1,49 @@
+# A reason that nothing read
+
+The paid browser reported when its session ended, and then kept serving pages
+anyway.
+
+Onionwright hands back a `terminal_reason` on a paid session: expiry,
+revocation, non-payment. The daemon surfaced it — in `status`, once, next to the
+session id and the paid-until time. That was the only place the word appeared
+outside of writing it down. A grep for it in the whole codebase returned two
+lines: the assignment, and the status field.
+
+So the sequence was: a session ends upstream, Onionwright sets
+`terminal_reason`, and the browser context it produced is still open. The next
+`go_to`, the next `extract_data`, the next screenshot — all run. The session is
+over; the browser is not. That is an unpaid browser doing paid work, and nothing
+in the client stopped it, because nothing in the client read the field that says
+to.
+
+The fix is a guard at the one place every page command enters:
+
+```python
+def _require_live_paid_session(self):
+    run = self._paid_run
+    if run is None:
+        return                       # free/system: never gated
+    if getattr(run, "terminal_reason", None):
+        raise PaidSessionEndedError(run.terminal_reason)
+```
+
+`_tab_operation` is the single async context manager that wraps `go_to`,
+`extract_data`, every screenshot, every click. One call at the top of it, and a
+terminated session refuses every verb with the reason attached, instead of
+serving them.
+
+The test that matters here is not the one that checks the guard raises — that is
+easy and proves little. It is the one that asserts the guard is *called from the
+entry point*, because the whole bug was a check that existed (the reason was
+right there in `status`) and was never consulted. So the test reads the source of
+`_tab_operation` and asserts the call is in it; remove the call and the test goes
+red, which is the property that was actually missing — not "can this raise" but
+"does anything invoke it."
+
+There is a smaller lesson in how the guard almost shipped broken. Inserting the
+new method just above `_tab_operation` slid the `@asynccontextmanager` decorator
+onto the wrong function — it decorated the guard and left `_tab_operation` a bare
+async generator. Every page command failed with `AttributeError: __aenter__`.
+Eight existing tests caught it immediately, which is the argument for running the
+whole file after a mechanical edit and not just the new test: the new test passed
+in isolation while everything around it broke.

--- a/tests/unit/test_browser_paid_launch_seam.py
+++ b/tests/unit/test_browser_paid_launch_seam.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from connectonion.useful_tools.browser_tools import _async_browser as async_mod
 from connectonion.useful_tools.browser_tools import browser as mod
 from connectonion.useful_tools.browser_tools import engine
@@ -259,3 +261,41 @@ def test_status_names_the_browser_that_actually_runs(monkeypatch):
     browser.close()
 
     assert status["executable"] == "/runtimes/7de5a8/chrome"
+
+
+def test_a_terminated_paid_session_refuses_page_commands():
+    """Once Onionwright reports terminal_reason, the browser must stop serving.
+
+    The context can outlive the paid session — expiry, revocation, non-payment.
+    Serving page verbs against it is an unpaid browser treated as paid. The
+    reason was only ever shown in status; nothing acted on it.
+    """
+    core = async_mod.AsyncBrowserCore.__new__(async_mod.AsyncBrowserCore)
+    core._paid_run = FakePaidRun()
+
+    # A live session lets the guard pass.
+    core._paid_run.terminal_reason = None
+    core._require_live_paid_session()
+
+    # A terminated one refuses, carrying the reason.
+    core._paid_run.terminal_reason = "revoked"
+    with pytest.raises(async_mod.PaidSessionEndedError) as raised:
+        core._require_live_paid_session()
+    assert raised.value.reason == "revoked"
+
+    # A free/system session (no paid run) is never gated.
+    core._paid_run = None
+    core._require_live_paid_session()
+
+
+def test_the_guard_is_called_from_the_page_command_entry_point():
+    """The check must run where page commands enter, not sit unreferenced.
+
+    _tab_operation is the single gate every page verb passes through. A guard
+    defined but never called is exactly the terminal_reason situation this
+    fixes, so assert the call is there rather than trusting it.
+    """
+    import inspect
+
+    source = inspect.getsource(async_mod.AsyncBrowserCore._tab_operation)
+    assert "_require_live_paid_session()" in source


### PR DESCRIPTION
#1328 problem 3 — `terminal_reason` was read but never enforced.

Onionwright reports `terminal_reason` on a paid session (expiry, revocation, non-payment). A grep for it returned exactly two lines: the assignment, and the `status` field. So a session that ended upstream left its browser context open and serving every `go_to`, `extract_data` and screenshot — an unpaid browser doing paid work, because nothing consulted the field that says the session is over.

`_require_live_paid_session` gates `_tab_operation`, the single async context manager every page verb passes through:

```python
def _require_live_paid_session(self):
    run = self._paid_run
    if run is None:
        return                       # free/system: never gated
    if getattr(run, "terminal_reason", None):
        raise PaidSessionEndedError(run.terminal_reason)
```

## The test that matters

Not "does the guard raise" — easy, proves little. The bug was a check that *existed* (`terminal_reason` was right there in `status`) and was never called. So the entry-point test asserts the call is in `_tab_operation`; **removing the call reddens it**. That is the property that was missing: not "can this raise" but "does anything invoke it."

## A near-miss worth noting

Inserting the method just above `_tab_operation` slid `@asynccontextmanager` onto the wrong function — it decorated the guard and left `_tab_operation` a bare async generator, so every page command failed `AttributeError: __aenter__`. Eight existing tests caught it at once. Running the whole file after a mechanical edit, not just the new test, is what surfaced it — the new test passed in isolation while everything around it broke.

1,492 browser tests pass; ruff clean.

## Labels and target release (required)

- **Suggested labels:** browser, tests
- **Proposed target version:** 1.8.0a4
- **Estimated release window:** next alpha
- **Milestone:** maintainer assigns
- **Why this release:** an unpaid browser serving paid work is a billing-integrity gap on the merged paid path. Rollback is removing one method and one call.
- **Forward-port tracking issue (stable patches only):** N/A — alpha

## How this was written

- [x] Mostly AI-generated