### PR TITLE
feat(paid): show the interval price and live session in status

### DIFF
--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -545,12 +545,29 @@ class BrowserDaemon:
                 "reason": "status_unavailable",
                 "artifact_id": None,
             }
+        # The paid engine charges per interval the moment a command uses it —
+        # like tokens, no confirmation. So the price and the live session ride
+        # here in status, which is where an operator looks to see what a running
+        # browser is doing and costing.
+        price = engine.get("interval_usd")
+        cost = (
+            f" · ${price:.3f}/interval"
+            if isinstance(price, (int, float))
+            else ""
+        )
+        session = (
+            f" · paid session {engine['paid_session_id']}"
+            if engine.get("paid_session_id")
+            else ""
+        )
         lines.append(
             "Engine: "
             f"requested={engine['requested_engine']} · "
             f"resolved={engine['resolved_engine'] or 'not-started'} · "
             f"reason={engine['reason']}"
             + (f" · artifact={engine['artifact_id']}" if engine.get("artifact_id") else "")
+            + cost
+            + session
         )
         # Surface stealth-driver health here so a misconfigured driver (webdriver leak) is
         # visible where users look for browser state, not only in `co doctor`.

--- a/docs/blog/2026-08-30-charge-on-use-say-so-in-status.md
+++ b/docs/blog/2026-08-30-charge-on-use-say-so-in-status.md
@@ -1,0 +1,31 @@
+# Charge on use, say so in status
+
+The question was whether the paid browser should ask before it charges. The
+answer is no — it charges the way tokens do. Use it, and it bills; there is no
+prompt, because a prompt in front of every command that a script or an agent
+runs is friction with no payer confused about what they clicked.
+
+What was actually wrong was quieter: it charged and did not say so where you
+would look. The open message names the price once, at launch. But a paid
+browser is a long-lived thing — a daemon serving commands over minutes — and the
+place you go to ask "what is this browser doing right now" is `status`. The
+Engine line there reported the engine and the artifact and said nothing about
+money.
+
+Now it carries both the price and the live session:
+
+```
+Engine: requested=auto · resolved=onion · reason=onion_ready ·
+        artifact=chrome/151/linux-x86_64.tar.zst · $0.025/interval ·
+        paid session sess-123
+```
+
+Read defensively — a resolution with no price (a free or system engine, or an
+upstream that reports none) produces the old line, not a `$0.000`. The test that
+matters asserts the cost is *in* the rendered status, not merely computed;
+dropping the string from the Engine line reddens it.
+
+That is the whole change. The billing model is not a decision the client gets to
+make — it is charge-on-use, like the rest of the platform. The client's job is
+to make sure the number is never a surprise, and the surprise was never the
+charge, it was that status stayed silent about it.

--- a/tests/unit/test_browser_status_names_who_pays_for_do.py
+++ b/tests/unit/test_browser_status_names_who_pays_for_do.py
@@ -5,6 +5,8 @@ print that account in status. Moving the agent loop to the CLI process removes
 both the surprising payer and the reason status needed a billing line.
 """
 
+import pytest
+
 
 class _Browser:
     _headless = False
@@ -42,3 +44,36 @@ def test_daemon_module_no_longer_imports_or_resolves_model_credentials():
     assert not hasattr(mod, "resolve_api_key")
     assert not hasattr(mod, "build_browser_agent")
     assert not hasattr(mod, "_daemon_account")
+
+
+class _PaidBrowser(_Browser):
+    def engine_status(self):
+        return {
+            "requested_engine": "auto",
+            "resolved_engine": "onion",
+            "reason": "onion_ready",
+            "artifact_id": "chrome/151/linux-x86_64.tar.zst",
+            "interval_usd": 0.025,
+            "executable": "/runtimes/abc/chrome",
+            "paid_session_id": "sess-123",
+        }
+
+
+@pytest.mark.asyncio
+async def test_a_paid_session_shows_its_cost_in_status(monkeypatch):
+    """Auto charges on use like tokens, with no prompt — so status is where the
+    price and the live session have to appear (Aaron's call on #1327)."""
+    from connectonion.cli.browser_agent import daemon as mod
+
+    instance = mod.BrowserDaemon.__new__(mod.BrowserDaemon)
+    instance.browser = _PaidBrowser()
+    instance.last_command = None
+    monkeypatch.setattr(
+        mod, "driver_stealth_status", lambda: ("ok", "1.61.2", "stealth patches present")
+    )
+
+    ok, text = await instance._status_async()
+
+    assert ok is True
+    assert "$0.025/interval" in text
+    assert "paid session sess-123" in text


### PR DESCRIPTION
Aaron's decision on #1327: **charge on use, like tokens — no confirmation prompt.** A prompt before every command a script or agent runs is friction, and nobody is confused about what they are paying for. What was missing was surfacing: it charged, and status did not say so.

The open message names the price once at launch, but a paid browser is a daemon serving commands over minutes, and `status` is where an operator asks what a running browser is doing. The Engine line now carries the interval price and the paid session id:

```
Engine: requested=auto · resolved=onion · reason=onion_ready ·
        artifact=chrome/151/linux-x86_64.tar.zst · $0.025/interval ·
        paid session sess-123
```

Read defensively: a resolution with no price (free/system, or an upstream that reports none) renders the old line, not `$0.000`. The test asserts the cost is **in** the rendered status; dropping it from the Engine line reddens it.

18 status/paid tests pass; ruff clean.

## Labels and target release (required)

- **Suggested labels:** browser, tests
- **Proposed target version:** 1.8.0a4
- **Estimated release window:** next alpha
- **Milestone:** maintainer assigns
- **Why this release:** closes #1327 with Aaron's decision — the paid path now surfaces its cost where operators look. Rollback is two rendered fields.
- **Forward-port tracking issue (stable patches only):** N/A — alpha

## How this was written

- [x] Mostly AI-generated