### PR TITLE
feat: route Remote WTF Browser through Laptop Proxy

### DIFF
--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -148,6 +148,11 @@ def _spawn_daemon(
         cmd.extend(["--authkey-file", str(target.authkey_path)])
         if target.remote_egress:
             cmd.append("--remote-egress")
+        if (
+            target.shared_proxy_path is not None
+            and Path(target.shared_proxy_path).is_file()
+        ):
+            cmd.extend(["--shared-proxy-file", str(target.shared_proxy_path)])
     cmd.append(f"--engine={engine_mode}")
     with open(log_path, "a", encoding="utf-8") as log:  # the child dups the handle; ours closes right away
         transport.spawn_detached(cmd, log)  # POSIX: new session · Windows: DETACHED_PROCESS

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -245,6 +245,7 @@ class BrowserDaemon:
         profile_dir: str | Path | None = None,
         remote_egress: bool = False,
         authkey_path: str | Path | None = None,
+        shared_proxy_path: str | Path | None = None,
         gateway_factory=None,
         browser_factory=AsyncBrowserCore,
     ):
@@ -260,6 +261,13 @@ class BrowserDaemon:
         )
         self._remote_egress = remote_egress
         self._authkey_path = Path(authkey_path) if authkey_path is not None else None
+        self._shared_proxy_path = (
+            Path(shared_proxy_path).expanduser().resolve()
+            if shared_proxy_path is not None
+            else None
+        )
+        if self._shared_proxy_path is not None and not self._remote_egress:
+            raise ValueError("a shared proxy requires --remote-egress")
         self._gateway_factory = gateway_factory
         self._browser_factory = browser_factory
         self._proxy_auth_path = None
@@ -961,16 +969,22 @@ class BrowserDaemon:
             raise RuntimeError("private browser runtime is only prepared once")
         from connectonion.network.host.egress_gateway import EgressGateway
         from connectonion.network.host.private_browser_runtime import (
+            load_shared_proxy_file,
             proxy_auth_path_for_profile,
             remote_browser_launch_policy,
             remove_proxy_auth_file,
             write_proxy_auth_file,
         )
+        from connectonion.network.proxy_egress import shared_egress_gateway
 
         gateway = (
             self._gateway_factory()
             if self._gateway_factory is not None
-            else EgressGateway()
+            else (
+                shared_egress_gateway(load_shared_proxy_file(self._shared_proxy_path))
+                if self._shared_proxy_path is not None
+                else EgressGateway()
+            )
         )
         endpoint = await gateway.start()
         proxy_auth_path = proxy_auth_path_for_profile(self._profile_dir)
@@ -1591,6 +1605,7 @@ def main():
     parser.add_argument("--profile-dir")
     parser.add_argument("--authkey-file")
     parser.add_argument("--remote-egress", action="store_true")
+    parser.add_argument("--shared-proxy-file")
     parser.add_argument("--engine", choices=("auto", "system", "onion"), default="auto")
     args = parser.parse_args()
     BrowserDaemon(
@@ -1600,6 +1615,7 @@ def main():
         profile_dir=args.profile_dir,
         authkey_path=args.authkey_file,
         remote_egress=args.remote_egress,
+        shared_proxy_path=args.shared_proxy_file,
     ).serve()
 
 

--- a/connectonion/cli/commands/proxy_commands.py
+++ b/connectonion/cli/commands/proxy_commands.py
@@ -14,9 +14,14 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hmac
 import json
+import os
+import secrets
 import signal
 import sys
