### PR TITLE
fix(cli): report max-iteration runs as incomplete

### DIFF
--- a/connectonion/console.py
+++ b/connectonion/console.py
@@ -644,8 +644,27 @@ class Console:
         _rich_console.print()
         self.print(f"[{DIM_COLOR}]═══════════════════════════════════════════════[/{DIM_COLOR}]")
 
-        # Print summary: green check, white "complete", dim metadata
-        self.print(f"[{SUCCESS_COLOR}]{SUCCESS_SYMBOL}[/{SUCCESS_COLOR}] complete [{DIM_COLOR}]· {tokens_str} tokens · {cost_str} · {time_str}[/{DIM_COLOR}]")
+        latest_outcome = next(
+            (
+                entry.get("reason")
+                for entry in reversed(session.get("trace", []))
+                if entry.get("type") == "turn_result"
+            ),
+            None,
+        )
+        if latest_outcome == "max_iterations":
+            status_color = ERROR_COLOR
+            status_symbol = ERROR_SYMBOL
+            status_text = "incomplete"
+        else:
+            status_color = SUCCESS_COLOR
+            status_symbol = SUCCESS_SYMBOL
+            status_text = "complete"
+
+        self.print(
+            f"[{status_color}]{status_symbol}[/{status_color}] {status_text} "
+            f"[{DIM_COLOR}]· {tokens_str} tokens · {cost_str} · {time_str}[/{DIM_COLOR}]"
+        )
 
         # Print session path if provided (dim)
         if session_path:

--- a/tests/e2e/cli/test_cli_ai.py
+++ b/tests/e2e/cli/test_cli_ai.py
@@ -7,6 +7,7 @@ from click.utils import strip_ansi
 from typer.testing import CliRunner
 
 from connectonion.cli.main import app
+from connectonion.console import Console
 from connectonion.core.usage import DEFAULT_MODEL
 
 runner = CliRunner()
@@ -88,3 +89,26 @@ def test_ai_forwards_invocation_invite_options():
     assert result.exit_code == 0
     assert handler.call_args.kwargs["invite_code"] is None
     assert handler.call_args.kwargs["invite_code_file"] == Path("/private/invite")
+
+
+def test_ai_max_iterations_exits_nonzero_without_success_summary(monkeypatch):
+    class IncompleteAgent:
+        def input(self, prompt):
+            self.current_session = {
+                "trace": [{"type": "turn_result", "reason": "max_iterations"}]
+            }
+            Console().print_completion(0.1, self.current_session)
+            return "Task incomplete: Maximum iterations (1) reached."
+
+    monkeypatch.setattr(
+        "connectonion.cli.co_ai.agent.create_agent",
+        lambda **_: IncompleteAgent(),
+    )
+
+    result = runner.invoke(app, ["ai", "task", "--max-iterations", "1"])
+
+    output = strip_ansi(result.output)
+    assert result.exit_code == 1
+    assert "Task incomplete" in output
+    assert "✓ complete" not in output
+    assert "✗ incomplete" in output


### PR DESCRIPTION
## Description

Report max-iteration one-shot runs as incomplete in the terminal summary and add a real Typer CLI regression proving the process exits nonzero.

## Related Issue

Fixes #1291

## Labels and target release (required)

- **Suggested labels:** bug, no-blog
- **Proposed target version:** 1.7.1
- **Estimated release window:** next stable patch
- **Milestone:** 1.7.1 — framework correctness patch
- **Why this release:** v1.7.0 already preserves `max_iterations` and exits 1, but immediately precedes the incomplete message with a green `✓ complete`. This patch corrects the remaining operator-visible contradiction without changing iteration or exit semantics.
- **Forward-port tracking issue (stable patches only):** #1342

## How this was written

- [x] AI-assisted — I reviewed every line and can explain why each change is there

**Which model?** GPT-5.6 via Codex.

The reported exit-zero behavior could not be reproduced at the real Typer command boundary: the stable implementation and new CLI integration test both return exit code 1. The least certain possibility is an external scheduler wrapper that masked that status; this repository patch does not speculate about outside shell behavior. If the summary lookup is wrong, the newest `turn_result` regression will show the wrong symbol/text.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dev Blog (required)

This is a small terminal status correction backed by an integration test. Maintainer exemption: `no-blog`.

## Changes Made

- Read the newest `turn_result.reason` when rendering the run summary.
- Render red `✗ incomplete` for `max_iterations`.
- Preserve green `✓ complete` for natural and legacy traces.
- Exercise the real `co ai` Typer command with a mock Agent and assert exit code 1, the incomplete result, and absence of the success summary.

## Testing

```text
$ /Users/changxing/projects/connectonion/.venv/bin/python -m pytest tests/e2e/cli/test_cli_ai.py tests/unit/test_cli_commands_ai_trust.py tests/unit/test_co_ai_one_shot_sessions.py tests/unit/test_the_run_summary_counts_the_run.py -q
75 passed in 0.46s
```

- [x] I have added regression tests

## Scope

- `connectonion/console.py`: truthful terminal summary only.
- `tests/e2e/cli/test_cli_ai.py`: real CLI boundary and exit status.

No agent loop, scheduler, browser, Patchright, Onionwright, paid-browser, dependency, or release-workflow files change.

## Example Usage

```text
✗ incomplete · … tokens · $… · …s
Task incomplete: Maximum iterations (N) reached.
```

The command exits 1.

## Checklist

- [x] I proposed labels and target version
- [x] I reviewed the complete diff
- [x] CLI, one-shot session, and summary regression suites pass
- [x] A maintainer applies `no-blog`
- [x] The stable forward-port tracker is #1342 and remains open through the main forward-port
- [x] The linked issue's executable contract is covered by a Typer CLI integration test

## Screenshots (if applicable)

Not applicable: terminal glyph/text and exit status are asserted by the integration test.
