### PR TITLE
fix(outlook): reuse valid Microsoft tokens

### DIFF
--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -2,7 +2,7 @@
 Purpose: Outlook integration tool for email and contact management via Microsoft Graph API
 LLM-Note:
   Dependencies: imports from [os, html, httpx] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth microsoft' | tested by [tests/unit/test_outlook.py]
-  Data flow: Agent calls Outlook methods → _get_access_token() validates the ambient OpenOnion account and refreshes locally owned Microsoft tokens via oo-api → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | download_attachments() decodes Graph fileAttachment bytes into a caller-selected project directory without overwriting existing paths | send()/reply() with attachments share _encoded_attachments() (validate, size-check, base64) and place fileAttachments on the sent message — reply() puts them on the reply action's message so Graph still threads it | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
+  Data flow: Agent calls Outlook methods → _get_access_token() uses a cached Microsoft access token while its expiry is valid or unknown, preemptively refreshing near expiry via oo-api and refreshing after a Graph 401 → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | download_attachments() decodes Graph fileAttachment bytes into a caller-selected project directory without overwriting existing paths | send()/reply() with attachments share _encoded_attachments() (validate, size-check, base64) and place fileAttachments on the sent message — reply() puts them on the reply action's message so Graph still threads it | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
   State/Effects: reads MICROSOFT_* env vars for OAuth tokens/scopes | makes HTTP calls to Microsoft Graph API | can modify mailbox state (mark read, archive, send emails), create contacts, and write downloaded attachments inside the project boundary | token refresh rewrites ~/.co/keys.env
   Integration: exposes Outlook class with email methods plus add_contact(), list_contacts(), search_contacts() | structured list methods feed cli/commands/outlook_commands.py | used as agent tool via Agent(tools=[Outlook()]) | reply(email_id, body, send_at, *, attachments) keeps send_at third positional for pre-attachment callers, so attachments is keyword-only
   Performance: network I/O per API call | batch fetching for list operations | email body fetched separately
@@ -46,6 +46,7 @@ Example:
 
 import html
 import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import httpx
@@ -98,27 +99,51 @@ class Outlook:
             )
 
     def _get_access_token(self) -> str:
-        """Get Microsoft access token, refreshing once per Outlook instance.
+        """Return a usable Microsoft access token.
 
-        Microsoft refresh tokens have a 90-day default lifetime in this flow
-        and each refresh can return a replacement. Persist the newest token
-        locally; interactive authorization is still required if Microsoft
-        expires or revokes it.
+        Refresh only when a parseable expiry is within five minutes. Older
+        credential files may have no expiry (or a malformed one); use their
+        access token first and let Graph's 401 response trigger one refresh.
+        This keeps a working Microsoft token independent of the refresh broker
+        until a refresh is actually necessary.
         """
-        if self._access_token:
-            return self._access_token
-
-        access_token = os.getenv("MICROSOFT_ACCESS_TOKEN")
+        access_token = self._access_token or os.getenv("MICROSOFT_ACCESS_TOKEN")
         refresh_token = os.getenv("MICROSOFT_REFRESH_TOKEN")
+        expires_at = self._parse_token_expiry(
+            os.getenv("MICROSOFT_TOKEN_EXPIRES_AT")
+        )
 
-        if not access_token or not refresh_token:
+        if not access_token:
             raise ValueError(
                 "Microsoft OAuth credentials not found.\n"
                 "Run: co auth microsoft"
             )
 
-        self._access_token = self._refresh_via_backend(refresh_token)
+        if expires_at is not None:
+            refresh_at = expires_at - timedelta(minutes=5)
+            if datetime.now(timezone.utc) >= refresh_at:
+                if not refresh_token:
+                    raise ValueError(
+                        "Microsoft access token is expiring, but its refresh "
+                        "credential is missing.\nRun: co auth microsoft"
+                    )
+                access_token = self._refresh_via_backend(refresh_token)
+
+        self._access_token = access_token
         return self._access_token
+
+    @staticmethod
+    def _parse_token_expiry(value: str | None) -> datetime | None:
+        """Parse a token expiry as UTC, returning ``None`` for legacy values."""
+        if not value:
+            return None
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
 
     def _refresh_via_backend(self, refresh_token: str) -> str:
         """Refresh tokens via backend API and persist the rotated pair.
