### PR TITLE
fix: report file tool refusals as failures

### DIFF
--- a/connectonion/core/tool_executor.py
+++ b/connectonion/core/tool_executor.py
@@ -6,7 +6,7 @@ LLM-Note:
   State/Effects: mutates agent.current_session['messages'] by appending assistant message with tool_calls and tool result messages | mutates agent.current_session['trace'] by appending tool_call then tool_result entries | calls logger.log_tool_call() and logger.log_tool_result() for user feedback | injects/clears xray context via thread-local storage
   Integration: exposes execute_and_record_tools(tool_calls, tools, agent, logger), execute_single_tool(...) | uses logger.log_tool_call(name, args) for natural function-call style output: greet(name='Alice') | creates trace entries with type, tool_name, arguments, call_id, result, status, timing, iteration, timestamp
   Performance: times each tool execution in milliseconds | executes tools sequentially (not parallel) | trace entry added BEFORE auto-trace so xray.trace() sees it | agent injection uses cached _needs_agent flag (set by tool_factory) instead of inspect.signature() for zero overhead
-  Errors: catches all tool execution exceptions | wraps errors in trace_entry with error, error_type fields | returns error message to LLM for retry | prints error to logger with red ✗
+  Errors: catches tool exceptions and recognizes explicit ToolFailure results | wraps failures in trace_entry with error, error_type fields | returns error message to LLM for retry | prints error to logger with red ✗
 """
 
 import asyncio
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional
 
 from ..debug.xray import clear_xray_context, inject_xray_context, is_xray_enabled
 from .interrupt import InterruptibleIO, UserInterrupt, run_interruptible
+from .tool_result import ToolFailure
 
 _async_loop: Optional[asyncio.AbstractEventLoop] = None
 _async_loop_thread: Optional[threading.Thread] = None
@@ -501,7 +502,12 @@ def execute_single_tool(
 
         trace_entry["timing_ms"] = tool_duration
         trace_entry["result"] = str(result)
-        trace_entry["status"] = "success"
+        if isinstance(result, ToolFailure):
+            trace_entry["status"] = "error"
+            trace_entry["error"] = str(result)
+            trace_entry["error_type"] = type(result).__name__
+        else:
+            trace_entry["status"] = "success"
 
     except UserInterrupt:
         return interrupted_tool_result()
@@ -548,7 +554,12 @@ def execute_single_tool(
             agent._record_trace(trace_entry, wire_extras=wire_extras)
         else:
             agent._record_trace(trace_entry)
-        logger.log_tool_result(trace_entry["result"], tool_duration)
+        if trace_entry["status"] == "error":
+            logger.log_tool_result(
+                trace_entry["result"], tool_duration, success=False
+            )
+        else:
+            logger.log_tool_result(trace_entry["result"], tool_duration)
 
         if xray_enabled:
             logger.print_xray_table(

--- a/connectonion/core/tool_result.py
+++ b/connectonion/core/tool_result.py
@@ -1,0 +1,13 @@
+"""Typed return values that carry tool execution outcome semantics."""
+
+
+class ToolFailure(str):
+    """A string-compatible, expected tool failure.
+
+    Tools use this for user-correctable refusals and validation failures that
+    should reach the model as ordinary text while still being recorded and
+    displayed as a failed execution. Ordinary strings, including strings that
+    happen to start with ``"Error:"``, keep their existing success semantics.
+    """
+
+    __slots__ = ()

--- a/connectonion/logger.py
+++ b/connectonion/logger.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [datetime, pathlib, typing, json, re, yaml, os, console.py] | imported by [agent.py, tool_executor.py] | tested by [tests/unit/test_logger.py]
   Data flow: receives from Agent/tool_executor → delegates to Console for terminal/file → writes YAML evals to .co/evals/
   State/Effects: writes to .co/evals/{input_slug}.yaml (one file per unique first input — _slugify keeps Unicode word characters, so a Chinese, Japanese or Cyrillic prompt gets its own file; keeping only [a-zA-Z0-9] made every non-Latin prompt collapse to `default` and share one) | retains KEEP_EVAL_RECORDS generated records and KEEP_RUNS_PER_EVAL runs per record | authored evals are never pruned | eval data persisted after each turn
-  Integration: exposes Logger(agent_name, quiet, log), .print(), .log_tool_call(name, args), .log_tool_result(result, timing), .log_llm_response(), .start_session(), .log_turn()
+  Integration: exposes Logger(agent_name, quiet, log), .print(), .log_tool_call(name, args), .log_tool_result(result, timing, success), .log_llm_response(), .start_session(), .log_turn()
   Eval format: eval.yaml (metadata + turns) | run_N.yaml (system_prompt, model, cwd, tokens, cost, duration_ms, timestamp, messages as multi-line JSON)
   Performance: YAML written after each turn (incremental) | Console delegation is direct passthrough
   Errors: let I/O errors bubble up (no try-except)
@@ -171,10 +171,15 @@ class Logger:
         if self.console:
             self.console.log_tool_call(tool_name, tool_args)
 
-    def log_tool_result(self, result: str, timing_ms: float):
+    def log_tool_result(
+        self, result: str, timing_ms: float, success: bool = True
+    ) -> None:
         """Log tool result."""
         if self.console:
-            self.console.log_tool_result(result, timing_ms)
+            if success:
+                self.console.log_tool_result(result, timing_ms)
+            else:
+                self.console.log_tool_result(result, timing_ms, success=False)
 
     def _format_tool_call(self, trace_entry: dict) -> str:
         """Format tool call as natural function-call style: greet(name='Alice')"""

--- a/connectonion/useful_tools/file_tools/edit.py
+++ b/connectonion/useful_tools/file_tools/edit.py
@@ -15,6 +15,8 @@ Usage:
 
 from pathlib import Path
 
+from ...core.tool_result import ToolFailure
+
 
 def edit(
     file_path: str,
@@ -45,10 +47,10 @@ def edit(
     path = Path(file_path)
 
     if not path.exists():
-        return f"Error: File '{file_path}' does not exist"
+        return ToolFailure(f"Error: File '{file_path}' does not exist")
 
     if not path.is_file():
-        return f"Error: '{file_path}' is not a file"
+        return ToolFailure(f"Error: '{file_path}' is not a file")
 
     content = path.read_text(encoding="utf-8")
 
@@ -70,7 +72,7 @@ def edit(
         msg = f"Error: String not found in '{file_path}'"
         if lines_with_similar:
             msg += f"\n\nSimilar content found:\n" + "\n".join(lines_with_similar[:5])
-        return msg
+        return ToolFailure(msg)
 
     if count > 1 and not replace_all:
         # Show where the duplicates are
@@ -79,7 +81,7 @@ def edit(
             if old_string in line:
                 lines_with_match.append(f"  Line {i}: {line[:80]}")
 
-        return (
+        return ToolFailure(
             f"Error: String appears {count} times in '{file_path}'. "
             f"Use replace_all=True to replace all, or provide more context to make it unique.\n\n"
             f"Found at:\n" + "\n".join(lines_with_match[:10])

--- a/connectonion/useful_tools/file_tools/file_tools.py
+++ b/connectonion/useful_tools/file_tools/file_tools.py
@@ -16,6 +16,7 @@ import hashlib
 from pathlib import Path
 from typing import Optional, List, Literal
 
+from ...core.tool_result import ToolFailure
 from .read import read_file as _read_file
 from .edit import edit as _edit
 from .multi_edit import multi_edit as _multi_edit, EditOperation
@@ -64,7 +65,7 @@ class FileTools:
         result = _read_file(path, offset, limit)
 
         # Track snapshot for edit validation (only if read succeeded)
-        if not result.startswith("Error:"):
+        if not isinstance(result, ToolFailure):
             file_path = Path(path)
             if file_path.exists() and file_path.is_file():
                 content = file_path.read_text(encoding="utf-8", errors="replace")
@@ -132,16 +133,20 @@ class FileTools:
             Success message or error description
         """
         if self._permission == "read":
