### PR TITLE
test(install-onion): prove the pinned key rejects another signer

### DIFF
--- a/tests/unit/test_onionwright_install.py
+++ b/tests/unit/test_onionwright_install.py
@@ -266,3 +266,39 @@ def test_cli_install_rejects_extra_arguments_without_daemon(monkeypatch, capsys)
 
     assert browser_commands.handle_browser(["install-onion", "unexpected"]) == 2
     assert "usage: co browser install-onion" in capsys.readouterr().err
+
+
+def test_a_manifest_signed_by_another_key_is_rejected_with_the_pin_untouched(monkeypatch):
+    """The trust root must be the pinned key, not one the response supplies.
+
+    Every other test here monkeypatches RELEASE_VERIFY_KEY_HEX to its own
+    generated key, so none proves the real pin rejects an attacker's signature.
+    This one signs a perfectly valid manifest with a DIFFERENT key and leaves
+    the pin alone: replacing the module constant with a key read from the
+    response body would make this pass, which is exactly the bypass it guards.
+    """
+    attacker_key = SigningKey.generate()
+    assert bytes(attacker_key.verify_key).hex() != installer.RELEASE_VERIFY_KEY_HEX
+    signed, _digest = _signed_manifest(attacker_key, b"wheel")
+
+    monkeypatch.setattr(installer, "_installed_version", lambda: None)
+    monkeypatch.setattr(installer, "require_ambient_api_key", lambda: "token")
+    monkeypatch.setattr(installer, "backend_url", lambda: "https://api.test")
+    monkeypatch.setattr(
+        installer.requests,
+        "request",
+        lambda *args, **kwargs: _Response(json_body=signed),
+    )
+    monkeypatch.setattr(
+        installer.requests,
+        "get",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("downloaded")),
+    )
+    monkeypatch.setattr(
+        installer.subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("ran pip")),
+    )
+
+    with pytest.raises(installer.OnionwrightInstallError, match="signature or schema"):
+        installer.install_onionwright()


### PR DESCRIPTION
Part of #1328 — the `install-onion` pin was correct but untested.

Every test in `test_onionwright_install.py` monkeypatches `RELEASE_VERIFY_KEY_HEX` to its own generated key, so none proved the real trust root rejects an attacker's signature. The code is right — pinned module constant, checksum from the signed manifest, `allow_redirects=False`, 0700 temp dir — but nothing asserted the pin holds.

This test signs a **valid** manifest with a **different** key and leaves the pin alone, asserting the install refuses it before download or pip.

**Mutation-checked**: replacing the pin with a key read from the response body — `VerifyKey(signed.get("verify_key", RELEASE_VERIFY_KEY_HEX))`, the exact bypass — plus the attacker's key in the manifest, reddens it.

The other #1328 items:
- **item 1** (cross-repo test green-by-skip) needs an `onionwright` install step in `.github/workflows`, which touches the workflow scope wall and is a CI-infra call — flagged on the issue rather than bundled here
- **item 3** (`terminal_reason` unenforced) shipped in #1335
- `pip install` without `--no-deps` pulling unverified deps — a real gap, left for the issue

## Labels and target release (required)

- **Suggested labels:** tests, browser
- **Proposed target version:** 1.8.0a4
- **Estimated release window:** next alpha
- **Milestone:** maintainer assigns
- **Why this release:** the supply-chain trust root on the paid install path had no test proving it holds. Rollback is deleting one test.
- **Forward-port tracking issue (stable patches only):** N/A — alpha

## How this was written

- [x] Mostly AI-generated