@@ -139,6 +164,28 @@ class Outlook:
         )
 
         if response.status_code != 200:
+            try:
+                payload = response.json()
+                detail = (
+                    payload.get("detail") if isinstance(payload, dict) else None
+                )
+            except (TypeError, ValueError):
+                detail = None
+
+            if (
+                response.status_code == 401
+                and isinstance(detail, dict)
+                and detail.get("error") == "reauth_required"
+            ):
+                raise ValueError(
+                    "Microsoft authorization expired.\n"
+                    "Run: co auth microsoft"
+                )
+            if response.status_code == 401:
+                raise ValueError(
+                    "OpenOnion authentication failed while refreshing "
+                    "Microsoft access.\nRun: co auth"
+                )
             raise ValueError(
                 f"Microsoft session expired and refresh failed ({response.status_code}).\n"
                 "Reconnect with: co auth microsoft"
@@ -193,9 +240,20 @@ class Outlook:
             if refresh_token:
                 self._access_token = None
                 token = self._refresh_via_backend(refresh_token)
+                self._access_token = token
                 headers["Authorization"] = f"Bearer {token}"
                 response = httpx.request(method, url, headers=headers, **kwargs)
 
+        if response.status_code == 401:
+            raise ValueError(
+                "Microsoft authorization expired.\n"
+                "Run: co auth microsoft"
+            )
+        if response.status_code == 403:
+            raise ValueError(
+                "Microsoft permission denied for this operation.\n"
+                "Reconnect to grant the required scope: co auth microsoft"
+            )
         if response.status_code not in [200, 201, 202, 204]:
             raise ValueError(f"Microsoft Graph API error: {response.status_code} - {response.text}")
 

--- a/docs/cli/outlook.md
+++ b/docs/cli/outlook.md
@@ -250,8 +250,10 @@ outlook.send(
 - **Missing Mail scopes** → run `co auth microsoft` again to re-consent.
 - **Missing `Contacts.ReadWrite`** → run `co auth microsoft` again; an older
   token cannot gain the new permission through refresh alone.
-- **Token expired** → tokens auto-refresh; if issues persist, re-run
-  `co auth microsoft`.
+- **OpenOnion authentication failed during token refresh** → run `co auth`.
+- **Microsoft authorization expired or permission denied** → tokens
+  auto-refresh when possible; re-run `co auth microsoft` if Microsoft revoked
+  the refresh token or the operation needs another scope.
 - **`No email #N in your inbox`** → the number is out of range; run
   `co outlook inbox` to refresh the listing.
 - **`co outlook cancel` rejected with 403** → some Exchange work/school

--- a/docs/useful_tools/outlook.md
+++ b/docs/useful_tools/outlook.md
@@ -214,4 +214,10 @@ to grant the new contact permission.
 
 **Credentials not found**: Run `co auth microsoft`
 
-**Token expired**: Tokens auto-refresh. If issues persist, run `co auth microsoft` again.
+**OpenOnion authentication failed while refreshing Microsoft access**: Run
+`co auth`. Your Microsoft access token is reused while it remains valid, but a
+refresh still needs a valid OpenOnion session.
+
+**Microsoft authorization expired or permission denied**: Run
+`co auth microsoft` again. Tokens auto-refresh when possible; reauthorization
+is required after Microsoft revokes a refresh token or when a scope is missing.

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -12,15 +12,18 @@ Components under test:
 
 import base64
 import os
-import pytest
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, MagicMock
+
+import pytest
 
 
 @pytest.fixture(autouse=True)
 def _stub_token_refresh(request, monkeypatch):
-    """Outlook refreshes tokens once per instance; stub that network call so
-    Graph-operation tests stay isolated. Tests of the refresh flow itself
-    opt out with @pytest.mark.real_refresh."""
+    """Keep Graph-operation tests isolated from the refresh broker.
+
+    Tests of the real refresh flow opt out with @pytest.mark.real_refresh.
+    """
     if "real_refresh" in request.keywords:
         return
     from connectonion.useful_tools.outlook import Outlook
@@ -75,7 +78,7 @@ class TestOutlookTokenManagement:
             assert "credentials not found" in str(exc_info.value)
 
     def test_get_access_token_returns_valid_token(self):
-        """Test that valid token is returned."""
+        """A token with a future expiry does not depend on the broker."""
         with patch.dict(os.environ, {
             "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
             "MICROSOFT_ACCESS_TOKEN": "test-token",
@@ -84,13 +87,89 @@ class TestOutlookTokenManagement:
         }, clear=False):
             from connectonion.useful_tools.outlook import Outlook
             outlook = Outlook()
+            outlook._refresh_via_backend = MagicMock(return_value="unexpected")
             token = outlook._get_access_token()
             assert token == "test-token"
+            outlook._refresh_via_backend.assert_not_called()
+
+    def test_get_access_token_refreshes_near_expiry(self):
+        """A parseable expiry inside the five-minute window refreshes early."""
+        near_expiry = (datetime.now(timezone.utc) + timedelta(minutes=2)).isoformat()
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "old-token",
+            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": near_expiry,
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            outlook._refresh_via_backend = MagicMock(return_value="new-token")
+
+            assert outlook._get_access_token() == "new-token"
+            outlook._refresh_via_backend.assert_called_once_with("test-refresh")
+
+    @pytest.mark.parametrize("expiry", ["", "not-an-iso-date"])
+    def test_unknown_expiry_uses_existing_token(self, expiry):
+        """Legacy or malformed expiry metadata does not force a refresh."""
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "test-token",
+            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": expiry,
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            outlook._refresh_via_backend = MagicMock(return_value="unexpected")
+
+            assert outlook._get_access_token() == "test-token"
+            outlook._refresh_via_backend.assert_not_called()
+
+    def test_valid_access_token_does_not_require_refresh_credential(self):
+        """A usable access token remains useful when its refresh token is absent."""
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "test-token",
+            "MICROSOFT_REFRESH_TOKEN": "",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z",
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+
+            assert Outlook()._get_access_token() == "test-token"
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_unknown_expiry_refreshes_after_graph_401(self, mock_httpx):
+        """Graph remains the expiry authority when local metadata is malformed."""
+        rejected = MagicMock(status_code=401, text="expired")
+        accepted = MagicMock(status_code=200, text="ok")
+        accepted.json.return_value = {"value": []}
+        responses = iter([rejected, accepted])
+        authorizations = []
+
+        def request_with_auth(*args, **kwargs):
+            authorizations.append(kwargs["headers"]["Authorization"])
+            return next(responses)
+
+        mock_httpx.request.side_effect = request_with_auth
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "old-token",
+            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "unknown",
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            outlook._refresh_via_backend = MagicMock(return_value="new-token")
+
+            assert outlook._request("GET", "/me/messages") == {"value": []}
+            outlook._refresh_via_backend.assert_called_once_with("test-refresh")
+
+        assert authorizations == ["Bearer old-token", "Bearer new-token"]
 
     @pytest.mark.real_refresh
     @patch('connectonion.useful_tools.outlook.httpx')
     def test_refresh_persists_rotated_refresh_token(self, mock_httpx, tmp_path):
-        """Every use refreshes and saves the rotated refresh token to keys.env."""
+        """An expired token refreshes and saves the rotated token to keys.env."""
         keys_env = tmp_path / "keys.env"
         keys_env.write_text(
             "MICROSOFT_ACCESS_TOKEN=old-access\n"
@@ -111,6 +190,7 @@ class TestOutlookTokenManagement:
             "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
             "MICROSOFT_ACCESS_TOKEN": "old-access",
             "MICROSOFT_REFRESH_TOKEN": "old-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2000-01-01T00:00:00Z",
             "OPENONION_API_KEY": "test-key",
             "AGENT_CONFIG_PATH": str(tmp_path),
         }, clear=False):
@@ -143,6 +223,7 @@ class TestOutlookTokenManagement:
             "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
             "MICROSOFT_ACCESS_TOKEN": "old-access",
             "MICROSOFT_REFRESH_TOKEN": "old-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2000-01-01T00:00:00Z",
             "OPENONION_API_KEY": "test-key",
             "AGENT_CONFIG_PATH": str(tmp_path),
         }, clear=False):
