### PR TITLE
fix(cli): forward-port OpenRouter key detection to 1.8

### DIFF
--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -580,6 +580,10 @@ def detect_api_provider(api_key: str) -> Tuple[str, str]:
     if api_key.startswith('sk-ant-'):
         return 'anthropic', 'claude'
 
+    # OpenRouter shares the generic sk- prefix, so match it before OpenAI.
+    if api_key.startswith('sk-or-'):
+        return 'openrouter', 'openrouter'
+
     # OpenAI formats
     if api_key.startswith('sk-proj-'):
         return 'openai', 'project'
@@ -597,10 +601,6 @@ def detect_api_provider(api_key: str) -> Tuple[str, str]:
     # xAI Grok
     if api_key.startswith('xai-'):
         return 'grok', 'xai'
-
-    # OpenRouter
-    if api_key.startswith('sk-or-'):
-        return 'openrouter', 'openrouter'
 
     # Default to OpenAI if unsure
     return 'openai', 'unknown'

--- a/tests/unit/test_project_cmd_lib.py
+++ b/tests/unit/test_project_cmd_lib.py
@@ -3,7 +3,33 @@
 import sys
 from pathlib import Path
 
-from connectonion.cli.commands.project_cmd_lib import upsert_env
+from connectonion.cli.commands.project_cmd_lib import (
+    configure_env_for_provider,
+    detect_api_provider,
+    upsert_env,
+)
+
+
+class TestApiProviderDetection:
+    """Provider-specific key prefixes win before generic prefixes."""
+
+    def test_specific_sk_prefixes_win_before_generic_openai_prefix(self):
+        assert detect_api_provider("sk-or-v1-test-key") == (
+            "openrouter",
+            "openrouter",
+        )
+        assert detect_api_provider("sk-proj-test-key") == ("openai", "project")
+        assert detect_api_provider("sk-test-key") == ("openai", "user")
+
+    def test_openrouter_key_configures_openrouter_environment(self):
+        api_key = "sk-or-v1-test-key"
+        provider, _key_type = detect_api_provider(api_key)
+
+        env_content = configure_env_for_provider(provider, api_key)
+
+        assert f"OPENROUTER_API_KEY={api_key}" in env_content
+        assert "OPENAI_API_KEY=" not in env_content
+        assert "MODEL=openrouter/openai/o4-mini" in env_content
 
 
 class TestUpsertEnv:


### PR DESCRIPTION
## Description

Forward-port the published v1.7.1 OpenRouter provider-detection fix to the active 1.8 line. `sk-or-` is matched before the generic OpenAI `sk-` prefix, and environment-key selection remains consistent with the detected provider.

This is the exact product fix from stable commit `181d0b2d`; it does not copy 1.7.1 version, channel, release-note, or visual-manifest metadata.

## Related Issue

Related to #1341. Forward-port ledger: #1342.

## Labels and target release (required)

- **Suggested labels:** bug, tests
- **Proposed target version:** 1.8.0
- **Estimated release window:** next alpha
- **Milestone:** 1.8.0 — remote browser sessions and async execution
- **Why this release:** main still misclassifies OpenRouter keys as OpenAI. Carrying the stable fix forward prevents the next preview from regressing relative to 1.7.1. The change is isolated to provider detection and tests; rollback is one commit.
- **Forward-port tracking issue (stable patches only):** #1342 (this PR is the forward port, not a stable patch)

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** OpenAI Codex (GPT-5).

The least certain path is a future, undocumented OpenAI key prefix that also starts with `sk-or-`; current provider contracts and the existing explicit OpenRouter environment variable support make the specific-prefix-first rule correct. No live provider API request was made. If wrong, project initialization would select the wrong provider/model pair; no browser implementation or dependency changes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Dev Blog

No new post: this is a mechanical forward-port of a published maintenance fix. Apply `no-blog`.

## Changes Made

- Match `sk-or-` before generic `sk-`.
- Lock provider precedence and `OPENROUTER_API_KEY` configuration with regression tests.

## Testing

```text
$ python -m pytest tests/unit/test_project_cmd_lib.py tests/e2e/cli/test_cli_init.py tests/e2e/cli/test_cli_create.py -q
68 passed in 35.05s

$ git diff --check origin/main...HEAD
clean
```

## Scope

- `connectonion/cli/commands/project_cmd_lib.py`: provider prefix ordering.
- `tests/unit/test_project_cmd_lib.py`: regression coverage.

No browser, workflow, dependency, or release metadata files changed.

## Checklist

- [x] I proposed labels and target version
- [x] I read and reviewed the complete diff
- [x] Focused and CLI integration tests pass
- [x] No 1.7 version/channel metadata was copied
- [x] Forward-port ledger #1342 remains open until this and the other 1.8 PRs merge and pass CI