+import tempfile
+import time
 from pathlib import Path
 
 USAGE = """co proxy — share this computer's internet connection.
@@ -44,8 +49,19 @@ def _load() -> dict:
 
 def _save(state: dict) -> None:
     STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    STATE_PATH.write_text(json.dumps(state, indent=2), encoding="utf-8")
-    STATE_PATH.chmod(0o600)
+    fd, temporary = tempfile.mkstemp(
+        prefix=f".{STATE_PATH.name}.", dir=STATE_PATH.parent
+    )
+    path = Path(temporary)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(state, stream, indent=2)
+            stream.flush()
+            os.fsync(stream.fileno())
+        path.chmod(0o600)
+        path.replace(STATE_PATH)
+    finally:
+        path.unlink(missing_ok=True)
 
 
 def _emit(envelope: dict, as_json: bool) -> int:
@@ -72,12 +88,38 @@ def _share(address: str, as_json: bool, bind: str | None, ttl: int | None) -> in
     async def run() -> int:
         service = ProxyEgressService(bind_host=bind)
         endpoint = await service.start()
+        stop = asyncio.Event()
+        control_token = secrets.token_urlsafe(32)
+
+        async def control(reader, writer):
+            try:
+                supplied = await asyncio.wait_for(reader.readline(), timeout=2)
+                expected = (control_token + "\n").encode("ascii")
+                if hmac.compare_digest(supplied, expected):
+                    writer.write(b"OK\n")
+                    await writer.drain()
+                    stop.set()
+                else:
+                    writer.write(b"REFUSED\n")
+                    await writer.drain()
+            finally:
+                writer.close()
+                with contextlib.suppress(Exception):
+                    await writer.wait_closed()
+
+        controller = await asyncio.start_server(control, "127.0.0.1", 0)
+        control_host, control_port = controller.sockets[0].getsockname()[:2]
         state = _load()
         state[address] = {
             "url": endpoint.url,
+            "host": endpoint.host,
+            "port": endpoint.port,
             "username": endpoint.username,
             "password": endpoint.password,
             "ttl": ttl,
+            "control_host": control_host,
+            "control_port": control_port,
+            "control_token": control_token,
         }
         _save(state)
         _emit(
@@ -100,7 +142,6 @@ def _share(address: str, as_json: bool, bind: str | None, ttl: int | None) -> in
         # A supervisor stops this with SIGTERM, not Ctrl-C, and a share that
         # outlives its process in the registry is a share every later command
         # reports as live while nothing listens.
-        stop = asyncio.Event()
         loop = asyncio.get_running_loop()
         for signal_name in ("SIGTERM", "SIGINT"):
             number = getattr(signal, signal_name, None)
@@ -112,6 +153,8 @@ def _share(address: str, as_json: bool, bind: str | None, ttl: int | None) -> in
         except (asyncio.TimeoutError, KeyboardInterrupt, asyncio.CancelledError):
             pass
         finally:
+            controller.close()
+            await controller.wait_closed()
             await service.stop()
             remaining = _load()
             remaining.pop(address, None)
@@ -168,8 +211,56 @@ def _stop(address: str, as_json: bool) -> int:
             },
             as_json,
         )
-    state.pop(address)
-    _save(state)
+    share = state[address]
+
+    async def stop_live_share() -> bool:
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(
+                    share["control_host"], int(share["control_port"])
+                ),
+                timeout=2,
+            )
+            writer.write((share["control_token"] + "\n").encode("ascii"))
+            await writer.drain()
+            reply = await asyncio.wait_for(reader.readline(), timeout=2)
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+            return reply == b"OK\n"
+        except (KeyError, TypeError, ValueError, OSError, asyncio.TimeoutError):
+            return False
+
+    if not asyncio.run(stop_live_share()):
+        return _emit(
+            {
+                "ok": False,
+                "code": "SHARE_STOP_FAILED",
+                "command": "stop",
+                "summary": (
+                    f"The share for {address} is recorded but its service did not "
+                    "accept the stop request."
+                ),
+                "next_actions": [
+                    f"Inspect it with: co proxy diagnose {address}",
+                ],
+            },
+            as_json,
+        )
+    deadline = time.monotonic() + 5
+    while address in _load() and time.monotonic() < deadline:
+        time.sleep(0.05)
+    if address in _load():
+        return _emit(
+            {
+                "ok": False,
+                "code": "SHARE_STOP_TIMEOUT",
+                "command": "stop",
+                "summary": f"The share for {address} accepted stop but is still shutting down.",
+                "next_actions": ["Retry: co proxy status"],
+            },
+            as_json,
+        )
     return _emit(
         {
             "ok": True,

--- a/connectonion/network/host/egress_gateway.py
+++ b/connectonion/network/host/egress_gateway.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
 import contextlib
 import hmac
 import ipaddress
@@ -41,6 +42,7 @@ OVERLOADED = "EGRESS_OVERLOADED"
 CONNECT_FAILED = "EGRESS_CONNECT_FAILED"
 TRANSFER_LIMIT = "EGRESS_TRANSFER_LIMIT"
 GATEWAY_STOPPING = "EGRESS_GATEWAY_STOPPING"
+RESOLVE_UNAVAILABLE = "EGRESS_RESOLVE_UNAVAILABLE"
 
 _HEADER_NAME = re.compile(rb"[!#$%&'*+.^_`|~0-9A-Za-z-]+")
 _METHOD = re.compile(rb"[A-Z][A-Z0-9!#$%&'*+.^_`|~-]{0,31}")
@@ -58,6 +60,7 @@ _ERROR_STATUS = {
     CONNECT_FAILED: (502, "Bad Gateway"),
     TRANSFER_LIMIT: (413, "Content Too Large"),
     GATEWAY_STOPPING: (503, "Service Unavailable"),
+    RESOLVE_UNAVAILABLE: (403, "Forbidden"),
 }
 
 
@@ -230,12 +233,14 @@ class EgressGateway:
         username: str = "connectonion",
         password: str | None = None,
         bind_host: str = "127.0.0.1",
+        allow_remote_resolution: bool = False,
     ):
         # Loopback is the default and the only address a browser-private
         # gateway may use. `co proxy share` runs the same request machinery on
         # a reachable address so a remote agent can egress through this
         # machine, and that is the only reason this is a parameter.
         self.bind_host = bind_host
+        self.allow_remote_resolution = bool(allow_remote_resolution)
         self.resolver = resolver
         self.dialer = dialer
         try:
@@ -439,6 +444,9 @@ class EgressGateway:
             # decides next.
             self._handled += 1
             await self._promote(admission)
+            if request.method == "CORESOLVE":
+                await self._serve_resolution(request, writer)
+                return
             authority, origin_target, upgrade = self._request_destination(request)
             endpoints = await self._approved_endpoints(authority)
             upstream_reader, upstream_writer = await self._connect(endpoints)
@@ -478,6 +486,50 @@ class EgressGateway:
             upstream_writer.close()
             with contextlib.suppress(Exception):
                 await upstream_writer.wait_closed()
+
+    async def _serve_resolution(
+        self, request: ProxyRequest, writer: asyncio.StreamWriter
+    ) -> None:
+        """Resolve one authority on the egress machine for a shared browser.
+
+        Chromium never calls this method.  The remote host-private gateway uses
+        it before asking this same service to CONNECT one returned numeric
+        address.  Keeping resolution here makes the Laptop the DNS boundary;
+        keeping the ordinary destination decision here means sharing an exit
+        never shares the Laptop's LAN.
+        """
+        if not self.allow_remote_resolution:
+            raise GatewayRefusal(RESOLVE_UNAVAILABLE)
+        if request.values("host"):
+            raise GatewayRefusal(INVALID)
+        try:
+            encoded, raw_port = request.target.rsplit(":", 1)
+            padding = "=" * (-len(encoded) % 4)
+            host = base64.urlsafe_b64decode((encoded + padding).encode("ascii")).decode(
+                "utf-8"
+            )
+            port = int(raw_port)
+        except (ValueError, UnicodeError, binascii.Error):
+            raise GatewayRefusal(INVALID) from None
+        if not host or isinstance(port, bool) or not 1 <= port <= 65535:
+            raise GatewayRefusal(INVALID)
+        bracketed = f"[{host}]" if ":" in host else host
+        try:
+            authority = normalize_web_destination(f"https://{bracketed}:{port}")
+            endpoints = await self._approved_endpoints(authority)
+        except DestinationPolicyError as refusal:
+            raise GatewayRefusal(refusal.code) from refusal
+        body = ("\n".join(endpoint.address for endpoint in endpoints) + "\n").encode(
+            "ascii"
+        )
+        writer.write(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Connection: close\r\n"
+            b"Content-Type: text/plain; charset=us-ascii\r\n"
+            + f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+            + body
+        )
+        await self._drain(writer)
 
     async def _read_request(self, reader: asyncio.StreamReader) -> ProxyRequest:
         refusal_code = None

--- a/connectonion/network/host/private_browser_runtime.py
+++ b/connectonion/network/host/private_browser_runtime.py
@@ -20,6 +20,7 @@ from ...useful_tools.browser_tools.launch_policy import (
     BrowserLaunchPolicy,
     BrowserProxySettings,
 )
+from ..proxy_egress import ShareEndpoint
 from .egress_gateway import ProxyEndpoint
 
 # Every entry here is a switch the launched binary actually defines. A switch
@@ -38,6 +39,7 @@ REMOTE_BROWSER_CHROME_ARGS = (
     "--disable-extensions",
 )
 PROXY_AUTH_FILENAME = "proxy-auth.json"
+SHARED_PROXY_FILENAME = "shared-proxy.json"
 PROXY_AUTH_REALM = "ConnectOnion Remote Browser"
 PROXY_AUTH_USERNAME = "connectonion"
 _PROXY_AUTH_PASSWORD = re.compile(r"[A-Za-z0-9_-]{43}\Z")
@@ -52,6 +54,7 @@ class PrivateBrowserTarget:
     log_path: Path
     authkey_path: Path
     proxy_auth_path: Path | None = None
+    shared_proxy_path: Path | None = None
     remote_egress: bool = True
 
     @classmethod
@@ -68,7 +71,103 @@ class PrivateBrowserTarget:
             log_path=root / "browser.log",
             authkey_path=root / "authkey",
             proxy_auth_path=root / PROXY_AUTH_FILENAME,
+            shared_proxy_path=root / SHARED_PROXY_FILENAME,
         )
+
+
+def _canonical_share_endpoint(value: dict) -> ShareEndpoint:
+    """Validate one Laptop Proxy endpoint before it can affect a WTF runtime."""
+    if not isinstance(value, dict):
+        raise ValueError("shared proxy endpoint must be an object")
+    try:
+        host = value["host"]
+        port = value["port"]
+        username = value["username"]
+        password = value["password"]
+    except KeyError as exc:
+        raise ValueError("shared proxy endpoint is incomplete") from exc
+    if (
+        not isinstance(host, str)
+        or not host
+        or len(host) > 253
+        or any(ord(char) < 0x21 or ord(char) > 0x7E for char in host)
+        or isinstance(port, bool)
+        or not isinstance(port, int)
+        or not 1 <= port <= 65535
+        or not isinstance(username, str)
+        or not username
+        or len(username) > 256
+        or ":" in username
+        or not isinstance(password, str)
+        or not password
+        or len(password) > 256
+        or any(ord(char) < 0x21 or ord(char) > 0x7E for char in username + password)
+    ):
+        raise ValueError("shared proxy endpoint is invalid")
+    return ShareEndpoint(host, port, username, password)
+
+
+def write_shared_proxy_file(path: Path, endpoint: ShareEndpoint) -> Path:
+    """Atomically bind a private Remote Browser runtime to one Laptop exit."""
+    path = Path(path).expanduser()
+    payload = {
+        "host": endpoint.host,
+        "password": endpoint.password,
+        "port": endpoint.port,
+        "username": endpoint.username,
+        "v": 1,
+    }
+    # Reuse the validation path for both callers and later daemon reads.
+    _canonical_share_endpoint(payload)
+    if not path.is_absolute() or not path.parent.is_dir() or path.parent.is_symlink():
+        raise ValueError("shared proxy path must be absolute in a private runtime")
+    if os.name != "nt":
+        parent_stat = path.parent.stat()
+        if stat.S_IMODE(parent_stat.st_mode) & 0o077 or parent_stat.st_uid != os.getuid():
+            raise ValueError("shared proxy root must be private and owned by this user")
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("ascii")
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", dir=path.parent, prefix=f".{path.name}.", delete=False
+        ) as stream:
+            temporary = Path(stream.name)
+            if os.name != "nt":
+                os.chmod(temporary, 0o600)
+            stream.write(body)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        temporary = None
+        return path
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def load_shared_proxy_file(path: Path) -> ShareEndpoint:
+    """Load the Laptop exit selected by the Remote Browser authority process."""
+    path = Path(path).expanduser()
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+        with os.fdopen(descriptor, "rb") as stream:
+            info = os.fstat(stream.fileno())
+            if not stat.S_ISREG(info.st_mode) or info.st_size > 4096:
+                raise ValueError("shared proxy file is not a bounded regular file")
+            if os.name != "nt" and (
+                stat.S_IMODE(info.st_mode) & 0o077 or info.st_uid != os.getuid()
+            ):
+                raise ValueError("shared proxy file must be private and owned")
+            body = stream.read(4097)
+        if len(body) > 4096:
+            raise ValueError("shared proxy file is not a bounded regular file")
+        value = json.loads(body.decode("ascii"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError("shared proxy file is unreadable") from exc
+    if value.get("v") != 1 or set(value) != {"host", "password", "port", "username", "v"}:
+        raise ValueError("shared proxy file has an unknown format")
+    return _canonical_share_endpoint(value)
 
 
 def canonical_proxy_auth(endpoint: ProxyEndpoint) -> bytes:

--- a/connectonion/network/host/remote_browser.py
+++ b/connectonion/network/host/remote_browser.py
@@ -8,6 +8,7 @@ subresources as well as the first URL.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -18,6 +19,7 @@ import time
 import uuid
 from pathlib import Path
 from typing import Callable
+from urllib.parse import urlsplit
 
 SCHEMA_VERSION = "1"
 REQUEST_ID = re.compile(r"[\x21-\x7e]{1,128}")
@@ -94,6 +96,49 @@ class RemoteBrowserService:
             def daemon_request(line, **identity):
                 return request_target_as(self.daemon_target, line, **identity)
         self.daemon_request = daemon_request
+
+    @staticmethod
+    def _share_endpoint(share: dict):
+        """Return one validated Laptop Proxy endpoint without retaining its URL."""
+        from ..proxy_egress import ShareEndpoint
+        from .private_browser_runtime import _canonical_share_endpoint
+
+        value = dict(share)
+        if "host" not in value or "port" not in value:
+            try:
+                parsed = urlsplit(value.pop("url"))
+                if (
+                    parsed.scheme != "http"
+                    or parsed.hostname is None
+                    or parsed.username is not None
+                    or parsed.password is not None
+                    or parsed.path not in {"", "/"}
+                    or parsed.query
+                    or parsed.fragment
+                ):
+                    raise ValueError
+                value["host"] = parsed.hostname
+                value["port"] = parsed.port
+            except (KeyError, TypeError, ValueError):
+                raise ValueError("shared proxy endpoint is invalid") from None
+        endpoint = _canonical_share_endpoint(value)
+        return ShareEndpoint(
+            endpoint.host, endpoint.port, endpoint.username, endpoint.password
+        )
+
+    @staticmethod
+    def _share_binding(endpoint) -> str:
+        canonical = json.dumps(
+            {
+                "host": endpoint.host,
+                "password": endpoint.password,
+                "port": endpoint.port,
+                "username": endpoint.username,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("ascii")
+        return hashlib.sha256(canonical).hexdigest()
 
     def _load(self) -> dict:
         if not self.state_path.exists():
@@ -235,6 +280,20 @@ class RemoteBrowserService:
                 "Run `co proxy share to <this host>` and retry.",
                 state={"fallback_applied": False},
             )
+        share_endpoint = None
+        share_binding = None
+        if proxy_mode == "shared":
+            try:
+                share_endpoint = self._share_endpoint(share)
+            except ValueError as exc:
+                return _failure(
+                    request_id,
+                    "start",
+                    "REMOTE_SESSION_SHARE_INVALID",
+                    str(exc),
+                    state={"fallback_applied": False},
+                )
+            share_binding = self._share_binding(share_endpoint)
         headless = args.get("headless", True)
         if not isinstance(headless, bool):
             return _failure(
@@ -253,25 +312,66 @@ class RemoteBrowserService:
                         result=self._public(session),
                         state={"session": session["status"], "fallback_applied": False},
                     )
+            active = [
+                session
+                for session in state["sessions"].values()
+                if session.get("status") == "active"
+            ]
+            runtime_already_active = bool(active)
+            if any(
+                session.get("proxy_mode") != proxy_mode
+                or (
+                    proxy_mode == "shared"
+                    and session.get("proxy_binding") != share_binding
+                )
+                for session in active
+            ):
+                return _failure(
+                    request_id,
+                    "start",
+                    "REMOTE_SESSION_PROXY_LOCKED",
+                    "The running WTF Browser is already pinned to another proxy.",
+                    state={"fallback_applied": False},
+                )
+            if share_endpoint is not None and self.daemon_target is not None:
+                from .private_browser_runtime import write_shared_proxy_file
+
+                write_shared_proxy_file(
+                    self.daemon_target.shared_proxy_path, share_endpoint
+                )
             session_id = f"rb_{uuid.uuid4().hex}"
             tab = f"remote-{session_id[3:19]}"
             line = shlex.join(
                 ["tab", "open", tab, "--who", owner, "--for", "remote-browser"]
             )
-            code, payload = self.daemon_request(
-                line, caller=owner, account=owner, headless=headless
-            )
-            if code:
-                raise RuntimeError(payload or "browser daemon rejected session start")
-            if payload.strip() != tab:
-                raise RuntimeError("browser daemon returned an unexpected tab identity")
+            try:
+                code, payload = self.daemon_request(
+                    line, caller=owner, account=owner, headless=headless
+                )
+                if code:
+                    raise RuntimeError(
+                        payload or "browser daemon rejected session start"
+                    )
+                if payload.strip() != tab:
+                    raise RuntimeError(
+                        "browser daemon returned an unexpected tab identity"
+                    )
+            except Exception:
+                if (
+                    not runtime_already_active
+                    and self.daemon_target is not None
+                    and self.daemon_target.shared_proxy_path is not None
+                ):
+                    self.daemon_target.shared_proxy_path.unlink(missing_ok=True)
+                raise
             now = int(self.clock())
             session = {
                 "session_id": session_id,
                 "owner": owner,
                 "tab": tab,
                 "status": "active",
-                "proxy_mode": "direct",
+                "proxy_mode": proxy_mode,
+                "proxy_binding": share_binding,
                 "headless": headless,
                 "start_request_id": request_id,
                 "created_at": now,
@@ -293,6 +393,21 @@ class RemoteBrowserService:
                     )
                 except Exception:
                     pass
+                if not runtime_already_active:
+                    try:
+                        self.daemon_request(
+                            "close",
+                            caller=owner,
+                            account=owner,
+                            headless=headless,
+                        )
+                    except Exception:
+                        pass
+                    if (
+                        self.daemon_target is not None
+                        and self.daemon_target.shared_proxy_path is not None
+                    ):
+                        self.daemon_target.shared_proxy_path.unlink(missing_ok=True)
                 raise
         return _success(
             request_id,
@@ -354,7 +469,23 @@ class RemoteBrowserService:
                     )
                 session["status"] = "stopped"
                 session["updated_at"] = int(self.clock())
-                self._save(state)
+            if not any(
+                candidate.get("status") == "active"
+                for candidate in state["sessions"].values()
+            ):
+                close_code, close_payload = self.daemon_request(
+                    "close",
+                    caller=owner,
+                    account=owner,
+                    headless=session["headless"],
+                )
+                if close_code not in (0, 3):
+                    raise RuntimeError(
+                        close_payload or "browser daemon rejected runtime stop"
+                    )
+                if self.daemon_target is not None:
+                    self.daemon_target.shared_proxy_path.unlink(missing_ok=True)
+            self._save(state)
             public = self._public(session)
         return _success(
             request_id,
@@ -376,10 +507,15 @@ class RemoteBrowserService:
                 "session_registry": "ok",
                 "transport": "direct",
                 "proxy_mode": "direct",
+                "egress_gateway": "ready",
+                "dns_boundary": (
+                    "laptop" if status["result"]["proxy_mode"] == "shared" else "host"
+                ),
                 "navigation_policy": "not_enabled",
             },
         }
+        status["result"]["checks"]["proxy_mode"] = status["result"]["proxy_mode"]
         status["warnings"] = [
-            "Remote navigation remains disabled until the public-destination policy is enforced."
+            "The WTF Browser egress boundary is ready; remote page commands remain disabled."
         ]
         return status

--- a/connectonion/network/host/remote_browser.py
+++ b/connectonion/network/host/remote_browser.py
@@ -9,6 +9,7 @@ subresources as well as the first URL.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import os
 import re
@@ -128,17 +129,23 @@ class RemoteBrowserService:
 
     @staticmethod
     def _share_binding(endpoint) -> str:
-        canonical = json.dumps(
+        identity = json.dumps(
             {
                 "host": endpoint.host,
-                "password": endpoint.password,
                 "port": endpoint.port,
                 "username": endpoint.username,
             },
             sort_keys=True,
             separators=(",", ":"),
         ).encode("ascii")
-        return hashlib.sha256(canonical).hexdigest()
+        # The random Proxy credential is a key, not a user password to verify.
+        # HMAC gives this private registry a purpose-separated, non-reversible
+        # binding without persisting the bearer credential itself.
+        return hmac.new(
+            endpoint.password.encode("ascii"),
+            b"connectonion:remote-browser:proxy-binding:v1\x00" + identity,
+            hashlib.sha256,
+        ).hexdigest()
 
     def _load(self) -> dict:
         if not self.state_path.exists():

--- a/connectonion/network/proxy_egress.py
+++ b/connectonion/network/proxy_egress.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import ipaddress
 import socket
 from dataclasses import dataclass
 
@@ -39,6 +40,8 @@ from .host.egress_gateway import (
 SHARED_DENY_NETWORKS: tuple[str, ...] = ()
 
 DEFAULT_SHARE_PORT = 0
+_REMOTE_HEADER_LIMIT = 16 * 1024
+_REMOTE_IO_TIMEOUT = 10.0
 
 
 @dataclass(frozen=True)
@@ -99,6 +102,7 @@ class ProxyEgressService:
             username="connectonion-proxy",
             password=credential,
             bind_host=bind_host or local_egress_address(),
+            allow_remote_resolution=True,
         )
 
     @property
@@ -150,7 +154,10 @@ def remote_proxy_dialer(share: ShareEndpoint):
             f"{share.username}:{share.password}".encode("ascii")
         ).decode("ascii")
         reader, writer = await asyncio.wait_for(
-            asyncio.open_connection(share.host, share.port), timeout=timeout
+            asyncio.open_connection(
+                share.host, share.port, limit=_REMOTE_HEADER_LIMIT + 1
+            ),
+            timeout=timeout,
         )
         try:
             writer.write(
@@ -164,6 +171,17 @@ def remote_proxy_dialer(share: ShareEndpoint):
             head = await asyncio.wait_for(
                 reader.readuntil(b"\r\n\r\n"), timeout=timeout
             )
+            if len(head) > _REMOTE_HEADER_LIMIT:
+                raise OSError("shared connection returned an invalid response")
+        except (
+            asyncio.IncompleteReadError,
+            asyncio.LimitOverrunError,
+            asyncio.TimeoutError,
+        ) as exc:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+            raise OSError("shared connection returned an invalid response") from exc
         except BaseException:
             writer.close()
             with contextlib.suppress(Exception):
@@ -182,12 +200,91 @@ def remote_proxy_dialer(share: ShareEndpoint):
     return dial
 
 
+def remote_proxy_resolver(share: ShareEndpoint):
+    """Resolve browser destinations on the Laptop that owns the shared exit.
+
+    The server-side browser and operating system never resolve the target.  A
+    small authenticated request asks the Laptop's already-bounded egress
+    service for its complete answer set; the server classifies that set again
+    before selecting one numeric address, and the Laptop classifies the chosen
+    address once more when CONNECT arrives.
+    """
+
+    async def resolve(host: str, port: int):
+        encoded = base64.urlsafe_b64encode(host.encode("utf-8")).decode("ascii").rstrip(
+            "="
+        )
+        token = base64.b64encode(
+            f"{share.username}:{share.password}".encode("ascii")
+        ).decode("ascii")
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(
+                share.host, share.port, limit=_REMOTE_HEADER_LIMIT + 1
+            ),
+            timeout=_REMOTE_IO_TIMEOUT,
+        )
+        try:
+            writer.write(
+                (
+                    f"CORESOLVE {encoded}:{port} HTTP/1.1\r\n"
+                    f"Proxy-Authorization: Basic {token}\r\n\r\n"
+                ).encode("ascii")
+            )
+            await asyncio.wait_for(writer.drain(), timeout=_REMOTE_IO_TIMEOUT)
+            head = await asyncio.wait_for(
+                reader.readuntil(b"\r\n\r\n"), timeout=_REMOTE_IO_TIMEOUT
+            )
+            if len(head) > _REMOTE_HEADER_LIMIT:
+                raise OSError("shared connection returned invalid DNS response")
+            status = head.split(b" ")[1:2]
+            if status != [b"200"]:
+                raise OSError("shared connection refused remote DNS")
+            length = None
+            for line in head.split(b"\r\n")[1:]:
+                name, separator, value = line.partition(b":")
+                if separator and name.lower() == b"content-length":
+                    length = int(value.strip())
+                    break
+            if length is None or not 0 < length <= 4096:
+                raise OSError("shared connection returned invalid DNS response")
+            body = await asyncio.wait_for(
+                reader.readexactly(length), timeout=_REMOTE_IO_TIMEOUT
+            )
+            answers = tuple(line for line in body.decode("ascii").splitlines() if line)
+            if not answers:
+                raise OSError("shared connection returned no DNS answers")
+            # Canonicalize before returning into EgressGateway's independent
+            # frozen classifier.  A malformed Laptop response cannot reach a
+            # dial call or turn into a second hostname lookup.
+            return tuple(str(ipaddress.ip_address(answer)) for answer in answers)
+        except (
+            ValueError,
+            UnicodeError,
+            asyncio.IncompleteReadError,
+            asyncio.LimitOverrunError,
+            asyncio.TimeoutError,
+        ) as exc:
+            raise OSError("shared connection returned invalid DNS response") from exc
+        finally:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+
+    return resolve
+
+
 def shared_egress_gateway(
     share: ShareEndpoint,
     **kwargs,
 ) -> EgressGateway:
     """A host-private gateway whose last hop is the caller's own connection."""