@@ -177,6 +258,7 @@ class TestOutlookTokenManagement:
             "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
             "MICROSOFT_ACCESS_TOKEN": "old-access",
             "MICROSOFT_REFRESH_TOKEN": "old-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2000-01-01T00:00:00Z",
             "OPENONION_API_KEY": "test-key",
             "AGENT_CONFIG_PATH": str(config_dir),
         }, clear=False):
@@ -208,6 +290,7 @@ class TestOutlookTokenManagement:
             "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
             "MICROSOFT_ACCESS_TOKEN": "old-access",
             "MICROSOFT_REFRESH_TOKEN": "old-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2000-01-01T00:00:00Z",
             "OPENONION_API_KEY": "test-key",
             "AGENT_CONFIG_PATH": str(config_dir),
         }, clear=False):
@@ -215,6 +298,117 @@ class TestOutlookTokenManagement:
             assert Outlook()._get_access_token() == "new-access"
 
         assert (tmp_path / ".env").read_text() == "DATABASE_URL=postgres://local\n"
+
+    @pytest.mark.real_refresh
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_refresh_requires_openonion_auth(self, mock_httpx):
+        """A missing broker credential points to co auth, not Microsoft OAuth."""
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "OPENONION_API_KEY": "",
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            with pytest.raises(ValueError) as exc_info:
+                Outlook()._refresh_via_backend("refresh-token")
+
+        message = str(exc_info.value)
+        assert "co auth" in message
+        assert "co auth microsoft" not in message
+        assert "refresh-token" not in message
+        mock_httpx.post.assert_not_called()
+
+    @pytest.mark.real_refresh
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_backend_rejected_openonion_key_points_to_co_auth(self, mock_httpx):
+        """A broker-level 401 identifies the OpenOnion credential layer."""
+        response = MagicMock(status_code=401)
+        response.json.return_value = {"detail": "Invalid token"}
+        mock_httpx.post.return_value = response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "OPENONION_API_KEY": "invalid-openonion-key",
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            with pytest.raises(ValueError) as exc_info:
+                Outlook()._refresh_via_backend("microsoft-refresh-token")
+
+        message = str(exc_info.value)
+        assert "OpenOnion authentication failed" in message
+        assert "co auth" in message
+        assert "co auth microsoft" not in message
+        assert "invalid-openonion-key" not in message
+        assert "microsoft-refresh-token" not in message
+
+    @pytest.mark.real_refresh
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_microsoft_reauth_failure_points_to_microsoft_auth(self, mock_httpx):
+        """An explicit Microsoft revocation response keeps its own remedy."""
+        response = MagicMock(status_code=401)
+        response.json.return_value = {
+            "detail": {"error": "reauth_required"},
+        }
+        mock_httpx.post.return_value = response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "OPENONION_API_KEY": "valid-openonion-key",
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            with pytest.raises(ValueError) as exc_info:
+                Outlook()._refresh_via_backend("revoked-refresh-token")
+
+        message = str(exc_info.value)
+        assert "Microsoft authorization expired" in message
+        assert "co auth microsoft" in message
+        assert "valid-openonion-key" not in message
+        assert "revoked-refresh-token" not in message
+
+    @pytest.mark.real_refresh
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_other_microsoft_refresh_failure_points_to_microsoft_auth(self, mock_httpx):
+        """A non-auth broker failure still identifies the Microsoft session."""
+        response = MagicMock(status_code=400)
+        response.json.return_value = {"detail": "invalid_grant"}
+        mock_httpx.post.return_value = response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "OPENONION_API_KEY": "valid-openonion-key",
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            with pytest.raises(ValueError) as exc_info:
+                Outlook()._refresh_via_backend("revoked-refresh-token")
+
+        message = str(exc_info.value)
+        assert "Microsoft session expired" in message
+        assert "co auth microsoft" in message
+        assert "valid-openonion-key" not in message
+        assert "revoked-refresh-token" not in message
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_graph_scope_failure_points_to_microsoft_auth(self, mock_httpx):
+        """Graph 403 is a Microsoft consent problem, not an OpenOnion login."""
+        mock_httpx.request.return_value = MagicMock(
+            status_code=403,
+            text="ErrorAccessDenied",
+        )
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "access-token",
+            "MICROSOFT_REFRESH_TOKEN": "refresh-token",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z",
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            with pytest.raises(ValueError) as exc_info:
+                Outlook()._request("GET", "/me/messages")
+
+        message = str(exc_info.value)
+        assert "Microsoft permission denied" in message
+        assert "co auth microsoft" in message
+        assert "access-token" not in message
+        assert "refresh-token" not in message
 
 
 class TestOutlookEmailFormatting:


### PR DESCRIPTION
## Description

Keep a usable Microsoft access token independent of the refresh broker until refresh is actually needed, and attribute authentication failures to the correct login layer.

## Related Issue

Fixes #1312
Fixes #1313

## Labels and target release (required)

- **Suggested labels:** bug, no-blog
- **Proposed target version:** 1.7.1
- **Estimated release window:** next stable patch
- **Milestone:** 1.7.1 — framework correctness patch
- **Why this release:** v1.7.0 discards a working Microsoft token on first use and can turn an OpenOnion login failure into a misleading Microsoft re-consent instruction. The patch is isolated to Outlook token selection/error attribution and retains the existing Graph-401 refresh retry.
- **Forward-port tracking issue (stable patches only):** #1342

## How this was written

- [x] AI-assisted — I reviewed every line and can explain why each change is there

**Which model?** GPT-5.6 via Codex.

The least certain boundary is the live refresh broker's error payload outside the already established `detail.error = reauth_required` contract. I did not use a real Microsoft mailbox or refresh token; all network boundaries are mocked and secret-redaction assertions are included. If this is wrong, a genuinely expired token will fail during the pre-refresh or one Graph-401 retry, with the remedy naming the responsible authentication layer.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Dev Blog (required)

This maintenance patch corrects token reuse and two troubleshooting remedies; it does not introduce a reusable design story. Maintainer exemption: `no-blog`.