-            return "Error: Permission denied - FileTools is in read-only mode"
+            return ToolFailure(
+                "Error: Permission denied - FileTools is in read-only mode"
+            )
 
         # Check if file was read first
         if file_path not in self._snapshots:
-            return f"Error: Read '{file_path}' before editing (use read_file first)"
+            return ToolFailure(
+                f"Error: Read '{file_path}' before editing (use read_file first)"
+            )
 
         # Check if file changed since read (stale-read protection)
         path = Path(file_path)
         if not path.exists():
-            return f"Error: File '{file_path}' no longer exists"
+            return ToolFailure(f"Error: File '{file_path}' no longer exists")
 
         current_content = path.read_text(encoding="utf-8", errors="replace")
         current_hash = hashlib.md5(current_content.encode()).hexdigest()
@@ -149,13 +154,15 @@ class FileTools:
         if current_hash != self._snapshots[file_path]:
             # File changed externally - invalidate snapshot
             del self._snapshots[file_path]
-            return f"Error: '{file_path}' changed since last read - re-read it first"
+            return ToolFailure(
+                f"Error: '{file_path}' changed since last read - re-read it first"
+            )
 
         # Perform the edit
         result = _edit(file_path, old_string, new_string, replace_all)
 
         # Update snapshot if edit succeeded
