### PR TITLE
fix(cli): report max-iteration runs as incomplete

### DIFF
--- a/connectonion/console.py
+++ b/connectonion/console.py
@@ -645,8 +645,27 @@ class Console:
         _rich_console.print()
         self.print(f"[{DIM_COLOR}]═══════════════════════════════════════════════[/{DIM_COLOR}]")
 
-        # Print summary: green check, white "complete", dim metadata
-        self.print(f"[{SUCCESS_COLOR}]{SUCCESS_SYMBOL}[/{SUCCESS_COLOR}] complete [{DIM_COLOR}]· {tokens_str} tokens · {cost_str} · {time_str}[/{DIM_COLOR}]")
+        latest_outcome = next(
+            (
+                entry.get("reason")
+                for entry in reversed(session.get("trace", []))
+                if entry.get("type") == "turn_result"
+            ),
+            None,
+        )
+        if latest_outcome == "max_iterations":
+            status_color = ERROR_COLOR
+            status_symbol = ERROR_SYMBOL
+            status_text = "incomplete"
+        else:
+            status_color = SUCCESS_COLOR
+            status_symbol = SUCCESS_SYMBOL
+            status_text = "complete"
+
+        self.print(
+            f"[{status_color}]{status_symbol}[/{status_color}] {status_text} "
+            f"[{DIM_COLOR}]· {tokens_str} tokens · {cost_str} · {time_str}[/{DIM_COLOR}]"
+        )
 
         # Print session path if provided (dim)
         if session_path:

--- a/tests/e2e/cli/test_cli_ai.py
+++ b/tests/e2e/cli/test_cli_ai.py
@@ -7,6 +7,7 @@ from click.utils import strip_ansi
 from typer.testing import CliRunner
 
 from connectonion.cli.main import app
+from connectonion.console import Console
 from connectonion.core.usage import DEFAULT_MODEL
 
 runner = CliRunner()
@@ -88,3 +89,26 @@ def test_ai_forwards_invocation_invite_options():
     assert result.exit_code == 0
     assert handler.call_args.kwargs["invite_code"] is None
     assert handler.call_args.kwargs["invite_code_file"] == Path("/private/invite")
+
+
+def test_ai_max_iterations_exits_nonzero_without_success_summary(monkeypatch):
+    class IncompleteAgent:
+        def input(self, prompt):
+            self.current_session = {
+                "trace": [{"type": "turn_result", "reason": "max_iterations"}]
+            }
+            Console().print_completion(0.1, self.current_session)
+            return "Task incomplete: Maximum iterations (1) reached."
+
+    monkeypatch.setattr(
+        "connectonion.cli.co_ai.agent.create_agent",
+        lambda **_: IncompleteAgent(),
+    )
+
+    result = runner.invoke(app, ["ai", "task", "--max-iterations", "1"])
+
+    output = strip_ansi(result.output)
+    assert result.exit_code == 1
+    assert "Task incomplete" in output
+    assert "✓ complete" not in output
+    assert "✗ incomplete" in output


### PR DESCRIPTION
## Description

Forward-port the v1.7.1 terminal truthfulness fix from #1346. A run that exhausts its iteration budget still returns its useful incomplete result and exits nonzero, but its terminal footer now says `✗ incomplete` instead of the contradictory green `✓ complete`.

## Related Issue

Forward-ports #1346. Related to #1291 and tracked by the open 1.7.1 forward-port ledger #1342.

## Labels and target release (required)

- **Suggested labels:** bug, tests, no-blog
- **Proposed target version:** 1.8.0
- **Estimated release window:** next alpha
- **Milestone:** 1.8.0 — remote browser sessions and async execution
- **Why this release:** Keep the active 1.8 line behaviorally aligned with the verified 1.7.1 patch. The change is terminal-only, has no browser or protocol impact, and rolls back by reverting one commit.
- **Forward-port tracking issue (stable patches only):** #1342

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** Codex (GPT-5).

The part I am least confident about is the exact Rich color rendering on every terminal; the behavior test asserts the semantic failure symbol and wording after ANSI stripping. I did not run the full repository suite, Windows, or a live model request. If this is wrong, the first visible failure is the final run-summary label; the existing result text and nonzero exit code are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Dev Blog (required)

No blog file. This is a maintenance-only forward-port of the already published v1.7.1 fix; the `no-blog` label is applied.

## Changes Made

- Read the latest structured `turn_result.reason` before rendering the run footer.
- Render `max_iterations` as red `✗ incomplete`; preserve the existing success footer for natural completion and legacy traces.
- Add a real Typer `co ai` boundary regression using a mock agent, locking both exit code 1 and the truthful footer.

## Testing

```text
$ /Users/changxing/projects/connectonion/.venv/bin/python -m pytest tests/e2e/cli/test_cli_ai.py tests/unit/test_console.py tests/unit/test_the_run_summary_counts_the_run.py tests/unit/test_cli_commands_ai_trust.py tests/unit/test_turn_outcome.py -q
71 passed in 0.56s

$ git diff --check origin/main...HEAD
# no output
```

- [x] I have added tests for new functionality

## Scope

- `connectonion/console.py`: select the footer status from the latest terminal turn result.
- `tests/e2e/cli/test_cli_ai.py`: verify the user-visible footer and process exit status at the CLI boundary.

No package version, release metadata, browser code, protocols, or dependencies change.

## Example Usage

No new API. Run `co ai "task" --max-iterations 1`; if the budget is exhausted, the existing incomplete result is followed by `✗ incomplete` and the process exits 1.

## Checklist

- [x] I proposed at least one label and a target version above
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] No documentation change is needed for this terminal-only forward-port
- [x] This PR has the maintainer-applied `no-blog` label
- [x] My changes generate no new warnings
- [x] The dependent stable change has been merged and published in v1.7.1
- [x] The stable patch tracker #1342 remains open until all forward-ports merge and pass CI
- [x] The linked issues require no additional AI implementation-contract evidence beyond the included CLI regression

## Screenshots (if applicable)

Not applicable; the exact terminal text is asserted by the CLI regression.

## Additional Notes

Cherry-picked from stable commit `382a029992cff8332f5cfd50ac047e3ef24c9b11` onto current `origin/main` (`19c372555f3c4712d3a03d4cfeec68409c7a05df`) without conflicts.