-    return EgressGateway(dialer=remote_proxy_dialer(share), **kwargs)
+    if "resolver" in kwargs or "dialer" in kwargs:
+        raise ValueError("shared egress owns its resolver and dialer")
+    return EgressGateway(
+        resolver=remote_proxy_resolver(share),
+        dialer=remote_proxy_dialer(share),
+        **kwargs,
+    )
 
 
 __all__ = [
@@ -197,5 +294,6 @@ __all__ = [
     "ShareEndpoint",
     "local_egress_address",
     "remote_proxy_dialer",
+    "remote_proxy_resolver",
     "shared_egress_gateway",
 ]

--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -220,8 +220,8 @@ cache-scanning PR #797, ACP as a first-party transport, or client-created licenc
   compatibility facade: #498, #499, and #500.
 - Direct Remote Browser first, then Relay operation through the reviewed secure OIP
   channel.
-- Stable, revocable, bounded three-party proxy grants and a pinned egress for unattended
-  execution: #991, #1034, and #1036.
+- A two-machine Laptop Proxy pinned to the remote WTF Browser runtime: #991 and
+  #1036. The earlier three-party unattended grant model is a later phase.
 - `auto`, `system`, and `onion` engine resolution with typed outcomes: #511.
 - PAYG browser sessions at $0.10/hour per instance, prepaid in $0.025 15-minute
   intervals: oo-api#168 and onionwright#40.
@@ -589,26 +589,25 @@ after review and vectors.
 7. Fail closed for legacy Relay peers. Direct authenticated TLS is a distinct profile,
    never a silent downgrade from Relay E2EE.
 
-### Proxy grants and data plane
+### First Laptop Proxy and data plane
 
-1. Implement signed P→D grant and D→B delegation with bounded scope, destinations,
-   bytes, concurrency, expiry, `renewable_until`, and immediate revocation.
-2. Require B's separate policy consent to use P. A tunnel/session/grant ID is never
-   bearer authorization.
-3. Use the reverse-tunnel topology for an always-on Proxy Agent behind NAT. Expose the
-   actual path taken (`direct | tunnel | relay`) and refuse any path not pinned by the
-   Browser Session.
-4. Keep bulk bytes on a separate encrypted binary plane with backpressure,
+1. `co proxy share to <B>` binds the Laptop share to the authenticated remote
+   Agent address. `co proxy stop <B>` stops the live service before removing state.
+2. Resolve and pin `shared` or `direct` once when the WTF Browser runtime is
+   created. Do not allow one runtime to mix modes or Laptop exits.
+3. Keep Proxy selection and service lifecycle outside BrowserDaemon. The daemon
+   controls the browser but cannot choose another exit or restore Direct.
+4. Keep bulk bytes on a separate bounded plane with backpressure,
    cancellation, accounting, byte/time/frame limits, and deterministic teardown.
-5. Terminate as a local SOCKS5/CONNECT service for Chromium without TLS interception or
-   installed CA certificates.
+5. Terminate as an authenticated loopback HTTP/CONNECT service for WTF Browser
+   without TLS interception or installed CA certificates.
 6. On Linux Remote Browser hosts, put the browser/context subprocess tree in a network
    namespace whose only egress is the selected tunnel. Keep management traffic outside
    it. Treat launch flags alone as an interim test configuration, not the final leak
    boundary.
-7. Enforce destination policy at the Proxy Agent after DNS resolution: allow public web
-   destinations; block loopback, private/link-local ranges, metadata endpoints, unsafe
-   ports, inbound listening, and DNS rebinding.
+7. Resolve target DNS on the Laptop, never in Chromium or the remote operating
+   system. The Laptop and remote gateway both classify the complete answer set;
+   the Laptop classifies the selected numeric address again before dialing.
 8. Preflight with an actual egress fetch and browser-observed leak probe. Pin the measured
    public IP. If the proxy disappears or the IP changes, pause/fail; never silently use
    the remote host's datacenter IP.
@@ -619,10 +618,13 @@ Alpha 3 exit gate:
   duplicate, stale/revoked key, wrong endpoint, downgrade, truncation, nonce misuse,
   counter/limit overflow, and reconnect/rekey attacks.
 - Relay captures and logs contain no application plaintext or content keys.
-- The 3am test passes with D offline: B and P complete a task under a pre-authorized
-  grant.
-- Egress is measured through P; WebRTC/DNS/QUIC leak tests cannot observe B's direct IP.
+- Egress and DNS are measured through the Laptop; WebRTC/DNS/QUIC leak tests
+  cannot observe B's direct IP.
 - Proxy loss pauses the Browser Session without changing egress.
+
+The three-party 3am workflow, renewable grant chain and always-on residential
+Proxy are explicitly future work. They do not change this preview's two-machine
+CLI or acceptance boundary.
 
 ## Phase 4 / beta 1 — React, O Chat, takeover, and product hardening
 
@@ -695,7 +697,7 @@ No component may be silently rebuilt, republished, or replaced during acceptance
 | renewal/balance/network failure | Onion stops at signed `paid_until`; no hot swap |
 | direct Remote Browser | start → act → screenshot → takeover/release → Stop/reconnect/resume |
 | Relay Remote Browser | same lifecycle with verified E2EE and opaque Relay capture |
-| unattended three-party proxy | D offline; P→D→B grant; stable measured egress |
+| Laptop Proxy | Laptop DNS and observed egress; remote WTF direct IP never appears |
 | proxy loss/IP change | session pauses/fails; no direct-IP fallback |
 | cost ceiling | typed nonzero `budget_exhausted`, accurate model/browser spend |
 | upgrade/rollback | 1.7 → exact 1.8 RC → 1.7 with profiles and config handled safely |

--- a/docs/blog/2026-08-30-a-server-browser-that-uses-your-address.md
+++ b/docs/blog/2026-08-30-a-server-browser-that-uses-your-address.md
@@ -1,89 +1,78 @@
 # A browser on a server, using your address
 
-`co proxy share to <address>` is in 1.8.0a3. It lends this computer's internet
-connection to one agent you authorize, and a remote browser session started
-with `--proxy shared` reaches the internet through it.
+The first test looked finished. A browser was running on a cloud server, its
+traffic crossed a Laptop in Sydney, and the destination reported the Laptop's
+public IP. That was the number we wanted to move.
 
-```bash
-co proxy share to 0xHOST                        # on your computer
-co remote-browser 0xHOST start --proxy shared   # then start the session
-```
+Then we looked one step earlier than the destination.
 
-The number that matters, measured across two real machines — a Google Cloud
-server running the paid Chromium 151, a laptop in Sydney lending its
-connection:
+The server had resolved the hostname before asking the Laptop to open the
+numeric socket. The page arrived from the right address, but the server still
+announced where it was going through DNS. We had moved the last packet and left
+the first one behind.
 
-```text
-the server's own address        34.21.243.229
-what the site saw               129.94.43.159
-```
+That is a particularly dangerous kind of green test: the visible result is
+right while the security boundary is wrong.
 
-## Lending a connection, not a network
+## Moving DNS changes who must be trusted
 
-The obvious way to build this is a forwarder: accept a connection, open a
-socket, copy bytes. That version would also hand the remote caller your router's
-admin page, whatever listens on `localhost`, and every other thing that answers
-inside your house — and each of those requests would arrive from a machine that
-trusts them.
+Sending the hostname to the Laptop sounds like a small correction. It is not.
+DNS can return several addresses, change its answer, or point a public-looking
+name at a private machine. If the server approves one lookup and the Laptop
+performs another, neither side knows which socket the other side meant.
 
-So the share is not a forwarder. It is the same component as the browser's own
-egress gateway — same parser, same authentication, same destination policy, same
-limits — bound to a reachable address instead of loopback:
+The path now makes one answer set cross the boundary:
 
 ```text
-CONNECT 192.168.0.1:80  →  403 DESTINATION_ADDRESS_DENIED
+WTF Browser on server
+        │ hostname
+        ▼
+Laptop resolves and checks every answer
+        │ complete numeric answer set
+        ▼
+server checks it independently and chooses one address
+        │ numeric CONNECT
+        ▼
+Laptop checks again and opens the public socket
 ```
 
-The check that keeps a remote caller off a server's private network turned out
-to be, unchanged, the check that keeps it off yours.
+The remote operating system never resolves the target. The Laptop cannot talk
+the server into accepting a private answer, and the server cannot use the
+Laptop as a tunnel into somebody's home network. A request for
+`192.168.0.1:80` dies before any upstream socket opens.
 
-## DNS moves too
+The useful lesson was not “proxy DNS too.” It was that a proxy boundary is a
+decision about an exact socket. Hostname checks are only evidence used to reach
+that decision; they are not the decision itself.
 
-The first implementation moved only the final socket: the server resolved the
-hostname and asked the Laptop for one numeric address. That proved the public
-IP, but it did not satisfy the product boundary. A server-side DNS lookup is
-still a server-side network signal.
+## Truth has a lifecycle
 
-The next preview moves DNS to the Laptop as well:
+Once DNS and the final socket belonged to the same Laptop, two older behaviors
+became impossible to ignore. A shared session accepted the Laptop endpoint but
+recorded itself as `direct`. Stopping a share removed a JSON entry but left the
+listener alive.
 
-```text
-WTF Browser on server → Laptop DNS → both policies approve all answers
-                      → Laptop connects the selected numeric address
-```
+Both bugs said the system was in a state it had never reached.
 
-The Laptop classifies the complete answer set before returning it. The remote
-gateway classifies it independently. The Laptop classifies the selected numeric
-address again before dialing. Neither side can widen the other's decision, and
-Chromium never asks the server resolver for the target.
+The WTF runtime now binds to one Direct or shared exit before the browser
+starts. A second session cannot quietly change it. Stop authenticates to the
+live service, waits for the listener to close, and only then removes the state.
+If the Laptop disappears, the browser loses the network path; it does not find
+the server's datacentre address as a convenient fallback.
 
-The same correction closes a second truthful-state bug: `start --proxy shared`
-used to accept the Laptop endpoint and then persist `proxy_mode: direct`.
-Runtime creation now writes one private Proxy binding before WTF Browser starts,
-and a running runtime refuses a different exit. `co proxy stop` now stops the
-live listener rather than only deleting its registry entry.
+## The negative test mattered most
 
-## What else is in this release
+We drove a visible Chromium through the two real proxy hops and served a page
+from the fake Laptop exit. DNS and the numeric connection both appeared at the
+Laptop boundary. Then we deliberately restored Chromium's localhost bypass.
+The preflight failed.
 
-The boundary that makes the above safe to offer: a frozen destination policy
-that classifies alternate address forms and special-use names, an authenticated
-loopback gateway that owns DNS and dials only approved numeric sockets, a
-Host-private browser runtime that keeps a remote caller's session out of the
-browser holding your logins, and a preflight that makes the browser prove it
-used the gateway before the first page opens.
+That second run is the stronger result. A test that only proves the intended
+path works can stay green while another path leaks. A test that introduces a
+real leak and watches the boundary reject it tells us the alarm is connected.
 
-Paid Onion Browser on Linux is a working customer path in this preview:
-`co browser install-onion` bootstraps the runtime through a signed release
-channel, and a paid session downloads and runs the exact Chromium 151 artifact.
-A session now says what it costs when it starts.
-
-## Try it
-
-```bash
-pip install connectonion==1.8.0a3
-```
-
-Preview releases are opt-in; `pip install connectonion` still gives you stable
-1.7. Remote **navigation** is still switched off — `diagnose` reports
-`navigation_policy: not_enabled` until the installed-artifact acceptance suite
-finishes. The share is reachable on your own network today; carrying it across
-networks still uses a tunnel you provide.
+The next acceptance is deliberately less tidy: two physical machines, observed
+DNS on both sides, and a destination comparing the Laptop and server IPs. The
+current listener also needs a trusted VPN or tunnel between networks; its Basic
+credential is authentication, not transport encryption. Those are remaining
+boundaries, not details to hide behind the successful local run.

--- a/docs/blog/2026-08-30-a-server-browser-that-uses-your-address.md
+++ b/docs/blog/2026-08-30-a-server-browser-that-uses-your-address.md
@@ -37,21 +37,30 @@ CONNECT 192.168.0.1:80  →  403 DESTINATION_ADDRESS_DENIED
 The check that keeps a remote caller off a server's private network turned out
 to be, unchanged, the check that keeps it off yours.
 
-## One hop moves, and only one
+## DNS moves too
 
-The host resolves the hostname, classifies every address the lookup returns, and
-pins one numeric address — exactly as it does with no share involved. Then it
-asks your machine for that same numeric address:
+The first implementation moved only the final socket: the server resolved the
+hostname and asked the Laptop for one numeric address. That proved the public
+IP, but it did not satisfy the product boundary. A server-side DNS lookup is
+still a server-side network signal.
+
+The next preview moves DNS to the Laptop as well:
 
 ```text
-CONNECT 93.184.216.34:443      ← what the host asks your share for
-CONNECT example.com:443        ← what it never asks
+WTF Browser on server → Laptop DNS → both policies approve all answers
+                      → Laptop connects the selected numeric address
 ```
 
-If it forwarded the hostname, your machine would resolve it a second time, and
-the address it dialed could differ from the one the host approved. Your share
-then applies its own policy to what it was handed, so a destination has to pass
-both machines.
+The Laptop classifies the complete answer set before returning it. The remote
+gateway classifies it independently. The Laptop classifies the selected numeric
+address again before dialing. Neither side can widen the other's decision, and
+Chromium never asks the server resolver for the target.
+
+The same correction closes a second truthful-state bug: `start --proxy shared`
+used to accept the Laptop endpoint and then persist `proxy_mode: direct`.
+Runtime creation now writes one private Proxy binding before WTF Browser starts,
+and a running runtime refuses a different exit. `co proxy stop` now stops the
+live listener rather than only deleting its registry entry.
 
 ## What else is in this release
 

--- a/docs/cli/proxy.md
+++ b/docs/cli/proxy.md
@@ -41,22 +41,26 @@ carries bytes the remote browser already decided to send, and for HTTPS the TLS
 session stays end to end — the share connects a socket and copies bytes; it
 installs no certificate and sees no page content.
 
-## How the two hops divide the work
+## DNS and the two decisions
 
-The host resolves the hostname, classifies **every** address the lookup
-returns, and pins one numeric address — exactly as it does without a share.
-Only the last hop changes: instead of dialing that address itself, it asks your
-share for that same numeric address.
+In `shared` mode the remote server does not resolve browser destinations. Its
+private gateway asks the Laptop Proxy to resolve the hostname. The Laptop
+classifies the complete answer set first; the remote gateway independently
+classifies the same set and selects one numeric address; then the Laptop
+classifies that numeric address again before opening the public socket.
 
 ```text
-CONNECT 93.184.216.34:443      ← what the host asks your share for
-CONNECT example.com:443        ← what it never asks
+WTF Browser: example.com
+        ↓ no server DNS
+Laptop DNS: 93.184.216.34
+        ↓ complete answer set is accepted by both machines
+CONNECT 93.184.216.34:443      ← final Laptop dial
 ```
 
-That matters. If the host forwarded the hostname, your share would resolve it a
-second time and could land somewhere the host never approved. Your share then
-applies its own policy to the address it was given, so a destination has to
-pass **both** machines.
+This gives the remote WTF Browser the Laptop's DNS and public-IP boundary
+without trusting either machine's decision alone. Chromium target DNS, QUIC and
+non-proxied WebRTC UDP are disabled, and the browser has no Direct proxy
+fallback.
 
 ## Options
 
@@ -65,6 +69,10 @@ pass **both** machines.
 | `--json` | the complete stable envelope, for scripts and agents |
 | `--bind HOST` | listen on a specific address (default: the one a peer reaches) |
 | `--ttl SEC` | stop sharing automatically after this long |
+
+`co proxy stop` sends an authenticated stop request to the live service, waits
+for its listener to close, and only then reports success. Deleting stale state
+is not treated as stopping a Proxy.
 
 `co proxy share` picks its own address by asking the routing table which
 interface reaches the internet. On a machine with several interfaces, or behind
@@ -77,6 +85,10 @@ differ.
 A share listens on this machine. An agent on another network needs a path to
 it — a port forward, a VPN, or a tunnel you already run. `co proxy diagnose`
 prints the address a peer would use, which is where to point that path.
+
+The first preview intentionally keeps this two-machine model. A later transport
+may make `share to` create its own outbound reverse path through the remote
+Agent; that is not silently claimed by the current listener implementation.
 
 ## Verified
 

--- a/docs/design-decisions/056-remote-browser-egress-gateway.md
+++ b/docs/design-decisions/056-remote-browser-egress-gateway.md
@@ -1,6 +1,6 @@
 # DD-056: Remote Browser navigation needs an egress gateway, not a URL check
 
-**Status:** Proposed for 1.8; navigation remains disabled
+**Status:** Accepted for 1.8; shared Laptop egress wired, navigation remains disabled
 
 **Date:** 2026-08-26
 
@@ -140,6 +140,27 @@ profile and behavior.
 Future shared-proxy grants may require different browser contexts because
 Chromium proxy selection is context-scoped. #1036 must choose and test that
 context/process model; this decision does not claim per-tab proxy isolation.
+
+## First shared-Proxy decision (2026-09-01)
+
+The first preview uses the two-machine product selected in #1036: a Laptop runs
+`co proxy share to <B>`, and the remote WTF Browser B pins that Laptop for the
+runtime. It does not require the later three-party unattended D/P/B model.
+
+The authority split is:
+
+- `RemoteBrowserService` chooses and persists `direct` or `shared` once;
+- the private WTF runtime enforces one fixed loopback Proxy with no Direct
+  fallback;
+- Laptop `co proxy` owns target DNS resolution and the public socket;
+- BrowserDaemon controls pages/tabs but cannot choose or change the Proxy.
+
+In shared mode B does not call system DNS for target names. It sends an
+authenticated bounded resolution request to the Laptop, independently checks
+the complete returned answer set, and asks the Laptop to connect one selected
+numeric address. The Laptop applies the same frozen policy both while resolving
+and while dialing. This preserves the exact-socket invariant while ensuring DNS
+and public egress both belong to the Laptop.
 
 ## Gateway connection contract
 

--- a/docs/network/remote-browser-private-runtime.md
+++ b/docs/network/remote-browser-private-runtime.md
@@ -20,8 +20,9 @@ Each Host state file deterministically selects one private runtime with its own:
 - lifetime PID and singleton-lock sidecars;
 - persistent browser profile;
 - daemon log;
-- Windows IPC authentication key; and
-- ephemeral authenticated egress gateway credential.
+- Windows IPC authentication key;
+- ephemeral authenticated egress gateway credential; and
+- an optional mode-`0600` Laptop Proxy selection read only at runtime start.
 
 The local `co browser` namespace and profile remain unchanged. Local and private
 daemons can run at the same time and stop independently. Long project paths are
@@ -33,6 +34,13 @@ created through the existing atomic, per-file HMAC-key path. Gateway passwords
 are never command-line arguments and are excluded from dataclass
 representations. The session registry, state file, log path, errors, and command
 results contain no proxy credential.
+
+`RemoteBrowserService`, not BrowserDaemon, selects `direct` or `shared` and
+writes the private selection before asking the daemon adapter to open a tab.
+BrowserDaemon consumes that immutable choice while constructing the WTF Browser
+launch policy; it cannot select another Proxy or fall back to Direct. The
+Laptop's `co proxy` process has its own lifecycle and remains independently
+stoppable if BrowserDaemon fails.
 
 ## Start and stop order
 
@@ -46,6 +54,11 @@ If the gateway cannot start or the browser cannot be constructed, the daemon
 never binds its IPC endpoint. If the gateway stops serving later, every daemon
 command returns `EGRESS_GATEWAY_UNAVAILABLE` before a tab or browser mutation.
 There is no Direct fallback.
+
+For shared egress the loopback gateway replaces its system resolver and numeric
+dialer together: DNS asks the Laptop Proxy for its complete classified answer
+set, and the selected numeric connection returns to that same Laptop Proxy.
+Chromium and the remote operating system never resolve the destination.
 
 ## Requested Chromium launch policy
 

--- a/docs/network/remote-browser.md
+++ b/docs/network/remote-browser.md
@@ -43,6 +43,11 @@ centre while you believed it left from home. Any other mode answers
 Both machines apply the destination policy, so sharing a connection does not
 share the network behind it. See [co proxy](../cli/proxy.md).
 
+The selection is pinned when the WTF Browser runtime is created. One running
+runtime cannot mix `direct` and `shared`, or two different Laptop exits. A
+change requires a new runtime; losing the Laptop Proxy never falls back to the
+server's datacentre address.
+
 ## Scripting it
 
 `--json` returns a stable envelope on every command — `schema_version`, `ok`,
@@ -84,8 +89,9 @@ connections that the first check never saw.
 Navigation will be authorized at the socket, not at the URL. The host runs a
 loopback egress gateway and starts the browser with no way around it: every
 HTTP, HTTPS, WebSocket, worker, subresource, redirect and download connection
-goes through the gateway, which resolves the name itself, checks every address
-the lookup returned, and dials only an approved numeric address.
+goes through the gateway. In `direct` mode the host gateway resolves and dials.
+In `shared` mode the Laptop resolves the name and opens the final socket; both
+machines classify the complete answer set before one numeric address is used.
 
 ```text
 remote command ──▶ Remote Browser service ──▶ host-private browser
@@ -93,7 +99,7 @@ remote command ──▶ Remote Browser service ──▶ host-private browser
                                                      │ no direct fallback
                                                      ▼
                                        egress gateway 127.0.0.1:<port>
-                                       resolve · classify · dial approved IP
+                                       classify · direct/shared transport
                                                      ▼
                                              the public internet
 ```

--- a/tests/e2e/test_native_egress_preflight_real_driver.py
+++ b/tests/e2e/test_native_egress_preflight_real_driver.py
@@ -23,6 +23,10 @@ from connectonion.network.host.egress_gateway import EgressGateway
 from connectonion.network.host.private_browser_runtime import (
     REMOTE_BROWSER_CHROME_ARGS,
 )
+from connectonion.network.proxy_egress import (
+    ProxyEgressService,
+    shared_egress_gateway,
+)
 from connectonion.useful_tools.browser_tools.native_egress import (
     NativeEgressPreflightError,
     run_native_egress_preflight,
@@ -51,7 +55,7 @@ async def _run_preflight(args: tuple[str, ...]) -> tuple[bool, int]:
     try:
         async with async_playwright() as driver:
             browser = await driver.chromium.launch(
-                headless=True,
+                headless=False,
                 executable_path=_chrome(),
                 args=list(args),
                 proxy={
@@ -110,3 +114,76 @@ def test_a_real_loopback_leak_still_fails_the_preflight():
     passed, _ = asyncio.run(_run_preflight(leaking))
 
     assert not passed, "a genuine loopback leak passed the preflight"
+
+
+@pytest.mark.slow
+def test_real_chromium_resolves_and_egresses_through_the_laptop_proxy():
+    if _chrome() is None:
+        pytest.skip("no Chrome/Chromium on this machine")
+    pytest.importorskip("patchright")
+
+    body, resolved, handled = asyncio.run(_exercise_shared_proxy())
+
+    assert body == "through laptop"
+    assert ("example.com", 80) in resolved
+    assert handled >= 2  # authenticated DNS plus the numeric tunnel
+
+
+async def _exercise_shared_proxy():
+    from patchright.async_api import async_playwright
+
+    resolved = []
+
+    async def origin(reader, writer):
+        try:
+            await reader.readuntil(b"\r\n\r\n")
+        except asyncio.IncompleteReadError:
+            writer.close()
+            return
+        payload = b"through laptop"
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nConnection: close\r\n"
+            + f"Content-Length: {len(payload)}\r\n\r\n".encode("ascii")
+            + payload
+        )
+        await writer.drain()
+        writer.close()
+
+    origin_server = await asyncio.start_server(origin, "127.0.0.1", 0)
+    origin_port = origin_server.sockets[0].getsockname()[1]
+
+    async def laptop_dns(host, port):
+        resolved.append((host, port))
+        return ("8.8.8.8",)
+
+    async def laptop_dial(_endpoint, _timeout):
+        return await asyncio.open_connection("127.0.0.1", origin_port)
+
+    share = ProxyEgressService(
+        bind_host="127.0.0.1", resolver=laptop_dns, dialer=laptop_dial
+    )
+    await share.start()
+    gateway = shared_egress_gateway(share.endpoint)
+    endpoint = await gateway.start()
+    try:
+        async with async_playwright() as driver:
+            browser = await driver.chromium.launch(
+                headless=False,
+                executable_path=_chrome(),
+                args=list(REMOTE_BROWSER_CHROME_ARGS),
+                proxy={
+                    "server": f"http://127.0.0.1:{endpoint.port}",
+                    "username": endpoint.username,
+                    "password": endpoint.password,
+                },
+            )
+            page = await browser.new_page()
+            await page.goto("http://example.com/")
+            content = await page.text_content("body")
+            await browser.close()
+    finally:
+        await gateway.stop()
+        await share.stop()
+        origin_server.close()
+        await origin_server.wait_closed()
+    return content, resolved, share.handled_requests

--- a/tests/e2e/test_native_egress_preflight_real_driver.py
+++ b/tests/e2e/test_native_egress_preflight_real_driver.py
@@ -55,7 +55,7 @@ async def _run_preflight(args: tuple[str, ...]) -> tuple[bool, int]:
     try:
         async with async_playwright() as driver:
             browser = await driver.chromium.launch(
-                headless=False,
+                headless=True,
                 executable_path=_chrome(),
                 args=list(args),
                 proxy={
@@ -168,7 +168,7 @@ async def _exercise_shared_proxy():
     try:
         async with async_playwright() as driver:
             browser = await driver.chromium.launch(
-                headless=False,
+                headless=True,
                 executable_path=_chrome(),
                 args=list(REMOTE_BROWSER_CHROME_ARGS),
                 proxy={

--- a/tests/unit/test_cli_remote_browser.py
+++ b/tests/unit/test_cli_remote_browser.py
@@ -1,7 +1,7 @@
 """CLI contract tests for ``co remote-browser``."""
 
-import json
 import importlib
+import json
 
 from connectonion.cli.commands.remote_browser_commands import handle_remote_browser
 
@@ -107,3 +107,32 @@ def test_proxy_option_is_not_accepted_by_non_start_command(monkeypatch):
     handle_remote_browser(["--proxy", "direct", "0xhost", "sessions"])
 
     assert remote.calls == [("sessions", {"session_id": None, "timeout": 60.0})]
+
+
+def test_shared_start_passes_the_laptop_endpoint_once_at_runtime_creation(
+    tmp_path, monkeypatch
+):
+    remote = _install(monkeypatch, _result())
+    from connectonion.cli.commands import proxy_commands
+
+    state_path = tmp_path / "proxy-shares.json"
+    monkeypatch.setattr(proxy_commands, "STATE_PATH", state_path)
+    proxy_commands._save(
+        {
+            "0xhost": {
+                "url": "http://192.0.2.10:43123",
+                "host": "192.0.2.10",
+                "port": 43123,
+                "username": "laptop",
+                "password": "secret",
+            }
+        }
+    )
+
+    assert handle_remote_browser(["--proxy", "shared", "0xhost", "start"]) == 0
+
+    command, kwargs = remote.calls[0]
+    assert command == "start"
+    assert kwargs["proxy"] == "shared"
+    assert kwargs["share"]["host"] == "192.0.2.10"
+    assert kwargs["share"]["password"] == "secret"

--- a/tests/unit/test_proxy_egress.py
+++ b/tests/unit/test_proxy_egress.py
@@ -2,7 +2,10 @@
 
 import asyncio
 import base64
+import json
+import os
 import socket
+import stat
 
 import pytest
 
@@ -11,6 +14,7 @@ from connectonion.network.proxy_egress import (
     ProxyEgressService,
     local_egress_address,
     remote_proxy_dialer,
+    remote_proxy_resolver,
     shared_egress_gateway,
 )
 
@@ -33,6 +37,18 @@ async def _origin(response=b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection:
 def _auth(endpoint) -> str:
     raw = f"{endpoint.username}:{endpoint.password}".encode("ascii")
     return "Basic " + base64.b64encode(raw).decode("ascii")
+
+
+def test_proxy_registry_is_atomic_and_private(tmp_path, monkeypatch):
+    from connectonion.cli.commands import proxy_commands
+
+    path = tmp_path / ".co" / "proxy-shares.json"
+    monkeypatch.setattr(proxy_commands, "STATE_PATH", path)
+    proxy_commands._save({"0xtest": {"password": "secret"}})
+
+    assert json.loads(path.read_text()) == {"0xtest": {"password": "secret"}}
+    if os.name != "nt":
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
 
 @pytest.mark.asyncio
@@ -93,6 +109,19 @@ async def test_an_unauthenticated_neighbour_cannot_use_the_share():
 
 
 @pytest.mark.asyncio
+async def test_laptop_dns_refuses_a_name_that_resolves_into_its_lan():
+    async def private_answer(_host, _port):
+        return ("192.168.0.1",)
+
+    async with ProxyEgressService(
+        bind_host="127.0.0.1", resolver=private_answer
+    ) as share:
+        resolve = remote_proxy_resolver(share.endpoint)
+        with pytest.raises(OSError, match="refused remote DNS"):
+            await resolve("public-looking.example.net", 443)
+
+
+@pytest.mark.asyncio
 async def test_traffic_leaves_through_the_share_rather_than_the_host():
     """The end-to-end property: the destination sees the sharer, not the host.
 
@@ -114,9 +143,7 @@ async def test_traffic_leaves_through_the_share_rather_than_the_host():
     async with ProxyEgressService(
         bind_host="127.0.0.1", resolver=public, dialer=to_origin
     ) as share:
-        gateway = shared_egress_gateway(
-            share.endpoint, resolver=public, allowed_ports=(80, 443)
-        )
+        gateway = shared_egress_gateway(share.endpoint, allowed_ports=(80, 443))
         endpoint = await gateway.start()
         try:
             reader, writer = await asyncio.open_connection(endpoint.host, endpoint.port)
@@ -141,18 +168,22 @@ async def test_traffic_leaves_through_the_share_rather_than_the_host():
 
 
 @pytest.mark.asyncio
-async def test_the_host_asks_the_share_for_a_numeric_address_only():
-    """Lending a connection must not widen what the host was willing to reach.
-
-    The host resolves and classifies the hostname itself; only the last hop
-    moves. If it forwarded the name instead, the share would resolve it a
-    second time and could land somewhere the host never approved.
-    """
+async def test_dns_runs_on_the_laptop_then_the_host_asks_for_one_numeric_address():
+    """The browser host never resolves a target; the Laptop does, then both
+    sides classify the complete answer set before a numeric CONNECT."""
     requests = []
 
     async def recorder(reader, writer):
-        requests.append(await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5))
-        writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        request = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5)
+        requests.append(request)
+        if request.startswith(b"CORESOLVE "):
+            body = b"8.8.8.8\n"
+            writer.write(
+                b"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 8\r\n\r\n"
+                + body
+            )
+        else:
+            writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
         await writer.drain()
         writer.close()
 
@@ -160,10 +191,10 @@ async def test_the_host_asks_the_share_for_a_numeric_address_only():
     port = fake_share.sockets[0].getsockname()[1]
     from connectonion.network.proxy_egress import ShareEndpoint
 
-    dial = remote_proxy_dialer(ShareEndpoint("127.0.0.1", port, "u", "p"))
+    share = ShareEndpoint("127.0.0.1", port, "u", "p")
     gateway = EgressGateway(
-        resolver=lambda host, port_: asyncio.sleep(0, result=("8.8.8.8",)),
-        dialer=dial,
+        resolver=remote_proxy_resolver(share),
+        dialer=remote_proxy_dialer(share),
     )
     endpoint = await gateway.start()
     try:
@@ -182,10 +213,12 @@ async def test_the_host_asks_the_share_for_a_numeric_address_only():
         fake_share.close()
         await fake_share.wait_closed()
 
-    assert requests, "the host never reached the share"
-    asked = requests[0].decode("ascii")
-    assert "CONNECT 8.8.8.8:443" in asked, asked
-    assert "example.com" not in asked.split("\r\n")[0]
+    assert len(requests) == 2, "the host did not resolve and connect through the share"
+    resolve_line = requests[0].decode("ascii").split("\r\n")[0]
+    connect_line = requests[1].decode("ascii").split("\r\n")[0]
+    assert resolve_line.startswith("CORESOLVE ")
+    assert "example.com" not in resolve_line
+    assert connect_line == "CONNECT 8.8.8.8:443 HTTP/1.1"
 
 
 def test_the_reachable_address_is_not_loopback():
@@ -213,7 +246,17 @@ def test_the_share_command_serves_instead_of_reporting_and_exiting(tmp_path, mon
     (home / ".co").mkdir(parents=True)
     env = {**__import__("os").environ, "HOME": str(home)}
     process = subprocess.Popen(
-        [sys.executable, "-m", "connectonion.cli.main", "proxy", "share", "to", "0xtest"],
+        [
+            sys.executable,
+            "-m",
+            "connectonion.cli.main",
+            "proxy",
+            "share",
+            "to",
+            "0xtest",
+            "--bind",
+            "127.0.0.1",
+        ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         env=env,
@@ -235,9 +278,31 @@ def test_the_share_command_serves_instead_of_reporting_and_exiting(tmp_path, mon
             probe.connect((host, int(port)))
         finally:
             probe.close()
-    finally:
-        process.terminate()
+        stopped = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "connectonion.cli.main",
+                "proxy",
+                "stop",
+                "0xtest",
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=15,
+        )
+        assert stopped.returncode == 0, stopped.stdout + stopped.stderr
         process.wait(timeout=15)
+        refused = socket.socket()
+        refused.settimeout(1)
+        with pytest.raises(OSError):
+            refused.connect((host, int(port)))
+        refused.close()
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            process.wait(timeout=15)
 
     # And a stopped share does not stay in the registry claiming to be live.
     remaining = json.loads(registry.read_text()) if registry.exists() else {}

--- a/tests/unit/test_remote_browser_private_runtime.py
+++ b/tests/unit/test_remote_browser_private_runtime.py
@@ -20,11 +20,14 @@ from connectonion.network.host.private_browser_runtime import (
     REMOTE_BROWSER_CHROME_ARGS,
     PrivateBrowserTarget,
     canonical_proxy_auth,
+    load_shared_proxy_file,
     proxy_auth_path_for_profile,
     remote_browser_launch_policy,
     write_proxy_auth_file,
+    write_shared_proxy_file,
 )
 from connectonion.network.host.remote_browser import RemoteBrowserService
+from connectonion.network.proxy_egress import ShareEndpoint
 from connectonion.useful_tools.browser_tools import _async_browser as async_browser
 from connectonion.useful_tools.browser_tools.launch_policy import (
     BrowserLaunchPolicy,
@@ -197,6 +200,19 @@ def test_proxy_auth_file_matches_native_contract_and_is_private(tmp_path):
         assert stat.S_IMODE(auth_file.stat().st_mode) == 0o600
 
 
+def test_shared_proxy_file_is_private_bounded_and_round_trips(tmp_path):
+    endpoint = ShareEndpoint("192.0.2.10", 43123, "laptop", "secret")
+    path = tmp_path / "shared-proxy.json"
+
+    assert write_shared_proxy_file(path, endpoint) == path
+    assert load_shared_proxy_file(path) == endpoint
+    if os.name != "nt":
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        path.chmod(0o644)
+        with pytest.raises(ValueError, match="must be private"):
+            load_shared_proxy_file(path)
+
+
 @pytest.mark.parametrize(
     "endpoint",
     (
@@ -278,6 +294,39 @@ async def test_daemon_starts_gateway_before_browser_and_stops_it_after_browser(
         "gateway.stop",
     ]
     assert not auth_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_daemon_uses_the_runtime_selected_shared_gateway(
+    tmp_path, monkeypatch
+):
+    events = []
+    selected = []
+    share = ShareEndpoint("192.0.2.10", 43123, "laptop", "secret")
+    share_path = tmp_path / "shared-proxy.json"
+    write_shared_proxy_file(share_path, share)
+    gateway = RecordingGateway(events)
+
+    def shared_gateway(endpoint):
+        selected.append(endpoint)
+        return gateway
+
+    monkeypatch.setattr(
+        "connectonion.network.proxy_egress.shared_egress_gateway", shared_gateway
+    )
+    daemon = BrowserDaemon(
+        str(tmp_path / "private.sock"),
+        engine_mode="onion",
+        profile_dir=tmp_path / "profile",
+        remote_egress=True,
+        shared_proxy_path=share_path,
+        browser_factory=LifecycleBrowser,
+    )
+
+    await daemon._prepare_runtime()
+    assert selected == [share]
+    assert daemon.browser.egress_gateway is gateway
+    await daemon._shutdown_async()
 
 
 @pytest.mark.asyncio
@@ -653,6 +702,12 @@ async def test_private_spawn_argv_and_log_never_contain_gateway_secret(
         profile_dir=tmp_path / "profile",
         log_path=tmp_path / "private.log",
         authkey_path=tmp_path / "authkey",
+        shared_proxy_path=tmp_path / "shared-proxy.json",
+    )
+    share_secret = "laptop-proxy-secret"
+    write_shared_proxy_file(
+        target.shared_proxy_path,
+        ShareEndpoint("192.0.2.10", 43123, "laptop", share_secret),
     )
     spawned = []
     connection = object()
@@ -678,6 +733,9 @@ async def test_private_spawn_argv_and_log_never_contain_gateway_secret(
     assert "--remote-egress" in command
     assert command[command.index("--profile-dir") + 1] == str(target.profile_dir)
     assert command[command.index("--authkey-file") + 1] == str(target.authkey_path)
+    assert command[command.index("--shared-proxy-file") + 1] == str(
+        target.shared_proxy_path
+    )
     # Assert the credential the gateway actually minted is absent, not a
     # literal chosen by this test: the previous form passed on any argv,
     # including one carrying a real password, because this code path never
@@ -685,6 +743,7 @@ async def test_private_spawn_argv_and_log_never_contain_gateway_secret(
     assert secret
     assert secret not in repr(command)
     assert secret not in " ".join(command)
+    assert share_secret not in " ".join(command)
     assert secret not in target.log_path.read_text(encoding="utf-8")
     assert target.log_path.read_text(encoding="utf-8") == ""
 

--- a/tests/unit/test_remote_browser_service.py
+++ b/tests/unit/test_remote_browser_service.py
@@ -16,6 +16,8 @@ class Daemon:
             return 0, tokens[2]
         if tokens[:2] == ["tab", "close"]:
             return 0, f"Closed tab {tokens[2]}"
+        if tokens == ["close"]:
+            return 0, "Browser closed"
         raise AssertionError(line)
 
 
@@ -156,6 +158,102 @@ def test_non_direct_proxy_and_navigation_are_not_silently_enabled(tmp_path):
     assert unknown["code"] == "REMOTE_SESSION_PROXY_LOCKED"
     assert navigation["code"] == "INVALID_ARGUMENT"
     assert daemon.calls == []
+
+
+def test_shared_start_pins_the_laptop_proxy_without_persisting_its_secret(tmp_path):
+    daemon = Daemon()
+    remote = RemoteBrowserService(tmp_path / "sessions.json")
+    remote.daemon_request = daemon
+    share = {
+        "url": "http://192.0.2.10:43123",
+        "username": "laptop",
+        "password": "secret-value",
+    }
+
+    started = remote.handle(
+        request("start", args={"proxy": "shared", "share": share}),
+        owner="0xalice",
+        transport="direct",
+    )
+
+    assert started["ok"] is True
+    assert started["result"]["proxy_mode"] == "shared"
+    assert "secret-value" not in repr(started)
+    saved = json.loads((tmp_path / "sessions.json").read_text())
+    session = next(iter(saved["sessions"].values()))
+    assert session["proxy_mode"] == "shared"
+    assert len(session["proxy_binding"]) == 64
+    assert "secret-value" not in repr(saved)
+    config = json.loads(remote.daemon_target.shared_proxy_path.read_text())
+    assert config["host"] == "192.0.2.10"
+    assert config["port"] == 43123
+    assert config["password"] == "secret-value"
+
+    stopped = remote.handle(
+        request(
+            "stop",
+            request_id="req-stop-shared",
+            session_id=started["result"]["session_id"],
+        ),
+        owner="0xalice",
+        transport="direct",
+    )
+    assert stopped["ok"] is True
+    assert not remote.daemon_target.shared_proxy_path.exists()
+    assert daemon.calls[-1][0] == "close"
+
+
+def test_failed_first_shared_start_leaves_no_stale_proxy_selection(tmp_path):
+    remote = RemoteBrowserService(tmp_path / "sessions.json")
+
+    def rejected(_line, **_identity):
+        return 1, "browser rejected start"
+
+    remote.daemon_request = rejected
+    result = remote.handle(
+        request(
+            "start",
+            args={
+                "proxy": "shared",
+                "share": {
+                    "url": "http://192.0.2.10:43123",
+                    "username": "laptop",
+                    "password": "secret-value",
+                },
+            },
+        ),
+        owner="0xalice",
+        transport="direct",
+    )
+
+    assert result["code"] == "REMOTE_BROWSER_UNAVAILABLE"
+    assert not remote.daemon_target.shared_proxy_path.exists()
+    assert not (tmp_path / "sessions.json").exists()
+
+
+def test_one_wtf_runtime_cannot_mix_direct_and_shared_sessions(tmp_path):
+    remote, daemon = service(tmp_path)
+    first = remote.handle(request("start"), owner="0xalice", transport="direct")
+    second = remote.handle(
+        request(
+            "start",
+            request_id="req-shared",
+            args={
+                "proxy": "shared",
+                "share": {
+                    "url": "http://192.0.2.10:43123",
+                    "username": "u",
+                    "password": "p",
+                },
+            },
+        ),
+        owner="0xbob",
+        transport="direct",
+    )
+
+    assert first["ok"] is True
+    assert second["code"] == "REMOTE_SESSION_PROXY_LOCKED"
+    assert len(daemon.calls) == 1
 
 
 def test_explicit_non_object_args_are_rejected(tmp_path):


### PR DESCRIPTION
## Outcome

Implement the first two-machine Laptop Proxy for the ConnectOnion 1.8 Remote WTF Browser Preview. The remote browser keeps its profile/cookies, while all browser-controlled DNS and public sockets use the authorized Laptop egress. There is no silent datacenter `DIRECT` fallback.

Fixes #1036 only after the remaining acceptance gates below pass.

## Release planning

- **Proposed target version:** `1.8.0a5` / next 1.8 alpha after acceptance
- **Estimated release window:** September 2026, after lockfile recovery and the real two-machine IP/DNS/leak-prevention gate
- **Milestone:** `1.8.0 — remote browser sessions and async execution`
- **Forward-port tracking issue:** not applicable; this is breaking Preview work

## Product/runtime contract

- `co proxy share to <remote-agent>` starts an authenticated bounded Laptop-side DNS/data service.
- `co remote-browser <remote-agent> start --proxy shared` pins that proxy selection to the private WTF Browser runtime.
- Both Laptop and remote gateway reject private, loopback, link-local, metadata, reserved and rebinding targets.
- Proxy loss fails closed. Changing egress requires a new runtime.
- `co proxy stop` stops the live service/tunnels and removes truthful state.
- The first listener requires an existing VPN/SSH tunnel or equivalent protected path across untrusted networks; automatic encrypted reverse transport is later work.

## Implemented and previously verified

- authenticated bounded Laptop-side DNS resolution and numeric connect;
- double destination-policy enforcement;
- private mode-0600 proxy selection/credentials;
- fixed shared/direct runtime ownership and no mixed-mode fallback;
- live proxy Stop;
- headed Chromium positive shared path plus deliberate Direct-leak negative control;
- documentation, design decision and dev-blog updates.

Prior head `a62914c62ed03113cbf40ea5c09e523f00f77ddc` completed 25 GitHub checks with no failures, including Python 3.10–3.13, Linux/macOS/Windows egress, macOS/Windows E2E, Windows browser, CodeQL, blog and lockfile.

## Current head/check state — 2026-09-02

- Head: `eca1cda9cd4e7c421301a8c1f64d91bb3e8937ab` (`test: keep the real-driver preflight headless`).
- Draft: yes. The PR was briefly marked Ready while acceptance was still incomplete; it has been restored to Draft.
- Mergeability: mergeable, but GitHub state is currently `UNSTABLE`.
- Workflow `33568073057`: required `lockfile` job failed at “Verify and audit the exact dependency lock”; platform/egress/E2E jobs are passing or still completing.

## Required before Ready/Merge

- [ ] Fix/regenerate the exact dependency lock for the current head and obtain a fully green required matrix.
- [ ] Run a real two-physical-machine test proving site-observed IP equals the Laptop IP and remote-host DNS does not leak.
- [ ] Prove HTTP(S), WebSocket, redirects, subresources and downloads all use Laptop egress.
- [ ] Prove QUIC, local DNS and non-proxied WebRTC cannot escape.
- [ ] Prove proxy disconnect fails closed with no direct fallback.
- [ ] Exercise/document Linux remote WTF Browser with macOS/Linux Laptop Proxy.
- [ ] Complete hands-on Preview acceptance and record evidence in #1036.

Do not mark Ready, merge, tag or publish from the current head until every item above is complete. This is intentionally breaking 1.8 Preview work; Windows Remote WTF Browser remains outside the first cut.