## Changes Made

- Reuse cached/env Microsoft access tokens while expiry is safely in the future.
- Pre-refresh within five minutes of a parseable expiry.
- Treat missing or malformed legacy expiry metadata as unknown and let Graph 401 be authoritative.
- Keep the existing single refresh-and-retry behavior after Graph 401.
- Point missing/rejected OpenOnion credentials to `co auth`.
- Point Microsoft revocation and Graph permission failures to `co auth microsoft`.
- Update both Outlook troubleshooting references.

## Testing

```text
$ /Users/changxing/projects/connectonion/.venv/bin/python -m pytest tests/unit/test_outlook.py -q
69 passed in 1.33s

$ /Users/changxing/projects/connectonion/.venv/bin/python -m pytest tests/unit/test_credentials.py tests/unit/test_doctor_credentials_are_redacted.py tests/unit/test_home_isolation.py tests/unit/test_microsoft_calendar.py tests/unit/test_outlook_commands.py tests/e2e/cli/test_cli_outlook_contacts.py tests/e2e/cli/test_cli_outlook_reply.py -q
94 passed in 0.64s
```

- [x] I have added regression tests

## Scope

- `connectonion/useful_tools/outlook.py`: token validity window, refresh trigger, and actionable error attribution.
- `tests/unit/test_outlook.py`: future/near/missing/malformed expiry, Graph retry, auth-layer attribution, and secret-redaction coverage.
- `docs/cli/outlook.md`, `docs/useful_tools/outlook.md`: correct remedies.

No send/schedule behavior, browser code, Patchright, Onionwright, paid-browser, dependency, or release-workflow files change.

## Example Usage

Existing Outlook calls are unchanged. A valid local Microsoft access token now works even when the refresh broker is temporarily unavailable.

## Checklist

- [x] I proposed labels and target version
- [x] I reviewed the complete diff
- [x] Focused Outlook and credential regression suites pass
- [x] Documentation names both authentication layers
- [x] A maintainer applies `no-blog`
- [x] The stable forward-port tracker is #1342 and remains open through the main forward-port
- [x] The linked issues' implementation contracts are covered by deterministic tests

## Screenshots (if applicable)

Not applicable: this is an OAuth token/error-path correction.
