### PR TITLE
fix(cli): detect OpenRouter keys before OpenAI

### DIFF
--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -581,6 +581,10 @@ def detect_api_provider(api_key: str) -> Tuple[str, str]:
     if api_key.startswith('sk-ant-'):
         return 'anthropic', 'claude'
 
+    # OpenRouter shares the generic sk- prefix, so match it before OpenAI.
+    if api_key.startswith('sk-or-'):
+        return 'openrouter', 'openrouter'
+
     # OpenAI formats
     if api_key.startswith('sk-proj-'):
         return 'openai', 'project'
@@ -598,10 +602,6 @@ def detect_api_provider(api_key: str) -> Tuple[str, str]:
     # xAI Grok
     if api_key.startswith('xai-'):
         return 'grok', 'xai'
-
-    # OpenRouter
-    if api_key.startswith('sk-or-'):
-        return 'openrouter', 'openrouter'
 
     # Default to OpenAI if unsure
     return 'openai', 'unknown'

--- a/tests/unit/test_project_cmd_lib.py
+++ b/tests/unit/test_project_cmd_lib.py
@@ -3,7 +3,33 @@
 import sys
 from pathlib import Path
 
-from connectonion.cli.commands.project_cmd_lib import upsert_env
+from connectonion.cli.commands.project_cmd_lib import (
+    configure_env_for_provider,
+    detect_api_provider,
+    upsert_env,
+)
+
+
+class TestApiProviderDetection:
+    """Provider-specific key prefixes win before generic prefixes."""
+
+    def test_specific_sk_prefixes_win_before_generic_openai_prefix(self):
+        assert detect_api_provider("sk-or-v1-test-key") == (
+            "openrouter",
+            "openrouter",
+        )
+        assert detect_api_provider("sk-proj-test-key") == ("openai", "project")
+        assert detect_api_provider("sk-test-key") == ("openai", "user")
+
+    def test_openrouter_key_configures_openrouter_environment(self):
+        api_key = "sk-or-v1-test-key"
+        provider, _key_type = detect_api_provider(api_key)
+
+        env_content = configure_env_for_provider(provider, api_key)
+
+        assert f"OPENROUTER_API_KEY={api_key}" in env_content
+        assert "OPENAI_API_KEY=" not in env_content
+        assert "MODEL=openrouter/openai/o4-mini" in env_content
 
 
 class TestUpsertEnv:


### PR DESCRIPTION
## Description

Detect OpenRouter API keys before the generic OpenAI `sk-` prefix so project setup writes the key and model configuration for the intended provider.

## Related Issue

Fixes #1341

## Labels and target release (required)

- **Suggested labels:** bug, no-blog
- **Proposed target version:** 1.7.1
- **Estimated release window:** next stable patch
- **Milestone:** 1.7.1 — framework correctness patch
- **Why this release:** v1.7.0 deterministically misclassifies every `sk-or-...` key. The fix only reorders a more-specific prefix check, adds no dependency, and can be reverted as one commit.
- **Forward-port tracking issue (stable patches only):** #1342

## How this was written

- [x] AI-assisted — I reviewed every line and can explain why each change is there

**Which model?** GPT-5.6 via Codex.

The least certain surface is whether a future provider will introduce another overlapping `sk-` prefix; this PR covers the prefixes currently supported by the framework. I did not run a live provider request because the failure occurs before any network call. If the change is wrong, `co init` / `co create --key` would select the wrong environment-variable block; the regression tests exercise that boundary directly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dev Blog (required)

This is a two-line prefix-precedence correction with regression coverage. Maintainer exemption: `no-blog`.

## Changes Made

- Match `sk-or-` before the generic OpenAI `sk-` key prefix.
- Assert OpenRouter, OpenAI project, and OpenAI user key precedence.
- Assert an OpenRouter key generates `OPENROUTER_API_KEY` and the OpenRouter model configuration.

## Testing

```text
$ /Users/changxing/projects/connectonion/.venv/bin/python -m pytest tests/unit/test_project_cmd_lib.py tests/e2e/cli/test_cli_init.py tests/e2e/cli/test_cli_create.py -q
68 passed in 32.94s
```

- [x] I have added regression tests

## Scope

- `connectonion/cli/commands/project_cmd_lib.py`: correct provider-prefix precedence.
- `tests/unit/test_project_cmd_lib.py`: lock the detection and generated environment contract.

No browser, Patchright, Onionwright, paid-browser, release-workflow, or dependency files change.

## Example Usage

```bash
co init --key sk-or-v1-...
# writes OPENROUTER_API_KEY and selects the OpenRouter model path
```

## Checklist

- [x] I proposed labels and target version
- [x] I reviewed the complete diff
- [x] Focused and CLI regression tests pass
- [x] A maintainer applies `no-blog`
- [x] The stable forward-port tracker is #1342 and remains open through the main forward-port
- [x] The linked issue's implementation contract is covered by deterministic tests

## Screenshots (if applicable)

Not applicable: provider selection occurs in CLI configuration generation.