-        if not result.startswith("Error:"):
+        if not isinstance(result, ToolFailure):
             new_content = path.read_text(encoding="utf-8", errors="replace")
             self._snapshots[file_path] = hashlib.md5(new_content.encode()).hexdigest()
 
@@ -177,29 +184,35 @@ class FileTools:
             Success message or error description
         """
         if self._permission == "read":
-            return "Error: Permission denied - FileTools is in read-only mode"
+            return ToolFailure(
+                "Error: Permission denied - FileTools is in read-only mode"
+            )
 
         # Check if file was read first
         if file_path not in self._snapshots:
-            return f"Error: Read '{file_path}' before editing (use read_file first)"
+            return ToolFailure(
+                f"Error: Read '{file_path}' before editing (use read_file first)"
+            )
 
         # Check if file changed since read
         path = Path(file_path)
         if not path.exists():
-            return f"Error: File '{file_path}' no longer exists"
+            return ToolFailure(f"Error: File '{file_path}' no longer exists")
 
         current_content = path.read_text(encoding="utf-8", errors="replace")
         current_hash = hashlib.md5(current_content.encode()).hexdigest()
 
         if current_hash != self._snapshots[file_path]:
             del self._snapshots[file_path]
-            return f"Error: '{file_path}' changed since last read - re-read it first"
+            return ToolFailure(
+                f"Error: '{file_path}' changed since last read - re-read it first"
+            )
 
         # Perform multi-edit
         result = _multi_edit(file_path, edits)
 
         # Update snapshot if edit succeeded
-        if not result.startswith("Error:"):
+        if not isinstance(result, ToolFailure):
             new_content = path.read_text(encoding="utf-8", errors="replace")
             self._snapshots[file_path] = hashlib.md5(new_content.encode()).hexdigest()
 
@@ -219,13 +232,15 @@ class FileTools:
             Success message or error description
         """
         if self._permission == "read":
-            return "Error: Permission denied - FileTools is in read-only mode"
+            return ToolFailure(
+                "Error: Permission denied - FileTools is in read-only mode"
+            )
 
         # write() is full overwrite - no snapshot check needed
         result = _write(path, content)
 
         # Track snapshot after write (for subsequent edits)
-        if not result.startswith("Error:"):
+        if not isinstance(result, ToolFailure):
             file_path = Path(path)
             if file_path.exists() and file_path.is_file():
                 content_on_disk = file_path.read_text(encoding="utf-8", errors="replace")

--- a/connectonion/useful_tools/file_tools/glob.py
+++ b/connectonion/useful_tools/file_tools/glob.py
@@ -16,6 +16,8 @@ Usage:
 from pathlib import Path
 from typing import Optional
 
