### PR TITLE
co remote-browser config: remember the remote agent once

### DIFF
--- a/connectonion/cli/commands/proxy_commands.py
+++ b/connectonion/cli/commands/proxy_commands.py
@@ -26,10 +26,12 @@ from pathlib import Path
 
 USAGE = """co proxy — share this computer's internet connection.
 
-  co proxy share to <address>     lend your connection to one agent
+  co proxy share [to <address>]   lend your connection to one agent
   co proxy status                 what is shared right now
-  co proxy stop <address>         stop lending
-  co proxy diagnose <address>     why a share is not working
+  co proxy stop [<address>]       stop lending
+  co proxy diagnose [<address>]   why a share is not working
+
+<address> defaults to the one `co remote-browser config` remembered.
 
 Options:
   --json          emit the complete stable JSON envelope
@@ -339,23 +341,27 @@ def handle_proxy(args) -> int:
         print(USAGE)
         return 0
 
+    from .remote_browser_commands import NOT_CONFIGURED, configured_address
+
     verb, rest = args[0], args[1:]
-    if verb == "share":
-        # `share to <address>` reads as English; `share <address>` also works.
-        target = rest[1] if rest[:1] == ["to"] else (rest[0] if rest else None)
-        if not target:
-            print("co proxy share needs an address.", file=sys.stderr)
-            print("Try: co proxy share to 0xHOST", file=sys.stderr)
-            return 2
-        return _share(target, as_json, bind, ttl)
     if verb == "status":
         return _status(as_json)
-    if verb in {"stop", "diagnose"}:
-        if not rest:
-            print(f"co proxy {verb} needs an address.", file=sys.stderr)
-            print("See what is shared with: co proxy status", file=sys.stderr)
-            return 2
-        return (_stop if verb == "stop" else _diagnose)(rest[0], as_json)
+    if verb not in {"share", "stop", "diagnose"}:
+        print(f"Unknown command: co proxy {verb}", file=sys.stderr)
+        print(USAGE, file=sys.stderr)
+        return 2
+
+    # `share to <address>` reads as English; `share <address>` also works, and
+    # no address at all means the one `co remote-browser config` remembered.
+    if rest[:1] == ["to"]:
+        rest = rest[1:]
+    target = rest[0] if rest else configured_address()
+    if not target:
+        print(NOT_CONFIGURED, file=sys.stderr)
+        return 2
+    if verb == "share":
+        return _share(target, as_json, bind, ttl)
+    return (_stop if verb == "stop" else _diagnose)(target, as_json)
 
     print(f"Unknown command: co proxy {verb}", file=sys.stderr)
     print(USAGE, file=sys.stderr)

--- a/connectonion/cli/commands/remote_browser_commands.py
+++ b/connectonion/cli/commands/remote_browser_commands.py
@@ -21,8 +21,9 @@ Options:
   --json           emit the complete stable JSON envelope
   --timeout SEC    seconds to wait (default 60)
   --relay URL      relay backend used for discovery/fallback
-  --headless       start headless (default)
-  --headed         start with a visible browser
+  --headed         start with a visible window (default, like co browser;
+                   a host with no display runs headless by itself)
+  --headless       start without a window
   --proxy MODE     direct (this host's connection) or shared (yours)
 """
 
@@ -55,7 +56,7 @@ def _parse(args):
         "json_output": False,
         "timeout": 60.0,
         "relay_url": None,
-        "headless": True,
+        "headless": False,
         "proxy": None,
     }
     positional = []

--- a/connectonion/cli/commands/remote_browser_commands.py
+++ b/connectonion/cli/commands/remote_browser_commands.py
@@ -2,14 +2,20 @@
 
 import json
 import sys