+from ...core.tool_result import ToolFailure
+
 IGNORE_DIRS = {
     ".git",
     "node_modules",
@@ -54,10 +56,10 @@ def glob(pattern: str, path: Optional[str] = None) -> str:
     base = Path(path) if path else Path.cwd()
 
     if not base.exists():
-        return f"Error: Path '{base}' does not exist"
+        return ToolFailure(f"Error: Path '{base}' does not exist")
 
     if not base.is_dir():
-        return f"Error: Path '{base}' is not a directory"
+        return ToolFailure(f"Error: Path '{base}' is not a directory")
 
     matches = []
     for p in base.glob(pattern):

--- a/connectonion/useful_tools/file_tools/grep.py
+++ b/connectonion/useful_tools/file_tools/grep.py
@@ -17,6 +17,7 @@ import re
 from pathlib import Path
 from typing import Optional, Literal
 
+from ...core.tool_result import ToolFailure
 from .glob import IGNORE_DIRS
 
 
@@ -56,14 +57,14 @@ def grep(
     base = Path(path) if path else Path.cwd()
 
     if not base.exists():
-        return f"Error: Path '{base}' does not exist"
+        return ToolFailure(f"Error: Path '{base}' does not exist")
 
     # Compile regex
     flags = re.IGNORECASE if ignore_case else 0
     try:
         regex = re.compile(pattern, flags)
     except re.error as e:
-        return f"Error: Invalid regex pattern: {e}"
+        return ToolFailure(f"Error: Invalid regex pattern: {e}")
 
     # Collect files to search
     if base.is_file():

--- a/connectonion/useful_tools/file_tools/multi_edit.py
+++ b/connectonion/useful_tools/file_tools/multi_edit.py
@@ -17,6 +17,8 @@ Usage:
 from pathlib import Path
 from typing import List, TypedDict
 
+from ...core.tool_result import ToolFailure
+
 
 class EditOperation(TypedDict, total=False):
     """Single edit operation."""
@@ -54,13 +56,13 @@ def multi_edit(
     path = Path(file_path)
 
     if not path.exists():
-        return f"Error: File '{file_path}' does not exist"
+        return ToolFailure(f"Error: File '{file_path}' does not exist")
 
     if not path.is_file():
-        return f"Error: '{file_path}' is not a file"
+        return ToolFailure(f"Error: '{file_path}' is not a file")
 
     if not edits:
-        return "Error: No edits provided"
+        return ToolFailure("Error: No edits provided")
 
     # Read original content
     original_content = path.read_text(encoding="utf-8")
@@ -74,7 +76,7 @@ def multi_edit(
         replace_all = edit.get("replace_all", False)
 
         if not old_string:
-            return f"Error: Edit {i+1} missing 'old_string'"
+            return ToolFailure(f"Error: Edit {i+1} missing 'old_string'")
 
         # Check if old_string exists in current content
         count = content.count(old_string)
@@ -83,16 +85,19 @@ def multi_edit(
             # Show what edits were successful before failure
             if applied:
                 applied_msg = "\n".join([f"  {j+1}. Replaced '{e['old']}'" for j, e in enumerate(applied)])
-                return (
+                return ToolFailure(
                     f"Error: Edit {i+1} failed - string not found after previous edits.\n"
                     f"Looking for: {repr(old_string[:100])}\n\n"
                     f"Successfully applied before failure:\n{applied_msg}\n\n"
                     f"No changes were saved (atomic operation)."
                 )
-            return f"Error: Edit {i+1} - string not found in '{file_path}': {repr(old_string[:100])}"
+            return ToolFailure(
+                f"Error: Edit {i+1} - string not found in '{file_path}': "
+                f"{repr(old_string[:100])}"
+            )
 
         if count > 1 and not replace_all:
-            return (
+            return ToolFailure(
                 f"Error: Edit {i+1} - string appears {count} times. "
                 f"Use replace_all=True or provide more context.\n"
                 f"String: {repr(old_string[:100])}"

--- a/connectonion/useful_tools/file_tools/read.py
+++ b/connectonion/useful_tools/file_tools/read.py
@@ -15,6 +15,8 @@ Usage:
 from pathlib import Path
 from typing import Optional
 
+from ...core.tool_result import ToolFailure
+
 
 def read_file(
     path: str,
@@ -40,10 +42,10 @@ def read_file(
     file_path = Path(path)
 
     if not file_path.exists():
-        return f"Error: File '{path}' does not exist"
+        return ToolFailure(f"Error: File '{path}' does not exist")
 
     if not file_path.is_file():
-        return f"Error: '{path}' is not a file"
+        return ToolFailure(f"Error: '{path}' is not a file")
 
     content = file_path.read_text(encoding="utf-8", errors="replace")
     lines = content.splitlines()

--- a/connectonion/useful_tools/file_tools/write.py
+++ b/connectonion/useful_tools/file_tools/write.py
@@ -12,6 +12,8 @@ use edit() or multi_edit() which provide diff preview and validation.
 
 from pathlib import Path
 
+from ...core.tool_result import ToolFailure
+
 
 def write(path: str, content: str) -> str:
     """
@@ -35,7 +37,10 @@ def write(path: str, content: str) -> str:
 
     # Check if file already exists - should use edit() instead
     if file_path.exists():
-        return f"Error: File '{path}' already exists. Use edit() or multi_edit() to modify existing files, not write()"
+        return ToolFailure(
+            f"Error: File '{path}' already exists. Use edit() or multi_edit() "
+            "to modify existing files, not write()"
+        )
 
     try:
         # Create parent directories if they don't exist
@@ -47,6 +52,6 @@ def write(path: str, content: str) -> str:
         return f"Successfully wrote {len(content)} bytes to '{path}'"
 
     except PermissionError:
-        return f"Error: Permission denied writing to '{path}'"
+        return ToolFailure(f"Error: Permission denied writing to '{path}'")
     except OSError as e:
-        return f"Error: Failed to write '{path}': {e}"
+        return ToolFailure(f"Error: Failed to write '{path}': {e}")

--- a/tests/unit/test_file_tool_failure_results.py
+++ b/tests/unit/test_file_tool_failure_results.py
@@ -1,0 +1,146 @@
+"""Regression coverage for explicit FileTools failure results."""
+
+from unittest.mock import patch
+
+from connectonion.core.llm import ToolCall
+from connectonion.core.tool_executor import (
+    execute_and_record_tools,
+    execute_single_tool,
+)
+from connectonion.core.tool_factory import (
+    create_tool_from_function,
+    extract_methods_from_instance,
+)
+from connectonion.core.tool_registry import ToolRegistry
+from connectonion.core.tool_result import ToolFailure
+from connectonion.logger import Logger
+from connectonion.useful_tools.file_tools import FileTools
+
+
+class RecordingAgent:
+    """Small executor-compatible agent that records lifecycle events."""
+
+    name = "file-tool-test"
+    io = None
+
+    def __init__(self):
+        self.current_session = {
+            "messages": [],
+            "trace": [],
+            "iteration": 1,
+            "user_prompt": "Do not overwrite the existing file",
+        }
+        self.events = []
+
+    def _record_trace(self, entry, **_kwargs):
+        self.current_session["trace"].append(entry)
+
+    def _invoke_events(self, event_type):
+        self.events.append(event_type)
+
+
+def file_tool_registry(file_tools):
+    registry = ToolRegistry()
+    registry.add_instance("filetools", file_tools)
+    for tool in extract_methods_from_instance(file_tools):
+        registry.add(tool)
+    return registry
+
+
+def test_write_refusal_is_reported_as_failure_without_touching_file(tmp_path):
+    path = tmp_path / "existing.txt"
+    path.write_text("original\n", encoding="utf-8")
+    before = path.stat()
+    agent = RecordingAgent()
+    logger = Logger("file-tool-test", log=False)
+
+    with patch("connectonion.console._rich_console.print") as terminal_print:
+        execute_and_record_tools(
+            [
+                ToolCall(
+                    name="write",
+                    arguments={"path": str(path), "content": "replacement\n"},
+                    id="call-write-existing",
+                    extra_content=None,
+                )
+            ],
+            file_tool_registry(FileTools()),
+            agent,
+            logger,
+        )
+
+    result = next(
+        entry
+        for entry in agent.current_session["trace"]
+        if entry["type"] == "tool_result"
+    )
+    tool_message = agent.current_session["messages"][-1]
+    terminal_output = "\n".join(
+        str(call.args[0]) for call in terminal_print.call_args_list
+    )
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "ToolFailure"
+    assert result["error"] == result["result"]
+    assert "already exists" in result["result"]
+    assert tool_message == {
+        "role": "tool",
+        "content": result["result"],
+        "tool_call_id": "call-write-existing",
+    }
+    assert "on_error" in agent.events
+    assert "✗" in terminal_output
+    assert "✓" not in terminal_output
+    assert path.read_text(encoding="utf-8") == "original\n"
+    assert path.stat().st_mtime_ns == before.st_mtime_ns
+
+
+def test_file_tools_marks_each_explicit_failure_without_breaking_string_api(
+    tmp_path,
+):
+    path = tmp_path / "existing.txt"
+    path.write_text("original\n", encoding="utf-8")
+    missing = tmp_path / "missing"
+    file_tools = FileTools()
+
+    failures = [
+        file_tools.write(str(path), "replacement\n"),
+        file_tools.edit(str(path), "original", "replacement"),
+        file_tools.multi_edit(
+            str(path),
+            [{"old_string": "original", "new_string": "replacement"}],
+        ),
+        file_tools.read_file(str(missing)),
+        file_tools.glob("*.txt", path=str(missing)),
+        file_tools.grep("(", path=str(tmp_path)),
+    ]
+
+    assert all(isinstance(result, str) for result in failures)
+    assert all(isinstance(result, ToolFailure) for result in failures)
+    assert path.read_text(encoding="utf-8") == "original\n"
+
+    no_files = file_tools.glob("*.py", path=str(tmp_path))
+    no_matches = file_tools.grep("absent", path=str(path))
+    assert not isinstance(no_files, ToolFailure)
+    assert not isinstance(no_matches, ToolFailure)
+
+
+def test_an_ordinary_error_prefixed_string_keeps_success_semantics():
+    def domain_result() -> str:
+        return "Error: this is domain data, not an execution failure"
+
+    registry = ToolRegistry()
+    registry.add(create_tool_from_function(domain_result))
+
+    result = execute_single_tool(
+        tool_name="domain_result",
+        tool_args={},
+        tool_id="call-domain-result",
+        tools=registry,
+        agent=RecordingAgent(),
+        logger=Logger("file-tool-test", log=False),
+    )
+
+    assert result["status"] == "success"
+    assert result["result"].startswith("Error:")
+    assert "error" not in result


### PR DESCRIPTION
## Description

Make expected FileTools refusals explicit execution failures so a rejected write cannot appear as a green successful tool call.

## Related Issue

Fixes #1338

## Labels and target release (required)

- **Suggested labels:** bug, no-blog
- **Proposed target version:** 1.7.1
- **Estimated release window:** next stable patch
- **Milestone:** 1.7.1 — framework correctness patch
- **Why this release:** v1.7.0 correctly protects existing files but records the refusal as success, misleading both the operator and the agent. The marker is string-compatible, opt-in, and leaves arbitrary third-party `Error:` strings unchanged.
- **Forward-port tracking issue (stable patches only):** #1342

## How this was written

- [x] AI-assisted — I reviewed every line and can explain why each change is there

**Which model?** GPT-5.6 via Codex.

The least certain surface is third-party code that relies on the exact concrete type of a FileTools error instead of its documented string behavior; `ToolFailure` deliberately subclasses `str` to preserve normal comparisons and formatting. I did not run a model-provider journey. If this is wrong, file validation errors would be displayed or traced incorrectly; the tests exercise the real FileTools → ToolRegistry → executor → logger/message path.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dev Blog (required)

This is a narrow outcome-typing correction with no public API or UI design change. Maintainer exemption: `no-blog`.

## Changes Made

- Add explicit `ToolFailure(str)` for expected, user-correctable tool refusals.
- Return the marker from FileTools read/glob/grep/edit/multi-edit/write validation and I/O failures.
- Record marked results as `status=error` while preserving the original retryable tool message.
- Trigger `on_error` and render a red `✗` for marked failures.
- Keep ordinary strings, including arbitrary `Error: ...` domain text, on the existing success path.

## Testing

```text
$ /Users/changxing/projects/connectonion/.venv/bin/python -m pytest tests/unit/test_file_tool_failure_results.py tests/unit/test_useful_tools_files.py tests/unit/test_tool_executor.py tests/unit/test_tool_executor_errors.py tests/unit/test_logger.py -q
114 passed in 0.42s
```

The regression test also asserts that a refused overwrite leaves both file contents and `st_mtime_ns` unchanged.

- [x] I have added regression tests

## Scope

- `connectonion/core/tool_result.py`: internal, string-compatible failure marker.
- `connectonion/core/tool_executor.py`, `connectonion/logger.py`: truthful trace/lifecycle/terminal outcome.
- `connectonion/useful_tools/file_tools/*`: opt in only explicit file-operation failures.
- `tests/unit/test_file_tool_failure_results.py`: real registry/executor regression coverage.

No browser, Patchright, Onionwright, paid-browser, dependency, or release-workflow files change.

## Example Usage

Existing direct calls still receive a string-compatible result:

```python
result = FileTools().write("already-exists.txt", "new")
assert isinstance(result, str)
```

When invoked as an agent tool, that refusal is now traced and displayed as a failure.

## Checklist

- [x] I proposed labels and target version
- [x] I reviewed the complete diff
- [x] Focused file-tool, executor, and logger suites pass
- [x] Existing string behavior remains compatible
- [x] A maintainer applies `no-blog`
- [x] The stable forward-port tracker is #1342 and remains open through the main forward-port
- [x] The linked issue's implementation contract is covered by an end-to-end executor test

## Screenshots (if applicable)

Not applicable: terminal success/failure symbols are asserted in the regression test.