+from pathlib import Path
 
 USAGE = """co remote-browser — manage a browser session on a remote agent.
 
-  co remote-browser [options] <address> start
-  co remote-browser [options] <address> sessions
-  co remote-browser [options] <address> status <session-id>
-  co remote-browser [options] <address> stop <session-id>
-  co remote-browser [options] <address> diagnose <session-id>
+  co remote-browser config <address> [--proxy MODE]   remember the remote once
+  co remote-browser config                             show what is remembered
+
+  co remote-browser [options] [<address>] start
+  co remote-browser [options] [<address>] sessions
+  co remote-browser [options] [<address>] status <session-id>
+  co remote-browser [options] [<address>] stop <session-id>
+  co remote-browser [options] [<address>] diagnose <session-id>
+
+<address> is optional once `config` has remembered one; giving it still wins.
 
 Options:
   --json           emit the complete stable JSON envelope
@@ -20,6 +26,29 @@ Options:
   --proxy MODE     direct (this host's connection) or shared (yours)
 """
 
+CONFIG_PATH = Path.home() / ".co" / "remote-browser.json"
+PROXY_MODES = ("direct", "shared")
+NOT_CONFIGURED = (
+    "No remote browser configured.\n"
+    "Set one with: co remote-browser config <address> --proxy shared"
+)
+
+
+def load_config() -> dict:
+    """The remembered remote: {"address": ..., "proxy": ...}, or {} if none."""
+    if not CONFIG_PATH.exists():
+        return {}
+    return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+def _save_config(config: dict) -> None:
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG_PATH.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+
+def configured_address() -> str | None:
+    return load_config().get("address")
+
 
 def _parse(args):
     options = {
@@ -27,7 +56,7 @@ def _parse(args):
         "timeout": 60.0,
         "relay_url": None,
         "headless": True,
-        "proxy": "direct",
+        "proxy": None,
     }
     positional = []
     index = 0
@@ -106,6 +135,40 @@ def _print_invalid_argument(message, *, json_output):
     return 2
 
 
+def _config(positional, options) -> int:
+    """`config` with no address shows; with one, remembers it (and --proxy)."""
+    if len(positional) > 1:
+        return _print_invalid_argument(
+            "co remote-browser config [<address>] [--proxy MODE]",
+            json_output=options["json_output"],
+        )
+    if options["proxy"] is not None and options["proxy"] not in PROXY_MODES:
+        return _print_invalid_argument(
+            f"--proxy must be one of {', '.join(PROXY_MODES)}",
+            json_output=options["json_output"],
+        )
+    if not positional:
+        config = load_config()
+        if options["json_output"]:
+            print(json.dumps(config, sort_keys=True))
+            return 0
+        if not config:
+            print(NOT_CONFIGURED, file=sys.stderr)
+            return 2
+        print(f"{config['address']}  proxy: {config['proxy']}")
+        return 0
+    config = {"address": positional[0], "proxy": options["proxy"] or "direct"}
+    _save_config(config)
+    if options["json_output"]:
+        print(json.dumps(config, sort_keys=True))
+        return 0
+    print(f"Remembered {config['address']} (proxy: {config['proxy']}).")
+    print("Now: co remote-browser start")
+    if config["proxy"] == "shared":
+        print("Lend your connection first with: co proxy share")
+    return 0
+
+
 def handle_remote_browser(args) -> int:
     args = list(args or [])
     json_requested = "--json" in args
@@ -120,12 +183,24 @@ def handle_remote_browser(args) -> int:
     except ValueError as exc:
         return _print_invalid_argument(str(exc), json_output=json_requested)
 
-    if len(positional) < 2:
+    if positional[:1] == ["config"]:
+        return _config(positional[1:], options)
+
+    # The address is the only positional that can start with 0x, so its
+    # presence is decidable without knowing how many words the command takes.
+    if positional and positional[0].startswith("0x"):
+        address, *positional = positional
+    else:
+        address = configured_address()
+        if address is None:
+            print(NOT_CONFIGURED, file=sys.stderr)
+            return 2
+    if not positional:
         return _print_invalid_argument(
-            "co remote-browser <address> <command>",
+            "co remote-browser [<address>] <command>",
             json_output=options["json_output"],
         )
-    address, command, *rest = positional
+    command, *rest = positional
     if command not in {"start", "status", "sessions", "stop", "diagnose"}:
         return _print_invalid_argument(
             f"unknown Remote Browser command '{command}'",
@@ -135,9 +210,11 @@ def handle_remote_browser(args) -> int:
     if len(rest) != (1 if needs_session else 0):
         suffix = " <session-id>" if needs_session else ""
         return _print_invalid_argument(
-            f"co remote-browser <address> {command}{suffix}",
+            f"co remote-browser [<address>] {command}{suffix}",
             json_output=options["json_output"],
         )
+    if options["proxy"] is None:
+        options["proxy"] = load_config().get("proxy", "direct")
 
     from connectonion import connect
     from connectonion.network.connect import _this_callers_identity

--- a/connectonion/network/host/remote_browser.py
+++ b/connectonion/network/host/remote_browser.py
@@ -301,7 +301,7 @@ class RemoteBrowserService:
                     state={"fallback_applied": False},
                 )
             share_binding = self._share_binding(share_endpoint)
-        headless = args.get("headless", True)
+        headless = args.get("headless", False)
         if not isinstance(headless, bool):
             return _failure(
                 request_id, "start", "INVALID_ARGUMENT", "headless must be boolean."

--- a/docs/blog/2026-09-02-forty-two-characters-you-should-type-once.md
+++ b/docs/blog/2026-09-02-forty-two-characters-you-should-type-once.md
@@ -1,0 +1,66 @@
+# Forty-two characters you should type once
+
+The remote browser worked. Every command to drive it looked like this:
+
+```bash
+co proxy share to 0x3f9a7c2e1b8d4f6a9c0e2b5d7f1a3c8e6b4d2f0a
+co remote-browser 0x3f9a7c2e1b8d4f6a9c0e2b5d7f1a3c8e6b4d2f0a start --proxy shared
+co remote-browser 0x3f9a7c2e1b8d4f6a9c0e2b5d7f1a3c8e6b4d2f0a status rb_…
+```
+
+The address is forty-two characters. It is the same forty-two characters in
+every command, in every session, on every day, because the server you rent
+does not move. And yet each command asked for it again, plus the `--proxy`
+mode that also never changes, as if the tool had no memory between one line
+and the next.
+
+Aaron's review of the flow was one sentence: configure it once, and if it is
+not configured, say so.
+
+## Remember it, do not guess it
+
+```bash
+co remote-browser config 0x3f9a… --proxy shared   # once
+co remote-browser start                            # from now on
+co proxy share
+```
+
+`config` writes `~/.co/remote-browser.json`. Every command that used to take
+an address now reads it from there when none is given. An explicit address on
+the command line still wins, so a one-off against a second host needs no
+reconfiguration.
+
+The interesting rule is the failure. With nothing remembered and no address
+given, the command does not pick a host from the proxy registry, the last
+session, or anything else it could plausibly infer. It stops:
+
+```text
+No remote browser configured.
+Set one with: co remote-browser config <address> --proxy shared
+```
+
+A remote browser is someone's machine and someone's bill. A tool that guesses
+which one you meant is a tool that will one day start a session on the wrong
+one, and the operator will find out from the invoice. "I do not know, here is
+how to tell me" is the only honest answer.
+
+## Deciding whether an address is there
+
+The parser used to count positionals: two words meant `<address> <command>`.
+Making the address optional would have turned that into a table of every
+command and its arity. The address is the only token that can start with
+`0x`, so the parser looks at the first word instead of counting the rest. One
+check, no table.
+
+## The other default we got wrong
+
+While here: the remote session started headless by default. `co browser` on
+your own laptop opens a visible window, and the browser layer already knows
+to run headless on a Linux host with no display. The remote command now shares
+that default. A visible window is also what an anti-detect browser should
+look like when a window is possible; asking for `--headless` remains one
+flag.
+
+Measured: seven new CLI tests, all red before the change, all green after;
+the config path is redirected to a temporary directory so the suite never
+reads a developer's real `~/.co`.

--- a/docs/cli/proxy.md
+++ b/docs/cli/proxy.md
@@ -24,6 +24,9 @@ co remote-browser 0xHOST start --proxy shared
 
 `--proxy direct` (the default) keeps the host on its own connection.
 
+Every address above is optional once `co remote-browser config 0xHOST` has
+remembered one; `co proxy share`, `stop` and `diagnose` then use it.
+
 ## What gets shared, and what does not
 
 **Shared:** an outbound path to the public web, for destinations the policy

--- a/docs/network/remote-browser.md
+++ b/docs/network/remote-browser.md
@@ -16,6 +16,10 @@ co remote-browser 0xHOST stop    rb_0123456789abcdef0123456789abcdef
 That is the whole surface today. `start` is safe to retry: the same owner and
 request ID gets the same session back rather than a second one.
 
+The session opens a visible window by default, exactly like `co browser` on
+your own machine; a host with no display runs headless by itself. Pass
+`--headless` to ask for that explicitly.
+
 The address is 42 characters and never changes between calls, so remember it
 once and leave it out afterwards:
 

--- a/docs/network/remote-browser.md
+++ b/docs/network/remote-browser.md
@@ -16,6 +16,19 @@ co remote-browser 0xHOST stop    rb_0123456789abcdef0123456789abcdef
 That is the whole surface today. `start` is safe to retry: the same owner and
 request ID gets the same session back rather than a second one.
 
+The address is 42 characters and never changes between calls, so remember it
+once and leave it out afterwards:
+
+```bash
+co remote-browser config 0xHOST --proxy shared   # once
+co remote-browser start                           # from now on
+co remote-browser sessions
+```
+
+An explicit address still wins when you give one. With nothing remembered and
+no address on the command line, the command stops and tells you to run
+`config` — it never guesses a host.
+
 ## Reaching the internet through your own connection
 
 A browser on a server reaches the internet from a data-centre address. Lend it
@@ -30,6 +43,9 @@ browser on the host  ──▶  your computer  ──▶  the internet (your add
 co proxy share to 0xHOST                        # on your computer
 co remote-browser 0xHOST start --proxy shared   # then start the session
 ```
+
+Or, after `co remote-browser config 0xHOST --proxy shared`, the same two
+commands with nothing to type: `co proxy share` and `co remote-browser start`.
 
 Measured on a Google Cloud server egressing through a laptop in Sydney: the
 server's own address is `34.21.243.229`, and the site saw `129.94.43.159`.

--- a/tests/unit/test_cli_remote_browser.py
+++ b/tests/unit/test_cli_remote_browser.py
@@ -46,7 +46,7 @@ def _install(monkeypatch, result):
 def test_start_forwards_only_typed_start_options(monkeypatch, capsys):
     remote = _install(monkeypatch, _result())
 
-    assert handle_remote_browser(["--headed", "--timeout", "5", "0xhost", "start"]) == 0
+    assert handle_remote_browser(["--headless", "--timeout", "5", "0xhost", "start"]) == 0
 
     assert remote.calls == [
         (
@@ -54,7 +54,7 @@ def test_start_forwards_only_typed_start_options(monkeypatch, capsys):
             {
                 "session_id": None,
                 "timeout": 5.0,
-                "headless": False,
+                "headless": True,
                 "proxy": "direct",
             },
         )
@@ -245,3 +245,13 @@ def test_co_proxy_share_and_stop_default_to_the_remembered_address(monkeypatch, 
     capsys.readouterr()
     assert proxy_commands.handle_proxy(["stop"]) == 1
     assert "not sharing your connection with 0xhost" in capsys.readouterr().out
+
+
+def test_start_is_headed_by_default_like_co_browser(monkeypatch):
+    """A visible window is the local default and the anti-detect default; a
+    host without a display already falls back to headless on its own."""
+    remote = _install(monkeypatch, _result())
+
+    handle_remote_browser(["0xhost", "start"])
+
+    assert remote.calls[0][1]["headless"] is False

--- a/tests/unit/test_cli_remote_browser.py
+++ b/tests/unit/test_cli_remote_browser.py
@@ -136,3 +136,112 @@ def test_shared_start_passes_the_laptop_endpoint_once_at_runtime_creation(
     assert kwargs["proxy"] == "shared"
     assert kwargs["share"]["host"] == "192.0.2.10"
     assert kwargs["share"]["password"] == "secret"
+
+
+# --- `config`: remember the remote once, then leave the address out (#1366) ---
+
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _config_in_tmp(monkeypatch, tmp_path):
+    from connectonion.cli.commands import remote_browser_commands as mod
+
+    monkeypatch.setattr(mod, "CONFIG_PATH", tmp_path / "remote-browser.json")
+
+
+def _install_capturing_address(monkeypatch, result):
+    remote = FakeRemote(result)
+    seen = []
+
+    def connect(address, **kwargs):
+        seen.append(address)
+        return remote
+
+    monkeypatch.setattr("connectonion.connect", connect)
+    connect_module = importlib.import_module("connectonion.network.connect")
+    monkeypatch.setattr(
+        connect_module, "_this_callers_identity", lambda: {"address": "0xme"}
+    )
+    return remote, seen
+
+
+def test_config_remembers_address_and_proxy_then_start_needs_neither(monkeypatch, capsys):
+    remote, seen = _install_capturing_address(monkeypatch, _result())
+
+    assert handle_remote_browser(["config", "0xhost", "--proxy", "direct"]) == 0
+    assert "Now: co remote-browser start" in capsys.readouterr().out
+
+    assert handle_remote_browser(["start"]) == 0
+
+    assert seen == ["0xhost"]
+    assert remote.calls[0][1]["proxy"] == "direct"
+
+
+def test_config_shows_what_is_remembered(capsys):
+    handle_remote_browser(["config", "0xhost", "--proxy", "shared"])
+    capsys.readouterr()
+
+    assert handle_remote_browser(["config"]) == 0
+    assert capsys.readouterr().out.strip() == "0xhost  proxy: shared"
+
+    assert handle_remote_browser(["--json", "config"]) == 0
+    assert json.loads(capsys.readouterr().out) == {"address": "0xhost", "proxy": "shared"}
+
+
+def test_config_rejects_unknown_proxy_mode(capsys):
+    assert handle_remote_browser(["config", "0xhost", "--proxy", "tor"]) == 2
+    assert "--proxy must be one of direct, shared" in capsys.readouterr().err
+
+
+def test_without_config_and_without_address_it_says_how_to_configure(monkeypatch, capsys):
+    _install(monkeypatch, _result())
+
+    assert handle_remote_browser(["start"]) == 2
+
+    err = capsys.readouterr().err
+    assert "No remote browser configured." in err
+    assert "co remote-browser config <address> --proxy shared" in err
+
+
+def test_explicit_address_beats_the_remembered_one(monkeypatch):
+    remote, seen = _install_capturing_address(monkeypatch, _result())
+    handle_remote_browser(["config", "0xremembered"])
+
+    assert handle_remote_browser(["0xexplicit", "sessions"]) == 0
+
+    assert seen == ["0xexplicit"]
+
+
+def test_explicit_proxy_flag_beats_the_remembered_mode(monkeypatch):
+    remote, _ = _install_capturing_address(monkeypatch, _result())
+    handle_remote_browser(["config", "0xhost", "--proxy", "direct"])
+
+    handle_remote_browser(["--proxy", "direct", "start"])
+    handle_remote_browser(["config", "0xhost", "--proxy", "shared"])
+    handle_remote_browser(["--proxy", "direct", "start"])
+
+    assert [call[1]["proxy"] for call in remote.calls] == ["direct", "direct"]
+
+
+def test_co_proxy_share_and_stop_default_to_the_remembered_address(monkeypatch, capsys, tmp_path):
+    from connectonion.cli.commands import proxy_commands
+
+    monkeypatch.setattr(proxy_commands, "STATE_PATH", tmp_path / "proxy-shares.json")
+    shared_with = []
+    monkeypatch.setattr(
+        proxy_commands, "_share", lambda address, *a: shared_with.append(address) or 0
+    )
+
+    assert proxy_commands.handle_proxy(["share"]) == 2
+    assert "No remote browser configured." in capsys.readouterr().err
+
+    handle_remote_browser(["config", "0xhost", "--proxy", "shared"])
+    assert proxy_commands.handle_proxy(["share"]) == 0
+    assert proxy_commands.handle_proxy(["share", "to", "0xother"]) == 0
+    assert shared_with == ["0xhost", "0xother"]
+
+    capsys.readouterr()
+    assert proxy_commands.handle_proxy(["stop"]) == 1
+    assert "not sharing your connection with 0xhost" in capsys.readouterr().out


### PR DESCRIPTION
- **Proposed target version:** 1.8.0b1
- **Estimated release window:** next beta

## Outcome

Remember one default Remote Browser Agent address and proxy mode so users do not repeat the 42-character address on every `co remote-browser` / `co proxy` command.

Closes #1366 only after this stacked PR is rebased, fully green and merged.

## Labels and target release

- Labels: `feature`, `browser`
- Proposed target: ConnectOnion `1.8.0a5` Browser Preview
- **Proposed target version:** `1.8.0a5` / next 1.8 alpha
- **Estimated release window:** September 2026, after #1362 merges, this stack is rebased/split, and the full matrix passes
- Milestone: `1.8.0 — remote browser sessions and async execution`
- This is additive CLI ergonomics. It does not change WTF Browser billing, proxy authorization or fallback policy.

## Behavior

```bash
co remote-browser config 0xHOST --proxy shared
co remote-browser config

co remote-browser start
co proxy share
```

An explicit address or `--proxy` wins. With no configured address, the command exits 2 and prints the exact config command; it never guesses.

## Tests/docs

- seven focused tests cover remember/start, show, invalid mode, missing config, explicit address precedence, explicit proxy precedence and `co proxy share/stop` defaults;
- tests redirect config storage to `tmp_path` and do not read the operator's `~/.co`;
- docs update `docs/network/remote-browser.md` and `docs/cli/proxy.md`.

## Current stacked state — 2026-09-02

- Config feature commit: `e8680c22b74a761611758522499075d69c5d33d9`.
- Current head: `6cc2047848517520c080c3d739e1ed75bb0ff2ef`.
- This PR is stacked on #1362 and currently includes all of #1362's commits/files.
- It has been restored to Draft; it must not merge before #1362.
- The new head also changes Remote Browser's default from headless to headed and claims a host with no display falls back automatically. That behavior is not part of #1366 and intersects #1339's existing silent-headless-fallback problem.
- A fresh GitHub matrix is running; state remains `UNSTABLE` until required checks complete.

## Required before Ready/Merge

- [ ] #1362 restores a green lockfile gate, completes two-machine acceptance and merges.
- [ ] Rebase this branch so the final config diff contains only `e8680c22…`, or split/justify `6cc20478…` under a separate approved issue.
- [ ] Regenerate/verify the exact lock and pass the complete required matrix.
- [ ] Verify the installed wheel and CLI help/error/JSON output.
- [ ] If headed-default remains, verify truthful behavior on macOS/Linux with and without DISPLAY and resolve its relationship with #1339; no silent fallback claim.
- [ ] Mark Ready only after the final non-stacked diff is reviewed.

Do not merge the current stacked head.