### PR TITLE
feat(proxy): the laptop dials out — cross-network Laptop Proxy transport

### DIFF
--- a/connectonion/cli/commands/proxy_commands.py
+++ b/connectonion/cli/commands/proxy_commands.py
@@ -6,8 +6,10 @@ point of the Remote Browser product:
 
     browser on the host  ──▶  this machine  ──▶  the internet (your IP)
 
-Every command here ends by naming the next one, because the caller is usually
-an agent whose entire world is what it types and what comes back.
+This machine dials the host and stays attached; nothing listens here, so it
+works from behind any NAT. Every command ends by naming the next one, because
+the caller is usually an agent whose entire world is what it types and what
+comes back.
 """
 
 from __future__ import annotations
@@ -35,8 +37,7 @@ USAGE = """co proxy — share this computer's internet connection.
 
 Options:
   --json          emit the complete stable JSON envelope
-  --ttl SEC       stop sharing automatically after this long
-  --bind HOST     address to listen on (default: the one a peer reaches)
+  --ttl SEC       stop sharing automatically after this long (default: 24h)
 
 Start with: co proxy share to 0xHOST"""
 
@@ -76,20 +77,50 @@ def _emit(envelope: dict, as_json: bool) -> int:
     return 0 if envelope["ok"] else 1
 
 
-def _share(address: str, as_json: bool, bind: str | None, ttl: int | None) -> int:
-    """Serve the share until the operator stops it.
+def _share(address: str, as_json: bool, ttl: int | None) -> int:
+    """Stay attached to the host until the operator stops it.
 
-    This command holds the process open on purpose. A share is a listening
-    socket owned by this process: returning after printing "sharing" would
+    This command holds the process open on purpose. The share is a socket this
+    process dialled to the host: returning after printing "sharing" would
     close it the moment the shell got its prompt back, so the command would
-    report success and leave nothing running. Background it with `&` or a
+    report success and leave nothing attached. Background it with `&` or a
     supervisor if you want the shell back; `--ttl` stops it on a timer.
     """
-    from ...network.proxy_egress import ProxyEgressService
+    from ...network.connect import _this_callers_identity
+    from ...network.proxy_egress import DEFAULT_TTL, ProxyShare, ProxyShareRefused
+
+    keys = _this_callers_identity()
+    if keys is None:
+        print("This computer has no identity to sign the grant with.", file=sys.stderr)
+        print("Create one with: co init", file=sys.stderr)
+        return 2
+    ttl = ttl or DEFAULT_TTL
+
+    def record(state: str, detail: str) -> None:
+        """Every transition lands in the registry, so status/diagnose read
+        what the share is doing rather than what it once printed."""
+        if state == "error":
+            print(f"  {detail}", file=sys.stderr, flush=True)
+            return
+        current = _load()
+        if address in current:
+            current[address].update(state=state, detail=detail, since=int(time.time()))
+            _save(current)
+        if as_json:
+            print(json.dumps({"ok": True, "command": "share", "state": state, "detail": detail}), flush=True)
+        elif state == "attached":
+            print(
+                f"Attached to {address}. Traffic that agent's browser sends now "
+                "leaves from your address. Serving until you stop it.",
+                flush=True,
+            )
+            print("  Check it is being used with: co proxy status", flush=True)
+            print(f"  Stop lending with: co proxy stop {address}", flush=True)
+        elif state == "reconnecting":
+            print(f"Connection to {address} dropped: {detail}", flush=True)
 
     async def run() -> int:
-        service = ProxyEgressService(bind_host=bind)
-        endpoint = await service.start()
+        share = ProxyShare(address, keys=keys, ttl=ttl, on_state=record)
         stop = asyncio.Event()
         control_token = secrets.token_urlsafe(32)
 
@@ -113,51 +144,48 @@ def _share(address: str, as_json: bool, bind: str | None, ttl: int | None) -> in
         control_host, control_port = controller.sockets[0].getsockname()[:2]
         state = _load()
         state[address] = {
-            "url": endpoint.url,
-            "host": endpoint.host,
-            "port": endpoint.port,
-            "username": endpoint.username,
-            "password": endpoint.password,
-            "ttl": ttl,
+            "state": "connecting",
+            "detail": "",
+            "since": int(time.time()),
+            "expires_at": int(share.expires_at),
+            "pid": os.getpid(),
             "control_host": control_host,
             "control_port": control_port,
             "control_token": control_token,
         }
         _save(state)
-        _emit(
-            {
-                "ok": True,
-                "command": "share",
-                "summary": (
-                    f"Sharing this computer's connection with {address} at "
-                    f"{endpoint.url}. Traffic that agent's browser sends now "
-                    "leaves from your address. Serving until you stop it."
-                ),
-                "result": {"address": address, "url": endpoint.url},
-                "next_actions": [
-                    "Check it is being used with: co proxy status",
-                    f"Stop lending with: co proxy stop {address}",
-                ],
-            },
-            as_json,
-        )
         # A supervisor stops this with SIGTERM, not Ctrl-C, and a share that
         # outlives its process in the registry is a share every later command
-        # reports as live while nothing listens.
+        # reports as live while nothing is attached.
         loop = asyncio.get_running_loop()
         for signal_name in ("SIGTERM", "SIGINT"):
             number = getattr(signal, signal_name, None)
             if number is not None:
                 with contextlib.suppress(NotImplementedError):
                     loop.add_signal_handler(number, stop.set)
+        serving = asyncio.create_task(share.serve(stop))
         try:
-            await asyncio.wait_for(stop.wait(), timeout=ttl or None)
-        except (asyncio.TimeoutError, KeyboardInterrupt, asyncio.CancelledError):
-            pass
+            await asyncio.wait_for(asyncio.shield(serving), timeout=ttl)
+        except asyncio.TimeoutError:
+            stop.set()
+            await serving
+        except ProxyShareRefused as refused:
+            return _emit(
+                {
+                    "ok": False,
+                    "code": "SHARE_REFUSED",
+                    "command": "share",
+                    "summary": f"{address} refused this computer's share: {refused}",
+                    "next_actions": [
+                        f"Check the host can be reached with: co remote-browser {address} sessions",
+                        "Ask the host's admin to make this computer a contact.",
+                    ],
+                },
+                as_json,
+            )
         finally:
             controller.close()
             await controller.wait_closed()
-            await service.stop()
             remaining = _load()
             remaining.pop(address, None)
             _save(remaining)
@@ -169,6 +197,50 @@ def _share(address: str, as_json: bool, bind: str | None, ttl: int | None) -> in
         print(f"Stopped sharing with {address}.")
         print("  Lend it again with: co proxy share to " + address)
         return 0
+
+
+def _alive(share: dict) -> bool:
+    """Is the process behind this registry entry still there?
+
+    The control socket answers REFUSED to anything but its own stop token,
+    which is exactly the proof needed: something is listening, and it is not
+    being stopped by the question.
+    """
+
+    async def probe() -> bool:
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(share["control_host"], int(share["control_port"])),
+                timeout=2,
+            )
+        except (KeyError, TypeError, ValueError, OSError, asyncio.TimeoutError):
+            return False
+        writer.write(b"probe\n")
+        await writer.drain()
+        reply = await asyncio.wait_for(reader.readline(), timeout=2)
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+        return reply == b"REFUSED\n"
+
+    return asyncio.run(probe())
+
+
+def _row(address: str, share: dict) -> dict:
+    return {
+        "address": address,
+        "state": share.get("state", "unknown"),
+        "detail": share.get("detail", ""),
+        "alive": _alive(share),
+    }
+
+
+def _describe(row: dict) -> str:
+    if not row["alive"]:
+        return f"{row['address']}: recorded but its process is gone"
+    if row["state"] == "attached":
+        return f"{row['address']}: attached"
+    return f"{row['address']}: {row['state']} ({row['detail'] or 'no detail'})"
 
 
 def _status(as_json: bool) -> int:
@@ -184,13 +256,14 @@ def _status(as_json: bool) -> int:
             },
             as_json,
         )
+    rows = [_row(a, s) for a, s in state.items()]
     return _emit(
         {
             "ok": True,
             "command": "status",
             "summary": f"Sharing with {len(state)} agent(s): "
-            + ", ".join(f"{a} at {s['url']}" for a, s in state.items()),
-            "result": {"shares": [{"address": a, **{"url": s["url"]}} for a, s in state.items()]},
+            + "; ".join(_describe(row) for row in rows),
+            "result": {"shares": rows},
             "next_actions": [
                 f"Stop lending with: co proxy stop {next(iter(state))}",
                 f"Investigate one with: co proxy diagnose {next(iter(state))}",
@@ -275,10 +348,7 @@ def _stop(address: str, as_json: bool) -> int:
 
 
 def _diagnose(address: str, as_json: bool) -> int:
-    from ...network.proxy_egress import local_egress_address
-
-    state = _load()
-    share = state.get(address)
+    share = _load().get(address)
     if share is None:
         return _emit(
             {
@@ -290,25 +360,45 @@ def _diagnose(address: str, as_json: bool) -> int:
             },
             as_json,
         )
-    reachable = local_egress_address()
-    bound = share["url"].split("//", 1)[1].split(":")[0]
+    row = _row(address, share)
+    if not row["alive"]:
+        return _emit(
+            {
+                "ok": False,
+                "code": "SHARE_PROCESS_GONE",
+                "command": "diagnose",
+                "summary": f"The share for {address} is recorded but nothing is serving it.",
+                "result": row,
+                "next_actions": [f"Start it again with: co proxy share to {address}"],
+            },
+            as_json,
+        )
+    if row["state"] != "attached":
+        return _emit(
+            {
+                "ok": False,
+                "code": "SHARE_NOT_ATTACHED",
+                "command": "diagnose",
+                "summary": (
+                    f"The share for {address} is {row['state']}: {row['detail'] or 'no detail'}. "
+                    "It keeps retrying; the host has to be reachable directly, not through the relay."
+                ),
+                "result": row,
+                "next_actions": [
+                    f"Check the host answers with: co remote-browser {address} sessions",
+                    f"Stop lending with: co proxy stop {address}",
+                ],
+            },
+            as_json,
+        )
     return _emit(
         {
             "ok": True,
             "command": "diagnose",
-            "summary": (
-                f"Share for {address} listens on {share['url']}; a peer reaches this "
-                f"machine at {reachable}."
-                + (
-                    ""
-                    if bound == reachable
-                    else "  The bound address differs, so a remote agent may not "
-                    "reach it — rebind with --bind."
-                )
-            ),
-            "result": {"url": share["url"], "reachable_address": reachable},
+            "summary": f"The share for {address} is attached and serving.",
+            "result": row,
             "next_actions": [
-                f"Rebind with: co proxy share to {address} --bind {reachable}",
+                "Use it with: co remote-browser start --proxy shared",
                 f"Stop lending with: co proxy stop {address}",
             ],
         },
@@ -321,21 +411,15 @@ def handle_proxy(args) -> int:
     as_json = "--json" in args
     args = [a for a in args if a != "--json"]
 
-    bind = None
     ttl = None
-    for flag, setter in (("--bind", "bind"), ("--ttl", "ttl")):
-        if flag in args:
-            index = args.index(flag)
-            if index + 1 >= len(args):
-                print(f"{flag} needs a value.", file=sys.stderr)
-                print("Start with: co proxy share to 0xHOST", file=sys.stderr)
-                return 2
-            value = args[index + 2 - 1]
-            if setter == "bind":
-                bind = value
-            else:
-                ttl = int(value)
-            del args[index : index + 2]
+    if "--ttl" in args:
+        index = args.index("--ttl")
+        if index + 1 >= len(args):
+            print("--ttl needs a value.", file=sys.stderr)
+            print("Start with: co proxy share to 0xHOST", file=sys.stderr)
+            return 2
+        ttl = int(args[index + 1])
+        del args[index : index + 2]
 
     if not args:
         print(USAGE)
@@ -360,9 +444,5 @@ def handle_proxy(args) -> int:
         print(NOT_CONFIGURED, file=sys.stderr)
         return 2
     if verb == "share":
-        return _share(target, as_json, bind, ttl)
+        return _share(target, as_json, ttl)
     return (_stop if verb == "stop" else _diagnose)(target, as_json)
-
-    print(f"Unknown command: co proxy {verb}", file=sys.stderr)
-    print(USAGE, file=sys.stderr)
-    return 2

--- a/connectonion/cli/commands/remote_browser_commands.py
+++ b/connectonion/cli/commands/remote_browser_commands.py
@@ -225,25 +225,13 @@ def handle_remote_browser(args) -> int:
         connect_kwargs["relay_url"] = options["relay_url"]
     command_args = {}
     if command == "start":
+        # `shared` names no endpoint: the host uses the share this same
+        # identity attached with `co proxy share`, and says so
+        # (REMOTE_SESSION_PROXY_NOT_ATTACHED) when there is none.
         command_args = {
             "headless": options["headless"],
             "proxy": options["proxy"],
         }
-        if options["proxy"] == "shared":
-            # Only this machine knows where its own connection is reachable, so
-            # the share endpoint travels with the request rather than being
-            # something the host could guess.
-            from .proxy_commands import _load
-
-            share = _load().get(address)
-            if share is None:
-                print(
-                    f"You are not sharing your connection with {address}.",
-                    file=sys.stderr,
-                )
-                print(f"Lend it with: co proxy share to {address}", file=sys.stderr)
-                return 2
-            command_args["share"] = share
     try:
         result = connect(address, **connect_kwargs).remote_browser(
             command,

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -330,7 +330,7 @@ def browser(
 )
 def remote_browser(
     args: List[str] = typer.Argument(
-        None, help="[options] <address> <start|status|sessions|stop|diagnose>"
+        None, help="config <address> [--proxy shared] | [<address>] <start|status|sessions|stop|diagnose>"
     ),
 ):
     """Manage an owner-bound browser session on a remote agent over OIP."""

--- a/connectonion/network/host/egress_gateway.py
+++ b/connectonion/network/host/egress_gateway.py
@@ -513,12 +513,7 @@ class EgressGateway:
             raise GatewayRefusal(INVALID) from None
         if not host or isinstance(port, bool) or not 1 <= port <= 65535:
             raise GatewayRefusal(INVALID)
-        bracketed = f"[{host}]" if ":" in host else host
-        try:
-            authority = normalize_web_destination(f"https://{bracketed}:{port}")
-            endpoints = await self._approved_endpoints(authority)
-        except DestinationPolicyError as refusal:
-            raise GatewayRefusal(refusal.code) from refusal
+        endpoints = await self.resolve_destination(host, port)
         body = ("\n".join(endpoint.address for endpoint in endpoints) + "\n").encode(
             "ascii"
         )
@@ -530,6 +525,41 @@ class EgressGateway:
             + body
         )
         await self._drain(writer)
+
+    async def resolve_destination(
+        self, host: str, port: int
+    ) -> tuple[NumericEndpoint, ...]:
+        """This gateway's destination policy applied to one name, no socket.
+
+        The laptop end of a share answers the browser host's `resolve` with
+        this: the same resolver, the same bounds, the same frozen classifier
+        that decides what its own listener would connect to.
+        """
+        bracketed = f"[{host}]" if ":" in host else host
+        try:
+            authority = normalize_web_destination(f"https://{bracketed}:{port}")
+            return await self._approved_endpoints(authority)
+        except DestinationPolicyError as refusal:
+            raise GatewayRefusal(refusal.code) from refusal
+
+    async def connect_destination(
+        self, address: str, port: int
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        """Classify one numeric address again, then dial it.
+
+        A share connects only what it has just approved itself; the peer's
+        earlier resolve answer is not a decision it gets to keep.
+        """
+        bracketed = f"[{address}]" if ":" in address else address
+        try:
+            authority = normalize_web_destination(
+                f"https://{bracketed}:{port}/", allowed_ports=self.allowed_ports
+            )
+        except DestinationPolicyError as refusal:
+            raise GatewayRefusal(refusal.code) from refusal
+        if authority.literal is None:
+            raise GatewayRefusal(INVALID)
+        return await self._connect(await self._approved_endpoints(authority))
 
     async def _read_request(self, reader: asyncio.StreamReader) -> ProxyRequest:
         refusal_code = None

--- a/connectonion/network/host/proxy_channel.py
+++ b/connectonion/network/host/proxy_channel.py
@@ -1,0 +1,255 @@
+"""A laptop's attached share, seen from the browser host.
+
+The laptop is behind NAT, so it dials the host and stays on the socket. This
+module is what the host keeps for that socket: a `ProxyChannel` that turns the
+gateway's resolver/dialer calls into PROXY_STREAM frames going down to the
+laptop, and a registry keyed by the laptop's address so a `start` request from
+that same identity can find its own exit.
+
+The host-private browser gateway is unchanged. It still speaks CORESOLVE and
+numeric CONNECT to a "share endpoint"; that endpoint is now a second gateway on
+loopback in the host process whose last hop is this channel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import ipaddress
+import time
+from datetime import datetime
+
+from ..proxy import stream as wire
+from ..proxy_egress import ShareEndpoint
+from .egress_gateway import EgressGateway, NumericEndpoint
+
+
+class _Stream:
+    def __init__(self, stream_id: int):
+        self.id = stream_id
+        self.reader = asyncio.StreamReader()
+        self.reply: asyncio.Future = asyncio.get_running_loop().create_future()
+        self.closing = False
+        self.pending = b""
+        self.shutdown: asyncio.Task | None = None
+
+
+class _ChannelWriter:
+    """The StreamWriter half the gateway sees; bytes become data frames."""
+
+    def __init__(self, channel: "ProxyChannel", stream: _Stream):
+        self._channel = channel
+        self._stream = stream
+
+    def write(self, data: bytes) -> None:
+        if not self._stream.closing:
+            self._stream.pending += data
+
+    async def drain(self) -> None:
+        await self._channel._flush(self._stream)
+
+    def can_write_eof(self) -> bool:
+        return True
+
+    def write_eof(self) -> None:
+        self._later("eof")
+
+    def is_closing(self) -> bool:
+        return self._stream.closing
+
+    def close(self) -> None:
+        if self._stream.closing:
+            return
+        self._stream.closing = True
+        self._later("close")
+
+    async def wait_closed(self) -> None:
+        if self._stream.shutdown is not None:
+            await self._stream.shutdown
+
+    def _later(self, op: str) -> None:
+        # write_eof/close are synchronous on a StreamWriter; the frame goes out
+        # on a task, after whatever is still buffered. The task is kept so
+        # wait_closed() can await the close frame actually leaving.
+        self._stream.shutdown = asyncio.create_task(
+            self._channel._flush_then(self._stream, op)
+        )
+
+
+class ProxyChannel:
+    """One attached laptop: resolve and dial through it, receive its frames."""
+
+    def __init__(self, send, claims: dict, *, clock=time.time):
+        self._send = send
+        self.claims = claims
+        self.owner = claims["grantor"]
+        self._expires_at = datetime.fromisoformat(
+            claims["expires_at"].replace("Z", "+00:00")
+        ).timestamp()
+        self._max_bytes = claims["max_bytes"]
+        self._clock = clock
+        self.bytes_used = 0
+        self._streams: dict[int, _Stream] = {}
+        self._next_id = 1
+        self._send_lock = asyncio.Lock()
+        self.closed = False
+        self.gateway = EgressGateway(
+            resolver=self.resolve,
+            dialer=self.dial,
+            username="connectonion-proxy",
+            allow_remote_resolution=True,
+        )
+
+    @property
+    def endpoint(self) -> ShareEndpoint:
+        """Where the host's browser gateway reaches this laptop: loopback."""
+        inner = self.gateway.endpoint
+        return ShareEndpoint(inner.host, inner.port, inner.username, inner.password)
+
+    # ---- the Resolver and Dialer the gateway calls ----
+
+    async def resolve(self, host: str, port: int):
+        stream = self._open("resolve")
+        await self._send_stream(stream, "resolve", host=host, port=port)
+        reply = await self._answer(stream)
+        self._forget(stream)
+        addresses = reply.get("addresses")
+        if not isinstance(addresses, list) or not addresses:
+            raise OSError("share returned no DNS answers")
+        # Canonicalize before the gateway's own classifier sees the answer.
+        return tuple(str(ipaddress.ip_address(value)) for value in addresses)
+
+    async def dial(self, endpoint: NumericEndpoint, timeout: float):
+        stream = self._open("connect")
+        await self._send_stream(
+            stream, "connect", address=endpoint.address, port=endpoint.port
+        )
+        await self._answer(stream)
+        return stream.reader, _ChannelWriter(self, stream)
+
+    # ---- frames coming up from the laptop ----
+
+    async def receive(self, frame: dict) -> None:
+        stream_id = wire.stream_id_of(frame)
+        op = frame["op"]
+        stream = self._streams.get(stream_id)
+        if stream is None:
+            if op != "close":
+                await self._send(wire.stream_frame(stream_id, "close"))
+            return
+        if op in {"resolve", "connect"}:
+            self._settle(stream, frame)
+        elif op == "error":
+            self._settle(stream, frame)
+            self._forget(stream)
+        elif op == "data":
+            payload = wire.decode_data(frame)
+            self._spend(len(payload))
+            stream.reader.feed_data(payload)
+        elif op == "eof":
+            stream.reader.feed_eof()
+        else:
+            stream.reader.feed_eof()
+            self._forget(stream)
+
+    async def close(self) -> None:
+        """The socket is gone: every stream on it is too."""
+        self.closed = True
+        for stream in list(self._streams.values()):
+            stream.reader.feed_eof()
+            self._settle(stream, wire.stream_frame(stream.id, "error", code="PROXY_DETACHED"))
+        self._streams.clear()
+        await self.gateway.stop()
+
+    # ---- internals ----
+
+    def _open(self, purpose: str) -> _Stream:
+        if self.closed:
+            raise OSError("share is detached")
+        if self._clock() >= self._expires_at:
+            raise OSError("share grant expired")
+        if self._max_bytes is not None and self.bytes_used >= self._max_bytes:
+            raise OSError("share byte budget spent")
+        if len(self._streams) >= wire.MAX_STREAMS:
+            raise OSError(f"share has {wire.MAX_STREAMS} streams open")
+        stream = _Stream(self._next_id)
+        self._next_id += 1
+        self._streams[stream.id] = stream
+        return stream
+
+    async def _answer(self, stream: _Stream) -> dict:
+        try:
+            reply = await stream.reply
+        except BaseException:
+            self._forget(stream)
+            raise
+        if reply["op"] == "error":
+            raise OSError(f"share refused: {reply.get('code', 'PROXY_REFUSED')}")
+        return reply
+
+    def _settle(self, stream: _Stream, frame: dict) -> None:
+        if not stream.reply.done():
+            stream.reply.set_result(frame)
+
+    def _forget(self, stream: _Stream) -> None:
+        stream.closing = True
+        self._streams.pop(stream.id, None)
+
+    def _spend(self, count: int) -> None:
+        self.bytes_used += count
+        if self._max_bytes is not None and self.bytes_used > self._max_bytes:
+            raise OSError("share byte budget spent")
+
+    async def _send_stream(self, stream: _Stream, op: str, **fields) -> None:
+        if self.closed:
+            raise OSError("share is detached")
+        # One lock for the whole channel: frames of one stream leave in the
+        # order they were written, and no two coroutines interleave a send.
+        async with self._send_lock:
+            await self._send(wire.stream_frame(stream.id, op, **fields))
+
+    async def _flush(self, stream: _Stream) -> None:
+        while stream.pending:
+            chunk, stream.pending = (
+                stream.pending[: wire.CHUNK_BYTES],
+                stream.pending[wire.CHUNK_BYTES :],
+            )
+            self._spend(len(chunk))
+            async with self._send_lock:
+                await self._send(wire.data_frame(stream.id, chunk))
+
+    async def _flush_then(self, stream: _Stream, op: str) -> None:
+        with contextlib.suppress(OSError):
+            await self._flush(stream)
+            if stream.id in self._streams or op == "close":
+                await self._send_stream(stream, op)
+        if op == "close":
+            self._forget(stream)
+
+
+class ProxyChannelRegistry:
+    """Attached channels by the laptop address that attached them.
+
+    Read from `RemoteBrowserService.handle`, which runs on a worker thread,
+    so lookups are plain dict reads and every mutation happens on the loop.
+    """
+
+    def __init__(self):
+        self._channels: dict[str, ProxyChannel] = {}
+
+    def attach(self, channel: ProxyChannel) -> ProxyChannel | None:
+        """Register; returns the channel this one displaces, if any."""
+        displaced = self._channels.get(channel.owner)
+        self._channels[channel.owner] = channel
+        return displaced
+
+    def detach(self, channel: ProxyChannel) -> None:
+        if self._channels.get(channel.owner) is channel:
+            del self._channels[channel.owner]
+
+    def get(self, address: str) -> ProxyChannel | None:
+        return self._channels.get(address)
+
+    def endpoint_for(self, address: str) -> ShareEndpoint | None:
+        channel = self._channels.get(address)
+        return None if channel is None else channel.endpoint

--- a/connectonion/network/host/remote_browser.py
+++ b/connectonion/network/host/remote_browser.py
@@ -20,7 +20,8 @@ import time
 import uuid
 from pathlib import Path
 from typing import Callable
-from urllib.parse import urlsplit
+
+from .proxy_channel import ProxyChannelRegistry
 
 SCHEMA_VERSION = "1"
 REQUEST_ID = re.compile(r"[\x21-\x7e]{1,128}")
@@ -97,35 +98,11 @@ class RemoteBrowserService:
             def daemon_request(line, **identity):
                 return request_target_as(self.daemon_target, line, **identity)
         self.daemon_request = daemon_request
-
-    @staticmethod
-    def _share_endpoint(share: dict):
-        """Return one validated Laptop Proxy endpoint without retaining its URL."""
-        from ..proxy_egress import ShareEndpoint
-        from .private_browser_runtime import _canonical_share_endpoint
-
-        value = dict(share)
-        if "host" not in value or "port" not in value:
-            try:
-                parsed = urlsplit(value.pop("url"))
-                if (
-                    parsed.scheme != "http"
-                    or parsed.hostname is None
-                    or parsed.username is not None
-                    or parsed.password is not None
-                    or parsed.path not in {"", "/"}
-                    or parsed.query
-                    or parsed.fragment
-                ):
-                    raise ValueError
-                value["host"] = parsed.hostname
-                value["port"] = parsed.port
-            except (KeyError, TypeError, ValueError):
-                raise ValueError("shared proxy endpoint is invalid") from None
-        endpoint = _canonical_share_endpoint(value)
-        return ShareEndpoint(
-            endpoint.host, endpoint.port, endpoint.username, endpoint.password
-        )
+        # Laptops that are lending this host their connection right now,
+        # keyed by their address. The WS session that carried PROXY_ATTACH
+        # registers and, in its finally, detaches; `start` with
+        # `proxy: shared` only reads it.
+        self.proxy_channels = ProxyChannelRegistry()
 
     @staticmethod
     def _share_binding(endpoint) -> str:
@@ -274,31 +251,27 @@ class RemoteBrowserService:
             )
         # `shared` sends this session's egress out through the caller's machine,
         # so pages see the caller's address rather than this host's. The caller
-        # must already be lending it (`co proxy share to <this host>`); the
-        # share endpoint arrives with the request because only the caller knows
-        # where its own connection is reachable.
-        share = args.get("share") if proxy_mode == "shared" else None
-        if proxy_mode == "shared" and not isinstance(share, dict):
-            return _failure(
-                request_id,
-                "start",
-                "REMOTE_SESSION_SHARE_MISSING",
-                "Shared egress needs the caller's share endpoint. "
-                "Run `co proxy share to <this host>` and retry.",
-                state={"fallback_applied": False},
-            )
+        # lends it by staying attached (`co proxy share`); the exit is the
+        # channel that same identity attached, never one this host guessed.
         share_endpoint = None
         share_binding = None
         if proxy_mode == "shared":
-            try:
-                share_endpoint = self._share_endpoint(share)
-            except ValueError as exc:
+            share_endpoint = self.proxy_channels.endpoint_for(owner)
+            if share_endpoint is None:
                 return _failure(
                     request_id,
                     "start",
-                    "REMOTE_SESSION_SHARE_INVALID",
-                    str(exc),
+                    "REMOTE_SESSION_PROXY_NOT_ATTACHED",
+                    "Shared egress needs your computer attached to this host. "
+                    "On your computer run: co proxy share",
                     state={"fallback_applied": False},
+                    next_actions=[
+                        {
+                            "id": "attach_share",
+                            "command": "co proxy share",
+                            "requires_user_approval": False,
+                        }
+                    ],
                 )
             share_binding = self._share_binding(share_endpoint)
         headless = args.get("headless", False)

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -405,6 +405,11 @@ def _create_route_handlers(
         "ws_input": handle_ws_input,
         "ws_exec": handle_ws_exec,
         "remote_browser": handle_remote_browser,
+        # Laptops currently lending this host their connection (PROXY_ATTACH).
+        "proxy_channels": (
+            None if remote_browser_service is None
+            else remote_browser_service.proxy_channels
+        ),
         "prepare_provider_workroom_turn": handle_prepare_provider_workroom_turn,
         "admin_logs": handle_admin_logs,
         "admin_sessions": admin_sessions_handler,

--- a/connectonion/network/host/ws_router/proxy.py
+++ b/connectonion/network/host/ws_router/proxy.py
@@ -1,0 +1,72 @@
+"""PROXY_ATTACH and PROXY_STREAM: a laptop lending its connection to this host."""
+
+from datetime import datetime, timezone
+
+from ...proxy import GrantError, verify
+from ...proxy import stream as wire
+from ..proxy_channel import ProxyChannel
+
+ATTACH_REQUIRES = ("admin", "whitelist", "contact")
+
+
+def _attach_claims(data, conn, route_handlers) -> dict:
+    """The verified grant claims, or GrantError saying why not.
+
+    Same trust bar as REMOTE_BROWSER: a contact or admin, on a direct socket.
+    """
+    if not conn["authenticated"] or not conn["signed_commands"]:
+        raise GrantError("authenticate first (send a signed CONNECT)")
+    if conn["transport"] != "direct":
+        raise GrantError("a share attaches over a direct connection, not the relay")
+    if route_handlers.get("proxy_channels") is None:
+        raise GrantError("Remote Browser is not configured on this host")
+    trust = route_handlers["trust_agent"]
+    address = conn["agent_address"]
+    level = "admin" if trust.is_admin(address) else trust.get_level(address)
+    if level not in ATTACH_REQUIRES:
+        raise GrantError(f"sharing a connection requires a contact or admin; the caller is {level}")
+    grant = data.get("grant")
+    if not isinstance(grant, dict):
+        raise GrantError("PROXY_ATTACH carries no grant")
+    # The laptop signed the grant for this host to use, so the host is the
+    # presenter. And only the identity on this socket may lend its own exit:
+    # the grantor has to be the address CONNECT authenticated.
+    claims = verify(
+        grant,
+        None,
+        presenter=route_handlers["agent_metadata"]["address"],
+        now=datetime.now(timezone.utc),
+    )
+    if claims["grantor"] != address:
+        raise GrantError("grantor is not the connected agent")
+    return claims
+
+
+async def attach_proxy(data, send_msg, conn, route_handlers):
+    """Verify the grant, open the loopback gateway, register the channel.
+
+    Returns the channel the session must detach in its finally, or None when
+    the attach was refused and the ERROR frame has been sent.
+    """
+    try:
+        claims = _attach_claims(data, conn, route_handlers)
+    except GrantError as refused:
+        await send_msg({"type": "ERROR", "message": f"proxy attach refused: {refused}"})
+        return None
+    channel = ProxyChannel(send_msg, claims)
+    await channel.gateway.start()
+    displaced = route_handlers["proxy_channels"].attach(channel)
+    if displaced is not None:
+        await displaced.close()
+    await send_msg({
+        "type": wire.ATTACHED,
+        "expires_at": claims["expires_at"],
+        "max_bytes": claims["max_bytes"],
+    })
+    return channel
+
+
+async def detach_proxy(channel, route_handlers):
+    """The session ended: no share is reachable through it any more."""
+    route_handlers["proxy_channels"].detach(channel)
+    await channel.close()

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -2,8 +2,8 @@
 Purpose: Run one client session — read loop, per-type dispatch, lifecycle of forward + ping tasks
 LLM-Note:
   Dependencies: imports from [.connect, .agent_io, .exec, .mode, .ping, ...trust.ws_admin, asyncio, uuid, rich.console] | imported by [.__init__ as the only public symbol]
-  Data flow: recv → verify every v2 application command → first CONNECT auth or equivalent authenticated relay reattach → dispatch INPUT/EXEC/mode_change/INTERRUPT/admin/runtime frames → bounded response → cancel spawned tasks on close
-  State/Effects: per-call local state — conn dict, active_io, forward_task, ping_task | mutates conn via handle_connect | spawns asyncio Tasks (forward + ping) cancelled in finally
+  Data flow: recv → verify every v2 application command → first CONNECT auth or equivalent authenticated relay reattach → dispatch INPUT/EXEC/mode_change/INTERRUPT/admin/runtime/PROXY_ATTACH/PROXY_STREAM frames → bounded response → cancel spawned tasks on close
+  State/Effects: per-call local state — conn dict, active_io, forward_task, ping_task, proxy_channel | mutates conn via handle_connect | spawns asyncio Tasks (forward + ping) cancelled in finally | an attached laptop share is registered on PROXY_ATTACH and detached in finally
   Integration: OIP mode_change uses .mode durable authority; interrupt requires registered active IO; signed-command clients execute only verified payload copies
   Performance: single-reader of recv_msg | O(1) per-message dispatch | bounded local state
   Errors: recv_msg returning None → exit loop normally | other exceptions propagate out (transport-level errors, programmer bugs)
@@ -20,6 +20,7 @@ from .connect import establish_connection, handle_authenticated_reconnect, handl
 from .exec import run_exec
 from .mode import handle_mode_change
 from .ping import ping_loop
+from .proxy import attach_proxy, detach_proxy
 from .remote_browser import run_remote_browser
 
 console = Console()
@@ -122,6 +123,9 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
     active_io = None
     forward_task = None
     exec_tasks = set()
+    # The laptop share attached on this socket, if any. It lives exactly as
+    # long as the socket: registered on PROXY_ATTACH, detached in finally.
+    proxy_channel = None
     ping_task = asyncio.create_task(ping_loop(send_msg)) if enable_ping else None
 
     try:
@@ -292,6 +296,24 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                         run_exec(data, send_msg, route_handlers, conn["agent_address"]))
                     exec_tasks.add(task)
                     task.add_done_callback(exec_tasks.discard)
+
+            elif msg_type == "PROXY_ATTACH":
+                if proxy_channel is not None:
+                    await send_msg({
+                        "type": "ERROR",
+                        "message": "a share is already attached on this connection",
+                    })
+                else:
+                    proxy_channel = await attach_proxy(data, send_msg, conn, route_handlers)
+
+            elif msg_type == "PROXY_STREAM":
+                if proxy_channel is None:
+                    await send_msg({
+                        "type": "ERROR",
+                        "message": "no share attached (send PROXY_ATTACH first)",
+                    })
+                else:
+                    await proxy_channel.receive(data)
 
             elif msg_type == "REMOTE_BROWSER":
                 if not conn["authenticated"]:
@@ -593,6 +615,8 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                     "message": f"unknown message type: {msg_type!r}",
                 })
     finally:
+        if proxy_channel is not None:
+            await detach_proxy(proxy_channel, route_handlers)
         # asyncio cancel idiom: cancel() only signals; await ensures the task
         # actually unwinds before we return. The CancelledError surfaced by
         # that await is the expected exit signal — not a bug, swallow it.

--- a/connectonion/network/proxy/stream.py
+++ b/connectonion/network/proxy/stream.py
@@ -1,0 +1,78 @@
+"""Wire shape of a Laptop Proxy share: one WebSocket carrying many TCP streams.
+
+The laptop dials the browser host over the ordinary direct WebSocket, attaches
+with a grant, and from then on the host sends work *down* that socket:
+
+    PROXY_ATTACH    laptop → host   {"grant": {...}}            signed
+    PROXY_ATTACHED  host → laptop   {"expires_at", "max_bytes"}
+    PROXY_STREAM    both ways       {"id": int, "op": ..., ...}
+
+Every stream frame names the stream it belongs to; `op` says what happened:
+
+    resolve   host asks {host, port}; laptop answers {addresses: [ip, ...]}
+    connect   host asks {address, port}; laptop answers {} once connected
+    data      either side, {data: base64}; at most CHUNK_BYTES before encoding
+    eof       either side: no more bytes this way, the other way stays open
+    close     either side: the stream is gone
+    error     laptop → host: the request was refused, {code}
+
+The laptop signs what it sends because the host checks every command frame
+against the CONNECT identity. Frames from host to laptop carry no signature:
+they travel inside TLS to an endpoint the laptop resolved and verified
+before attaching, so the transport already says who is speaking.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+
+ATTACH = "PROXY_ATTACH"
+ATTACHED = "PROXY_ATTACHED"
+STREAM = "PROXY_STREAM"
+
+OPS = frozenset({"resolve", "connect", "data", "eof", "close", "error"})
+
+# Raw bytes per data frame. Small enough that one frame signs and parses in
+# well under a millisecond, large enough that a page load is not thousands of
+# them.
+CHUNK_BYTES = 32 * 1024
+# What a peer will accept in one data frame after decoding; a frame beyond
+# this is malformed, not merely large.
+MAX_DATA_BYTES = CHUNK_BYTES
+# Streams one attached share may have open at once, on either side.
+MAX_STREAMS = 64
+
+
+def stream_frame(stream_id: int, op: str, **fields) -> dict:
+    return {"type": STREAM, "id": stream_id, "op": op, **fields}
+
+
+def data_frame(stream_id: int, payload: bytes) -> dict:
+    return stream_frame(
+        stream_id, "data", data=base64.b64encode(payload).decode("ascii")
+    )
+
+
+def stream_id_of(frame: dict) -> int:
+    """The stream a frame belongs to, or ValueError if it names none."""
+    stream_id = frame.get("id")
+    if isinstance(stream_id, bool) or not isinstance(stream_id, int) or stream_id < 1:
+        raise ValueError("stream frame has no stream id")
+    if frame.get("op") not in OPS:
+        raise ValueError("stream frame has no op")
+    return stream_id
+
+
+def decode_data(frame: dict) -> bytes:
+    """The bytes a data frame carries, or ValueError if it is not a bounded one."""
+    encoded = frame.get("data")
+    if not isinstance(encoded, str) or len(encoded) > MAX_DATA_BYTES * 2:
+        raise ValueError("data frame is not bounded base64")
+    try:
+        payload = base64.b64decode(encoded, validate=True)
+    except binascii.Error as exc:
+        raise ValueError("data frame is not base64") from exc
+    if len(payload) > MAX_DATA_BYTES:
+        raise ValueError("data frame exceeds the chunk bound")
+    return payload

--- a/connectonion/network/proxy_egress.py
+++ b/connectonion/network/proxy_egress.py
@@ -163,8 +163,8 @@ class ProxyShare:
             if error:
                 raise ProxyShareRefused(error)
             await self._send({"type": wire.ATTACH, "grant": self._grant()})
-            reply = await self._next_frame(ws)
-            if reply.get("type") != wire.ATTACHED:
+            reply = await self._attach_reply(ws)
+            if reply["type"] != wire.ATTACHED:
                 raise ProxyShareRefused(reply.get("message", "attach refused"))
             self._set_state("attached", self.remote.address)
             reader = asyncio.create_task(self._read_frames(ws))
@@ -195,6 +195,17 @@ class ProxyShare:
                 await ws.send(json.dumps({"type": "PONG"}))
                 continue
             return frame
+
+    async def _attach_reply(self, ws) -> dict:
+        """The host's answer to PROXY_ATTACH, past whatever else it pushes.
+
+        A real host follows CONNECTED with AGENT_PROFILE and the like; only
+        PROXY_ATTACHED or ERROR says whether the share is up.
+        """
+        while True:
+            frame = await self._next_frame(ws)
+            if frame.get("type") in {wire.ATTACHED, "ERROR"}:
+                return frame
 
     async def _read_frames(self, ws) -> None:
         async for raw in ws:

--- a/connectonion/network/proxy_egress.py
+++ b/connectonion/network/proxy_egress.py
@@ -6,12 +6,17 @@ Remote Browser product lets the caller lend its own connection instead:
 
     browser on the host  ──▶  this machine  ──▶  the internet (your IP)
 
-This module is the middle box. It is deliberately the same request machinery as
-the host-private egress gateway — same parser, same authentication, same
-destination policy, same limits — bound to a reachable address instead of
-loopback. Sharing a connection must not mean sharing the network behind it, and
-the policy that keeps a remote caller off the host's private network is exactly
-the one that keeps it off yours.
+This machine is usually behind NAT, so nothing can dial in. `ProxyShare` dials
+*out* to the host over the ordinary direct WebSocket, attaches with a grant, and
+then serves the host's resolve/connect requests as they come down that socket.
+The host's browser gateway still speaks CORESOLVE and numeric CONNECT — to a
+loopback endpoint in the host process whose last hop is this socket
+(`host/proxy_channel.py`); `remote_proxy_dialer` and `remote_proxy_resolver`
+below are that gateway's side of the conversation.
+
+Lending a connection must not lend the network behind it. Every request the
+host sends is decided by the same destination policy as the host-private egress
+gateway, on this machine, before a socket is opened.
 
 The grant issued by `connectonion.network.proxy` is the credential. Nothing
 here reads a browser profile, a cookie, or a file: the tunnel carries bytes the
@@ -24,29 +29,37 @@ import asyncio
 import base64
 import contextlib
 import ipaddress
+import json
 import socket
+import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
+from .connect import RemoteAgent
 from .host.egress_gateway import (
     EgressGateway,
     GatewayLimits,
+    GatewayRefusal,
     NumericEndpoint,
     ProxyEndpoint,
 )
+from .proxy import issue_grant
+from .proxy import stream as wire
 
 # Ranges a shared connection must never reach on the sharer's behalf. The
 # gateway's frozen table already denies these; naming them here is what makes
 # the intent legible when someone widens the policy later.
 SHARED_DENY_NETWORKS: tuple[str, ...] = ()
 
-DEFAULT_SHARE_PORT = 0
+DEFAULT_TTL = 24 * 60 * 60
+_RECONNECT_CEILING = 60.0
 _REMOTE_HEADER_LIMIT = 16 * 1024
 _REMOTE_IO_TIMEOUT = 10.0
 
 
 @dataclass(frozen=True)
 class ShareEndpoint:
-    """Where an authorized agent connects, and what it must present."""
+    """Where the host's browser gateway connects, and what it must present."""
 
     host: str
     port: int
@@ -55,83 +68,252 @@ class ShareEndpoint:
 
     @property
     def url(self) -> str:
-        """The address to hand the remote host; carries no credential."""
+        """The address as a URL; carries no credential."""
         return f"http://{self.host}:{self.port}"
 
 
-def local_egress_address() -> str:
-    """The address on this machine a remote agent can actually reach.
-
-    Not `gethostname()`: on a laptop that frequently resolves to loopback, and
-    a service bound there is reachable by nothing. Asking the routing table
-    which address it would use to reach the internet gives the interface a
-    remote peer arrives on.
-    """
-    probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    try:
-        probe.connect(("8.8.8.8", 80))
-        return probe.getsockname()[0]
-    finally:
-        probe.close()
+class ProxyShareRefused(Exception):
+    """The host would not accept this machine's share; retrying will not help."""
 
 
-class ProxyEgressService:
-    """This machine's internet connection, lent to one authorized agent."""
+class _Stream:
+    def __init__(self, stream_id: int, writer: asyncio.StreamWriter):
+        self.id = stream_id
+        self.writer = writer
+        self.pump: asyncio.Task | None = None
+
+
+class ProxyShare:
+    """This machine's internet connection, lent to one host it dials itself."""
 
     def __init__(
         self,
+        remote_address: str,
         *,
-        bind_host: str | None = None,
-        credential: str | None = None,
+        keys: dict,
+        ttl: int = DEFAULT_TTL,
+        relay_url: str | None = None,
         allowed_ports=(80, 443, 8080, 8443),
         deny_networks=SHARED_DENY_NETWORKS,
         limits: GatewayLimits | None = None,
         resolver=None,
         dialer=None,
+        on_state=None,
     ):
         overrides = {}
         if resolver is not None:
             overrides["resolver"] = resolver
         if dialer is not None:
             overrides["dialer"] = dialer
-        self._gateway = EgressGateway(
+        # Never started: the gateway is the destination policy, not a listener.
+        self._policy = EgressGateway(
             allowed_ports=allowed_ports,
             deny_networks=deny_networks,
             limits=limits,
             **overrides,
-            username="connectonion-proxy",
-            password=credential,
-            bind_host=bind_host or local_egress_address(),
-            allow_remote_resolution=True,
+        )
+        self.remote = RemoteAgent(remote_address, keys=keys, relay_url=relay_url)
+        self._keys = keys
+        # One expiry for the life of this share. A reconnect mints a fresh
+        # grant, and a fresh grant must not quietly outlive the ttl asked for.
+        self.expires_at = time.time() + ttl
+        self.state = "connecting"
+        self.handled_requests = 0
+        self._on_state = on_state or (lambda state, detail: None)
+        self._ws = None
+        self._send_lock = asyncio.Lock()
+        self._streams: dict[int, _Stream] = {}
+        self._tasks: set[asyncio.Task] = set()
+
+    async def serve(self, stop: asyncio.Event) -> None:
+        """Stay attached until `stop`; dial again with backoff when it drops."""
+        import websockets
+
+        backoff = 1.0
+        while not stop.is_set():
+            self._set_state("connecting", self.remote.address)
+            try:
+                attached = await self._session(stop)
+            except (OSError, asyncio.TimeoutError, websockets.exceptions.WebSocketException) as dropped:
+                attached, detail = False, str(dropped) or type(dropped).__name__
+            else:
+                detail = "the host closed the connection"
+            if stop.is_set() or time.time() >= self.expires_at:
+                break
+            backoff = 1.0 if attached else min(backoff * 2, _RECONNECT_CEILING)
+            self._set_state("reconnecting", f"{detail}; retrying in {backoff:.0f}s")
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(stop.wait(), timeout=backoff)
+        self._set_state("stopped", "")
+
+    async def _session(self, stop: asyncio.Event) -> bool:
+        """One socket: dial, attach, serve until it drops. True once attached."""
+        import websockets
+
+        await self.remote._try_resolve_endpoint()
+        connection, is_direct = await self.remote._open_best_connection(websockets)
+        async with connection as ws:
+            if not is_direct:
+                # The relay would carry every byte of every page through
+                # oo.openonion.ai. A share only exists on a direct socket.
+                raise OSError("the host is not reachable directly")
+            self._ws = ws
+            await ws.send(json.dumps(self.remote._build_connect_message(True)))
+            error = await self.remote._wait_for_direct_command_connected(ws)
+            if error:
+                raise ProxyShareRefused(error)
+            await self._send({"type": wire.ATTACH, "grant": self._grant()})
+            reply = await self._next_frame(ws)
+            if reply.get("type") != wire.ATTACHED:
+                raise ProxyShareRefused(reply.get("message", "attach refused"))
+            self._set_state("attached", self.remote.address)
+            reader = asyncio.create_task(self._read_frames(ws))
+            stopper = asyncio.create_task(stop.wait())
+            try:
+                await asyncio.wait({reader, stopper}, return_when=asyncio.FIRST_COMPLETED)
+                if reader.done():
+                    reader.result()
+            finally:
+                stopper.cancel()
+                reader.cancel()
+                await self._abandon_streams()
+                self._ws = None
+        return True
+
+    def _grant(self) -> dict:
+        expires = datetime.fromtimestamp(self.expires_at, timezone.utc)
+        return issue_grant(
+            self._keys,
+            holder=self.remote.address,
+            expires_at=expires.isoformat().replace("+00:00", "Z"),
         )
 
-    @property
-    def endpoint(self) -> ShareEndpoint:
-        inner = self._gateway.endpoint
-        return ShareEndpoint(inner.host, inner.port, inner.username, inner.password)
+    async def _next_frame(self, ws) -> dict:
+        while True:
+            frame = json.loads(await asyncio.wait_for(ws.recv(), timeout=30))
+            if frame.get("type") == "PING":
+                await ws.send(json.dumps({"type": "PONG"}))
+                continue
+            return frame
 
-    @property
-    def is_running(self) -> bool:
-        return self._gateway.is_running
+    async def _read_frames(self, ws) -> None:
+        async for raw in ws:
+            frame = json.loads(raw)
+            kind = frame.get("type")
+            if kind == "PING":
+                await ws.send(json.dumps({"type": "PONG"}))
+            elif kind == wire.STREAM:
+                await self._handle(frame)
+            elif kind == "ERROR":
+                self._on_state("error", frame.get("message", ""))
 
-    @property
-    def handled_requests(self) -> int:
-        """Requests this share has decided; the evidence `co proxy status` shows."""
-        return self._gateway.handled_requests
+    # ---- requests coming down from the host ----
 
-    async def start(self) -> ShareEndpoint:
-        await self._gateway.start()
-        return self.endpoint
+    async def _handle(self, frame: dict) -> None:
+        stream_id = wire.stream_id_of(frame)
+        op = frame["op"]
+        if op in {"resolve", "connect"}:
+            self.handled_requests += 1
+            self._spawn(self._answer(stream_id, op, frame))
+            return
+        stream = self._streams.get(stream_id)
+        if stream is None:
+            return
+        if op == "data":
+            await self._write(stream, wire.decode_data(frame))
+        elif op == "eof":
+            with contextlib.suppress(NotImplementedError, OSError):
+                stream.writer.write_eof()
+        else:
+            self._forget(stream)
 
-    async def stop(self) -> None:
-        await self._gateway.stop()
+    async def _answer(self, stream_id: int, op: str, frame: dict) -> None:
+        host, port = frame.get("host") or frame.get("address"), frame.get("port")
+        if not isinstance(host, str) or isinstance(port, bool) or not isinstance(port, int):
+            await self._send(wire.stream_frame(stream_id, "error", code="EGRESS_INVALID"))
+            return
+        try:
+            if op == "resolve":
+                endpoints = await self._policy.resolve_destination(host, port)
+                addresses = [endpoint.address for endpoint in endpoints]
+                await self._send(wire.stream_frame(stream_id, "resolve", addresses=addresses))
+                return
+            reader, writer = await self._policy.connect_destination(host, port)
+        except GatewayRefusal as refused:
+            await self._send(wire.stream_frame(stream_id, "error", code=refused.code))
+            return
+        if stream_id in self._streams or len(self._streams) >= wire.MAX_STREAMS:
+            writer.close()
+            await self._send(wire.stream_frame(stream_id, "error", code="EGRESS_OVERLOADED"))
+            return
+        stream = _Stream(stream_id, writer)
+        self._streams[stream_id] = stream
+        await self._send(wire.stream_frame(stream_id, "connect"))
+        stream.pump = self._spawn(self._pump_up(stream, reader))
 
-    async def __aenter__(self) -> "ProxyEgressService":
-        await self.start()
-        return self
+    async def _pump_up(self, stream: _Stream, reader: asyncio.StreamReader) -> None:
+        """Bytes from the destination become data frames until it stops."""
+        try:
+            while True:
+                chunk = await reader.read(wire.CHUNK_BYTES)
+                if not chunk:
+                    await self._send(wire.stream_frame(stream.id, "eof"))
+                    return
+                await self._send(wire.data_frame(stream.id, chunk))
+        except OSError:
+            # The destination reset the socket; the host learns the stream is
+            # gone rather than waiting on an EOF that will never come.
+            if self._streams.get(stream.id) is stream:
+                self._forget(stream)
+                await self._send(wire.stream_frame(stream.id, "close"))
 
-    async def __aexit__(self, *_exc) -> None:
-        await self.stop()
+    async def _write(self, stream: _Stream, payload: bytes) -> None:
+        stream.writer.write(payload)
+        try:
+            await stream.writer.drain()
+        except OSError:
+            self._forget(stream)
+            await self._send(wire.stream_frame(stream.id, "close"))
+
+    def _forget(self, stream: _Stream) -> None:
+        self._streams.pop(stream.id, None)
+        if stream.pump is not None:
+            stream.pump.cancel()
+        stream.writer.close()
+
+    async def _abandon_streams(self) -> None:
+        for stream in list(self._streams.values()):
+            self._forget(stream)
+        for task in self._tasks:
+            task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+
+    def _spawn(self, coroutine) -> asyncio.Task:
+        task = asyncio.create_task(coroutine)
+        self._tasks.add(task)
+        task.add_done_callback(self._reap)
+        return task
+
+    def _reap(self, task: asyncio.Task) -> None:
+        self._tasks.discard(task)
+        if not task.cancelled() and task.exception() is not None:
+            # A stream task that died is not the share dying, but the operator
+            # should see it rather than an "exception was never retrieved" at
+            # garbage-collection time.
+            self._on_state("error", repr(task.exception()))
+
+    async def _send(self, frame: dict) -> None:
+        # Signed, because the host verifies every command frame against the
+        # CONNECT identity; one lock so frames of a stream leave in order.
+        signed = self.remote._build_command_message(frame, True)
+        async with self._send_lock:
+            await self._ws.send(json.dumps(signed))
+
+    def _set_state(self, state: str, detail: str) -> None:
+        self.state = state
+        self._on_state(state, detail)
 
 
 def remote_proxy_dialer(share: ShareEndpoint):
@@ -288,11 +470,11 @@ def shared_egress_gateway(
 
 
 __all__ = [
-    "DEFAULT_SHARE_PORT",
-    "ProxyEgressService",
+    "DEFAULT_TTL",
     "ProxyEndpoint",
+    "ProxyShare",
+    "ProxyShareRefused",
     "ShareEndpoint",
-    "local_egress_address",
     "remote_proxy_dialer",
     "remote_proxy_resolver",
     "shared_egress_gateway",

--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -288,7 +288,9 @@ connectonion
 
 Non-negotiable interface rules:
 
-- OIP carries control and state; it does not carry bulk proxy bytes.
+- The Relay carries control and state; it never carries bulk proxy bytes. A
+  Laptop share rides only the direct, signed socket, as bounded `PROXY_STREAM`
+  frames.
 - The Relay routes opaque records and never owns content keys.
 - Authorization is checked after authentication and is not implied by encryption.
 - ConnectOnion never reads `~/.onionwright`, parses private attestation JSON, guesses an
@@ -591,8 +593,11 @@ after review and vectors.
 
 ### First Laptop Proxy and data plane
 
-1. `co proxy share to <B>` binds the Laptop share to the authenticated remote
-   Agent address. `co proxy stop <B>` stops the live service before removing state.
+1. `co proxy share to <B>` dials B over the direct signed socket and attaches
+   with a grant the Laptop signs (`PROXY_ATTACH`); B keys the share by the
+   Laptop's address and serves its own resolve/connect work back down that
+   socket. The Laptop never listens. `co proxy stop <B>` stops the live share
+   before removing state.
 2. Resolve and pin `shared` or `direct` once when the WTF Browser runtime is
    created. Do not allow one runtime to mix modes or Laptop exits.
 3. Keep Proxy selection and service lifecycle outside BrowserDaemon. The daemon

--- a/docs/blog/2026-09-02-the-laptop-dials-out.md
+++ b/docs/blog/2026-09-02-the-laptop-dials-out.md
@@ -1,0 +1,80 @@
+# The laptop dials out
+
+`co proxy share` opened a listening socket on your laptop and told the browser
+host where it was. On a laptop that lives behind a home router, that address is
+`192.168.x.x`, and the host is a server in a data centre. The share came up,
+printed "sharing", and the host could not reach it. The only setups where it
+worked were the ones where both machines were on the same network — which is
+to say, the demo, and nothing anyone would pay for.
+
+The product is that a browser on a server leaves the internet from your
+address. The one machine involved that can never accept a connection is yours.
+
+## Reverse the arrow
+
+Nothing listens on the laptop any more. It dials the host over the same direct
+WebSocket every `co` command already uses, presents a grant, and stays on the
+socket. From then on the host sends work *down*:
+
+```text
+host → laptop   {"type":"PROXY_STREAM","id":7,"op":"resolve","host":"example.com","port":443}
+laptop → host   {"type":"PROXY_STREAM","id":7,"op":"resolve","addresses":["93.184.216.34"]}
+host → laptop   {"type":"PROXY_STREAM","id":8,"op":"connect","address":"93.184.216.34","port":443}
+laptop → host   {"type":"PROXY_STREAM","id":8,"op":"connect"}
+both            {"type":"PROXY_STREAM","id":8,"op":"data","data":"<base64, ≤32 KiB>"}
+```
+
+One socket, many streams, six ops. A home router is happy to let an outbound
+connection through and keep it open; that is the only thing it is good at.
+
+## What did not change
+
+The browser host's egress gateway still speaks CORESOLVE and numeric CONNECT
+to a "share endpoint". That endpoint is now a second gateway on loopback in
+the host process, whose resolver and dialer are the channel. The daemon, the
+pinned `shared-proxy.json`, the double classification, the frozen deny table:
+untouched. The share moved from a socket on the laptop to a socket in the
+host, and the gateway did not notice.
+
+The laptop end runs the same `EgressGateway` too — never started, used only as
+the policy. Every `resolve` and every `connect` the host asks for goes through
+the same classifier the laptop's own listener would have applied. Lending a
+connection still does not lend the network behind it.
+
+## What has to be true for the attach to happen
+
+The socket is the one `CONNECT` authenticated, so the host knows who is on it.
+The attach carries a grant signed by that same identity, naming the host as
+the holder. The host checks: authenticated, signed commands on, direct
+transport (the relay would carry every byte of every page through
+`oo.openonion.ai`, and a share only exists on a direct socket), trust at least
+`contact`, grant verifies, grantor is the socket's identity. Any one of those
+missing is a refusal with the reason, before a gateway is opened.
+
+A `start --proxy shared` from that identity finds its own channel by address.
+There is no channel to find when the laptop has not attached, and the answer
+is `REMOTE_SESSION_PROXY_NOT_ATTACHED` with the one command that fixes it,
+`co proxy share`. The laptop-side precheck that used to guess at this is gone;
+the host is the authority on what is attached to it.
+
+## The socket is the lifetime
+
+The channel is registered when `PROXY_ATTACH` is accepted and detached in the
+session's `finally`. When the laptop closes the lid, the socket drops, the
+channel closes, and every stream on it fails with `PROXY_DETACHED`. The
+browser's next request through the shared gateway gets a refusal, not a
+fallback to the host's own connection — the fail-closed rule from DD-056 is
+enforced by the socket going away, which is the one event nobody can forget
+to handle.
+
+`co proxy share` reconnects with backoff (1 s doubling to 60 s), minting a
+fresh grant with the *original* expiry. A reconnect must not quietly extend
+the TTL the operator asked for.
+
+`--bind` is gone; there is nothing to bind. `--ttl` stays, default 24 h.
+
+Measured: nine unit tests on the channel, one in-process end-to-end test with
+a real `run_ws_session` behind `websockets.serve` and a real `EgressGateway`
+on both ends, where the origin sees the laptop side. All red before the
+change. The two-machine run — a GCP host, this Mac behind home NAT, no ports
+opened — is the acceptance for `1.8.0b1` and is reported separately.

--- a/docs/cli/proxy.md
+++ b/docs/cli/proxy.md
@@ -27,6 +27,30 @@ co remote-browser 0xHOST start --proxy shared
 Every address above is optional once `co remote-browser config 0xHOST` has
 remembered one; `co proxy share`, `stop` and `diagnose` then use it.
 
+## How it connects
+
+Your computer dials the host — nothing listens here, so it works from behind
+a home router or a hotel NAT without port forwards or tunnels. `co proxy
+share` opens the same direct, signed WebSocket `co remote-browser` uses,
+attaches with a grant you sign (naming the host and an expiry), and then
+serves the host's requests over that socket: resolve this name, connect to
+this address, here are the bytes.
+
+```text
+your computer ──dials──▶ host        PROXY_ATTACH  (signed grant)
+your computer ◀──────── host         PROXY_STREAM  resolve / connect / data
+```
+
+The command keeps running while the share is attached. If the socket drops it
+reconnects with backoff (1 s, 2 s, ... up to 60 s) and re-attaches with a grant
+carrying the same expiry; `co proxy status` shows `attached` or `reconnecting`
+while that happens. The share ends when you stop it, when `--ttl` runs out
+(default 24 h), or when the process exits.
+
+Only a direct connection is accepted. The relay carries control frames, not
+page bytes; if the host is reachable only through the relay the share reports
+that and keeps retrying.
+
 ## What gets shared, and what does not
 
 **Shared:** an outbound path to the public web, for destinations the policy
@@ -70,28 +94,34 @@ fallback.
 | Option | What it does |
 |---|---|
 | `--json` | the complete stable envelope, for scripts and agents |
-| `--bind HOST` | listen on a specific address (default: the one a peer reaches) |
-| `--ttl SEC` | stop sharing automatically after this long |
+| `--ttl SEC` | stop sharing automatically after this long (default: 24 h) |
 
-`co proxy stop` sends an authenticated stop request to the live service, waits
-for its listener to close, and only then reports success. Deleting stale state
-is not treated as stopping a Proxy.
+`co proxy stop` sends an authenticated stop request to the live share, waits
+for it to detach and exit, and only then reports success. Deleting stale state
+is not treated as stopping a share.
 
-`co proxy share` picks its own address by asking the routing table which
-interface reaches the internet. On a machine with several interfaces, or behind
-a NAT where the peer arrives somewhere else, set `--bind` yourself;
-`co proxy diagnose` tells you when the bound address and the reachable one
-differ.
+`co proxy diagnose` distinguishes "never shared", "the share process is gone"
+and "the process is alive but not attached right now" — each with the one
+command that fixes it.
 
-## Reaching your share from outside your network
+## Security
 
-A share listens on this machine. An agent on another network needs a path to
-it — a port forward, a VPN, or a tunnel you already run. `co proxy diagnose`
-prints the address a peer would use, which is where to point that path.
-
-The first preview intentionally keeps this two-machine model. A later transport
-may make `share to` create its own outbound reverse path through the remote
-Agent; that is not silently claimed by the current listener implementation.
+- **You sign the grant.** The attach carries a grant signed by this computer's
+  identity, naming the host as holder with an expiry. The host refuses a grant
+  for another host, an expired one, or one signed by anyone other than the
+  identity on the socket — so a copied grant is useless to whoever copied it.
+- **Only your own sessions use it.** The host keys attached shares by your
+  address. `co remote-browser start --proxy shared` from your identity uses
+  your share; nobody else's session can.
+- **Signed one way, TLS both ways.** Your frames to the host are Ed25519-signed
+  like every other command. The host's frames back to you are not signed: they
+  arrive inside the TLS session you opened to an endpoint whose identity you
+  already verified, and no one else can inject into that socket.
+- **Bounded.** Streams per share and bytes per frame are capped; a grant's
+  `max_bytes` and `expires_at` are enforced on the host, and the share stops
+  itself at `--ttl`.
+- **Policy on both ends.** Every destination is classified on the host and
+  again on your computer. Your LAN stays yours.
 
 ## Verified
 

--- a/docs/design-decisions/056-remote-browser-egress-gateway.md
+++ b/docs/design-decisions/056-remote-browser-egress-gateway.md
@@ -162,6 +162,27 @@ numeric address. The Laptop applies the same frozen policy both while resolving
 and while dialing. This preserves the exact-socket invariant while ensuring DNS
 and public egress both belong to the Laptop.
 
+## Transport: the Laptop dials out (2026-09-02)
+
+The first preview had the Laptop *listen* and B connect in. That is the wrong
+direction for the machine that is actually a laptop: it sits behind NAT, and
+"open a port forward" is not a step a user of `co proxy share` will take.
+
+The transport is now reversed. `co proxy share` opens the same direct, signed
+WebSocket every other `co` command uses, attaches with a `PROXY_ATTACH` frame
+carrying a grant the Laptop signs, and B sends its resolve/connect/data work
+back down that socket as `PROXY_STREAM` frames. B keeps an address-keyed
+registry of attached channels and, for each one, an `EgressGateway` on
+`127.0.0.1` whose resolver and dialer are the channel. The private WTF runtime
+still sees exactly one fixed loopback Proxy with no Direct fallback — nothing
+below this line changed — and `start --proxy shared` simply looks the caller's
+address up in that registry (`REMOTE_SESSION_PROXY_NOT_ATTACHED` when absent).
+
+Only the direct socket may carry a share: the relay carries control frames, not
+page bytes, and B verifies the grant's holder, expiry and grantor against the
+identity on the socket. B → Laptop frames are unsigned; they travel inside the
+TLS session the Laptop opened to an endpoint whose identity it verified.
+
 ## Gateway connection contract
 
 The first implementation accepts only browser web traffic:

--- a/docs/network/remote-browser-private-runtime.md
+++ b/docs/network/remote-browser-private-runtime.md
@@ -58,7 +58,10 @@ There is no Direct fallback.
 For shared egress the loopback gateway replaces its system resolver and numeric
 dialer together: DNS asks the Laptop Proxy for its complete classified answer
 set, and the selected numeric connection returns to that same Laptop Proxy.
-Chromium and the remote operating system never resolve the destination.
+Chromium and the remote operating system never resolve the destination. The
+Laptop Proxy is reached through the channel the Laptop itself attached with
+`co proxy share` — a second loopback gateway in the host process, keyed by the
+Laptop's address — so the host never dials the Laptop.
 
 ## Requested Chromium launch policy
 

--- a/docs/network/remote-browser.md
+++ b/docs/network/remote-browser.md
@@ -44,19 +44,23 @@ browser on the host  ──▶  your computer  ──▶  the internet (your add
 ```
 
 ```bash
-co proxy share to 0xHOST                        # on your computer
-co remote-browser 0xHOST start --proxy shared   # then start the session
+co remote-browser config 0xHOST --proxy shared  # once
+co proxy share                                  # on your computer; keeps running
+co remote-browser start                         # then start the session
 ```
 
-Or, after `co remote-browser config 0xHOST --proxy shared`, the same two
-commands with nothing to type: `co proxy share` and `co remote-browser start`.
+Your computer dials the host and stays attached; the host never has to reach
+you, so this works from behind any home or office NAT. The share is keyed by
+your identity on the host — `start --proxy shared` from the same identity
+finds it by itself, and nothing about it travels in the start request.
 
 Measured on a Google Cloud server egressing through a laptop in Sydney: the
 server's own address is `34.21.243.229`, and the site saw `129.94.43.159`.
 
 `--proxy direct` (the default) keeps the host on its own connection. Asking for
-`shared` without a share endpoint answers `REMOTE_SESSION_SHARE_MISSING` rather
-than quietly falling back — a silent fallback would send traffic from the data
+`shared` while your computer is not attached answers
+`REMOTE_SESSION_PROXY_NOT_ATTACHED` (next action: `co proxy share`) rather than
+quietly falling back — a silent fallback would send traffic from the data
 centre while you believed it left from home. Any other mode answers
 `REMOTE_SESSION_PROXY_LOCKED`.
 

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -534,6 +534,59 @@ Pass the trust gate. Sent in reply to `ONBOARD_REQUIRED`, on the same socket.
 Sent on the same socket as the CONNECT it answers. A wrong code comes back as `ERROR` and
 the stashed CONNECT is **kept**, so the reader can simply try again — no reconnect needed.
 
+#### PROXY_ATTACH
+
+Lend this computer's internet connection to the host (`co proxy share`). Sent
+once per socket after a signed CONNECT, on a **direct** connection only — the
+relay never carries page bytes. Signed like every other command.
+
+```json
+{
+  "type": "PROXY_ATTACH",
+  "payload": {
+    "grant": {
+      "type": "proxy_grant", "grant_id": "pxg_...",
+      "grantor": "0xLaptop", "holder": "0xHost", "scope": "public_internet",
+      "expires_at": "2026-09-03T10:00:00Z", "max_bytes": null,
+      "signature": "..."
+    },
+    "to": "0xHost", "timestamp": 1702234567, "nonce": "..."
+  },
+  "from": "0xLaptop",
+  "signature": "0x..."
+}
+```
+
+The host verifies the grant (it must name this host as holder, be unexpired,
+and be signed by the identity on this socket), requires contact-or-better
+trust, and answers `PROXY_ATTACHED` or `ERROR`. A later attach from the same
+identity replaces the earlier one; the attachment ends when the socket closes.
+
+#### PROXY_STREAM
+
+One multiplexed stream operation, in either direction, while a share is
+attached. The host opens streams; the laptop answers them.
+
+```json
+{"type": "PROXY_STREAM", "payload": {"id": 7, "op": "connect", "address": "93.184.216.34", "port": 443}}
+```
+
+| `op` | Direction | Fields | Meaning |
+|------|-----------|--------|---------|
+| `resolve` | host → laptop | `host`, `port` | resolve this name with the laptop's DNS and policy |
+| `resolve` | laptop → host | `addresses` | the complete answer set |
+| `connect` | host → laptop | `address`, `port` | open a socket to this numeric address, re-classified on the laptop |
+| `connect` | laptop → host | — | the socket is open |
+| `data` | both | `data` (base64, ≤ 32 KiB) | bytes on the stream |
+| `eof` | both | — | half-close: no more bytes this way |
+| `close` | both | — | the stream is finished; forget it |
+| `error` | both | `code` | the request failed (`EGRESS_*` / `DESTINATION_*` codes) |
+
+Laptop → host frames are signed like every command. Host → laptop frames carry
+no signature: they travel inside the TLS session the laptop opened to an
+endpoint whose identity it already verified. At most 64 streams per share; the
+grant's `expires_at` and `max_bytes` are enforced by the host.
+
 ### Server → Client
 
 #### CONNECTED
@@ -782,6 +835,19 @@ Fields beyond `action` are whatever the trust handler returned for that operatio
 Also how a **refused onboard** comes back — `{"type": "ERROR", "message": "Invalid invite
 code"}`. There is no dedicated failure frame, and no repeat of `ONBOARD_REQUIRED`: a client
 waiting for one of those to detect the refusal will wait forever.
+
+#### PROXY_ATTACHED
+
+The share offered by `PROXY_ATTACH` is accepted and registered under the
+sender's address. A refused attach is an `ERROR` whose message starts with
+`proxy attach refused:`.
+
+```json
+{ "type": "PROXY_ATTACHED", "expires_at": "2026-09-03T10:00:00Z", "max_bytes": null }
+```
+
+From here the host sends `PROXY_STREAM` frames (unsigned, see above) down this
+socket until it closes.
 
 ---
 

--- a/tests/e2e/test_native_egress_preflight_real_driver.py
+++ b/tests/e2e/test_native_egress_preflight_real_driver.py
@@ -23,10 +23,7 @@ from connectonion.network.host.egress_gateway import EgressGateway
 from connectonion.network.host.private_browser_runtime import (
     REMOTE_BROWSER_CHROME_ARGS,
 )
-from connectonion.network.proxy_egress import (
-    ProxyEgressService,
-    shared_egress_gateway,
-)
+from connectonion.network.proxy_egress import ShareEndpoint, shared_egress_gateway
 from connectonion.useful_tools.browser_tools.native_egress import (
     NativeEgressPreflightError,
     run_native_egress_preflight,
@@ -159,11 +156,24 @@ async def _exercise_shared_proxy():
     async def laptop_dial(_endpoint, _timeout):
         return await asyncio.open_connection("127.0.0.1", origin_port)
 
-    share = ProxyEgressService(
-        bind_host="127.0.0.1", resolver=laptop_dns, dialer=laptop_dial
+    # Stands in for the laptop end of an attached share: a gateway on this
+    # machine that resolves and dials with the laptop's own policy.
+    share = EgressGateway(
+        bind_host="127.0.0.1",
+        allow_remote_resolution=True,
+        username="connectonion-proxy",
+        resolver=laptop_dns,
+        dialer=laptop_dial,
     )
-    await share.start()
-    gateway = shared_egress_gateway(share.endpoint)
+    share_endpoint = await share.start()
+    gateway = shared_egress_gateway(
+        ShareEndpoint(
+            share_endpoint.host,
+            share_endpoint.port,
+            share_endpoint.username,
+            share_endpoint.password,
+        )
+    )
     endpoint = await gateway.start()
     try:
         async with async_playwright() as driver:

--- a/tests/unit/test_cli_remote_browser.py
+++ b/tests/unit/test_cli_remote_browser.py
@@ -109,33 +109,18 @@ def test_proxy_option_is_not_accepted_by_non_start_command(monkeypatch):
     assert remote.calls == [("sessions", {"session_id": None, "timeout": 60.0})]
 
 
-def test_shared_start_passes_the_laptop_endpoint_once_at_runtime_creation(
-    tmp_path, monkeypatch
-):
+def test_shared_start_names_the_mode_and_sends_no_endpoint(tmp_path, monkeypatch):
+    """The share is attached to the host by `co proxy share`, not carried in
+    the start request — the host already holds this identity's channel and
+    answers REMOTE_SESSION_PROXY_NOT_ATTACHED when it does not."""
     remote = _install(monkeypatch, _result())
-    from connectonion.cli.commands import proxy_commands
-
-    state_path = tmp_path / "proxy-shares.json"
-    monkeypatch.setattr(proxy_commands, "STATE_PATH", state_path)
-    proxy_commands._save(
-        {
-            "0xhost": {
-                "url": "http://192.0.2.10:43123",
-                "host": "192.0.2.10",
-                "port": 43123,
-                "username": "laptop",
-                "password": "secret",
-            }
-        }
-    )
 
     assert handle_remote_browser(["--proxy", "shared", "0xhost", "start"]) == 0
 
     command, kwargs = remote.calls[0]
     assert command == "start"
     assert kwargs["proxy"] == "shared"
-    assert kwargs["share"]["host"] == "192.0.2.10"
-    assert kwargs["share"]["password"] == "secret"
+    assert "share" not in kwargs
 
 
 # --- `config`: remember the remote once, then leave the address out (#1366) ---

--- a/tests/unit/test_proxy_channel.py
+++ b/tests/unit/test_proxy_channel.py
@@ -1,0 +1,300 @@
+"""The laptop dials the host; the host sends its resolve/connect work back down.
+
+Both ends are real here — `ProxyChannel` (host) and `ProxyShare` (laptop) —
+joined by two in-process functions instead of a WebSocket. The laptop's frames
+still go through its signing path, so what the host receives is the signed
+payload it would see on the wire.
+"""
+
+import asyncio
+import socket
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from connectonion import address
+from connectonion.network.host.egress_gateway import NumericEndpoint
+from connectonion.network.host.proxy_channel import ProxyChannel, ProxyChannelRegistry
+from connectonion.network.proxy import GrantError, issue_grant, verify
+from connectonion.network.proxy import stream as wire
+from connectonion.network.proxy_egress import ProxyShare
+
+
+def _in(seconds: int) -> str:
+    when = datetime.now(timezone.utc) + timedelta(seconds=seconds)
+    return when.isoformat().replace("+00:00", "Z")
+
+
+@pytest.fixture(scope="module")
+def keys():
+    return {"laptop": address.generate(), "host": address.generate()}
+
+
+def _claims(keys, **grant_overrides):
+    grant = issue_grant(
+        keys["laptop"],
+        holder=keys["host"]["address"],
+        expires_at=_in(3600),
+        **grant_overrides,
+    )
+    return verify(grant, None, presenter=keys["host"]["address"], now=datetime.now(timezone.utc))
+
+
+class _Pair:
+    """A host channel and a laptop share wired to each other directly."""
+
+    def __init__(self, keys, claims=None, **share_kwargs):
+        self.laptop = ProxyShare(keys["host"]["address"], keys=keys["laptop"], **share_kwargs)
+        self.host = ProxyChannel(self._to_laptop, claims or _claims(keys))
+        self.laptop._ws = self
+        self.to_host = []
+
+    async def _to_laptop(self, frame):
+        await self.laptop._handle(frame)
+
+    async def send(self, raw):
+        import json
+
+        signed = json.loads(raw)
+        self.to_host.append(signed)
+        await self.host.receive(signed["payload"])
+
+
+async def _echo_server():
+    async def handler(reader, writer):
+        while True:
+            chunk = await reader.read(65536)
+            if not chunk:
+                break
+            writer.write(chunk)
+            await writer.drain()
+        writer.close()
+
+    server = await asyncio.start_server(handler, "127.0.0.1", 0)
+    return server, server.sockets[0].getsockname()[1]
+
+
+@pytest.mark.asyncio
+async def test_bytes_go_down_the_channel_and_come_back(keys):
+    server, port = await _echo_server()
+
+    async def to_echo(endpoint, timeout):
+        assert endpoint.address == "8.8.8.8"
+        return await asyncio.open_connection("127.0.0.1", port)
+
+    pair = _Pair(keys, dialer=to_echo, allowed_ports=(port,))
+    reader, writer = await pair.host.dial(NumericEndpoint(socket.AF_INET, "8.8.8.8", port), 5)
+    payload = bytes(range(256)) * 300  # crosses the chunk bound, so several frames
+    writer.write(payload)
+    await writer.drain()
+    echoed = await asyncio.wait_for(reader.readexactly(len(payload)), timeout=5)
+    writer.close()
+    await writer.wait_closed()
+    server.close()
+    await server.wait_closed()
+
+    assert echoed == payload
+    ops = [frame["payload"]["op"] for frame in pair.to_host]
+    assert ops[0] == "connect"
+    assert ops.count("data") >= 3
+    assert not pair.laptop._streams, "the laptop kept the socket after close"
+    assert not pair.host._streams, "the host kept the stream after close"
+    assert pair.host.bytes_used == 2 * len(payload)
+
+
+@pytest.mark.asyncio
+async def test_the_laptop_resolves_and_still_refuses_its_own_lan(keys):
+    async def answers(host, port):
+        return ("192.168.0.1",) if host.startswith("nas") else ("8.8.8.8",)
+
+    pair = _Pair(keys, resolver=answers)
+
+    assert await pair.host.resolve("example.com", 443) == ("8.8.8.8",)
+    with pytest.raises(OSError, match="DESTINATION_ADDRESS_DENIED"):
+        await pair.host.resolve("nas.example.com", 443)
+    with pytest.raises(OSError, match="DESTINATION_ADDRESS_DENIED"):
+        await pair.host.dial(NumericEndpoint(socket.AF_INET, "192.168.0.1", 443), 5)
+    assert pair.laptop.handled_requests == 3
+    assert not pair.host._streams
+
+
+@pytest.mark.asyncio
+async def test_a_spent_or_expired_grant_opens_nothing(keys):
+    spent = _Pair(keys, claims=_claims(keys, max_bytes=10))
+    spent.host.bytes_used = 10
+    with pytest.raises(OSError, match="budget"):
+        await spent.host.resolve("example.com", 443)
+
+    expired = _Pair(keys)
+    expired.host._expires_at = 0
+    with pytest.raises(OSError, match="expired"):
+        await expired.host.resolve("example.com", 443)
+
+
+@pytest.mark.asyncio
+async def test_detaching_ends_every_open_stream(keys):
+    server, port = await _echo_server()
+
+    async def to_echo(endpoint, timeout):
+        return await asyncio.open_connection("127.0.0.1", port)
+
+    pair = _Pair(keys, dialer=to_echo, allowed_ports=(port,))
+    reader, _writer = await pair.host.dial(NumericEndpoint(socket.AF_INET, "8.8.8.8", port), 5)
+    await pair.host.close()
+    server.close()
+    await server.wait_closed()
+
+    assert await asyncio.wait_for(reader.read(), timeout=5) == b""
+    with pytest.raises(OSError, match="detached"):
+        await pair.host.resolve("example.com", 443)
+
+
+@pytest.mark.asyncio
+async def test_more_streams_than_the_bound_are_refused(keys):
+    pair = _Pair(keys)
+    pair.host._streams = {index: object() for index in range(wire.MAX_STREAMS)}
+    with pytest.raises(OSError, match="streams open"):
+        await pair.host.resolve("example.com", 443)
+
+
+def test_the_registry_finds_a_share_by_its_owner(keys):
+    class Channel:
+        def __init__(self, owner):
+            self.owner = owner
+            self.endpoint = f"endpoint-of-{owner}"
+
+    registry = ProxyChannelRegistry()
+    first = Channel("0xlaptop")
+    assert registry.attach(first) is None
+    assert registry.endpoint_for("0xlaptop") == "endpoint-of-0xlaptop"
+    assert registry.endpoint_for("0xother") is None
+
+    # A reconnect displaces the stale channel; a late detach of the stale one
+    # must not remove the live one.
+    second = Channel("0xlaptop")
+    assert registry.attach(second) is first
+    registry.detach(first)
+    assert registry.get("0xlaptop") is second
+    registry.detach(second)
+    assert registry.endpoint_for("0xlaptop") is None
+
+
+# --- attaching: who may lend what to whom ------------------------------------
+
+
+class _Trust:
+    def __init__(self, level="contact"):
+        self.level = level
+
+    def is_admin(self, _address):
+        return False
+
+    def get_level(self, _address):
+        return self.level
+
+
+def _attach(keys, grant, *, level="contact", transport="direct", signed=True, connected=None):
+    from connectonion.network.host.ws_router.proxy import _attach_claims
+
+    conn = {
+        "authenticated": True,
+        "signed_commands": signed,
+        "agent_address": connected or keys["laptop"]["address"],
+        "transport": transport,
+    }
+    route_handlers = {
+        "proxy_channels": ProxyChannelRegistry(),
+        "trust_agent": _Trust(level),
+        "agent_metadata": {"address": keys["host"]["address"]},
+    }
+    return _attach_claims({"grant": grant}, conn, route_handlers)
+
+
+def test_a_grant_for_this_host_from_the_connected_laptop_attaches(keys):
+    grant = issue_grant(keys["laptop"], holder=keys["host"]["address"], expires_at=_in(60))
+    claims = _attach(keys, grant)
+    assert claims["grantor"] == keys["laptop"]["address"]
+
+
+def test_grants_are_refused_when_they_do_not_bind_this_socket_to_this_host(keys):
+    stranger = address.generate()
+    for_someone_else = issue_grant(keys["laptop"], holder=stranger["address"], expires_at=_in(60))
+    with pytest.raises(GrantError, match="not the grant holder"):
+        _attach(keys, for_someone_else)
+
+    expired = issue_grant(keys["laptop"], holder=keys["host"]["address"], expires_at=_in(-1))
+    with pytest.raises(GrantError, match="expired"):
+        _attach(keys, expired)
+
+    # Signed by a laptop other than the one on this socket: someone
+    # presenting a grant they found, not one they issued.
+    someone_elses = issue_grant(stranger, holder=keys["host"]["address"], expires_at=_in(60))
+    with pytest.raises(GrantError, match="not the connected agent"):
+        _attach(keys, someone_elses)
+
+    good = issue_grant(keys["laptop"], holder=keys["host"]["address"], expires_at=_in(60))
+    with pytest.raises(GrantError, match="direct connection"):
+        _attach(keys, good, transport="relay")
+    with pytest.raises(GrantError, match="contact or admin"):
+        _attach(keys, good, level="stranger")
+    with pytest.raises(GrantError, match="signed CONNECT"):
+        _attach(keys, good, signed=False)
+
+
+@pytest.mark.asyncio
+async def test_the_session_registers_on_attach_and_forgets_on_disconnect(keys, monkeypatch):
+    from connectonion.network.connect import RemoteAgent
+    from connectonion.network.host.ws_router import session
+
+    host = keys["host"]["address"]
+    grant = issue_grant(keys["laptop"], holder=host, expires_at=_in(60))
+    attach = RemoteAgent(host, keys=keys["laptop"])._build_command_message(
+        {"type": wire.ATTACH, "grant": grant}, True
+    )
+    frames = [{"type": "CONNECT", "from": keys["laptop"]["address"]}, attach]
+    registry = ProxyChannelRegistry()
+    attached = asyncio.Event()
+    seen_while_attached = []
+    sent = []
+
+    async def fake_connect(data, send, conn, *args):
+        conn.update(
+            authenticated=True,
+            agent_address=keys["laptop"]["address"],
+            signed_commands=True,
+            recipient_address=host,
+            session_id="oip-session",
+        )
+
+    async def recv():
+        if frames:
+            return frames.pop(0)
+        await attached.wait()
+        seen_while_attached.append(registry.endpoint_for(keys["laptop"]["address"]))
+        return None
+
+    async def send(message):
+        sent.append(message)
+        if message.get("type") == wire.ATTACHED:
+            attached.set()
+
+    monkeypatch.setattr(session, "handle_connect", fake_connect)
+    await session.run_ws_session(
+        send,
+        recv,
+        route_handlers={
+            "proxy_channels": registry,
+            "trust_agent": _Trust(),
+            "agent_metadata": {"address": host},
+        },
+        storage=None,
+        registry=None,
+        trust=None,
+        enable_ping=False,
+        transport="direct",
+    )
+
+    assert sent[-1]["type"] == wire.ATTACHED
+    endpoint = seen_while_attached[0]
+    assert endpoint is not None and endpoint.host == "127.0.0.1"
+    assert registry.endpoint_for(keys["laptop"]["address"]) is None

--- a/tests/unit/test_proxy_channel.py
+++ b/tests/unit/test_proxy_channel.py
@@ -140,13 +140,17 @@ async def test_detaching_ends_every_open_stream(keys):
 
     pair = _Pair(keys, dialer=to_echo, allowed_ports=(port,))
     reader, _writer = await pair.host.dial(NumericEndpoint(socket.AF_INET, "8.8.8.8", port), 5)
+    # The socket dropping is what detaches both ends at once.
     await pair.host.close()
-    server.close()
-    await server.wait_closed()
+    await pair.laptop._abandon_streams()
 
     assert await asyncio.wait_for(reader.read(), timeout=5) == b""
     with pytest.raises(OSError, match="detached"):
         await pair.host.resolve("example.com", 443)
+    assert not pair.laptop._streams
+    # Python ≥ 3.12 waits for every connection here; the laptop's must be gone.
+    server.close()
+    await asyncio.wait_for(server.wait_closed(), timeout=5)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_egress.py
+++ b/tests/unit/test_proxy_egress.py
@@ -4,34 +4,18 @@ import asyncio
 import base64
 import json
 import os
-import socket
 import stat
 
 import pytest
 
-from connectonion.network.host.egress_gateway import EgressGateway
+from connectonion import address
+from connectonion.network.host.egress_gateway import EgressGateway, GatewayRefusal
 from connectonion.network.proxy_egress import (
-    ProxyEgressService,
-    local_egress_address,
+    ProxyShare,
+    ShareEndpoint,
     remote_proxy_dialer,
     remote_proxy_resolver,
-    shared_egress_gateway,
 )
-
-
-async def _origin(response=b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi"):
-    """A destination that records the address its caller arrived from."""
-    seen = []
-
-    async def handler(reader, writer):
-        seen.append(writer.get_extra_info("peername")[0])
-        await reader.read(2048)
-        writer.write(response)
-        await writer.drain()
-        writer.close()
-
-    server = await asyncio.start_server(handler, "127.0.0.1", 0)
-    return server, server.sockets[0].getsockname()[1], seen
 
 
 def _auth(endpoint) -> str:
@@ -44,29 +28,26 @@ def test_proxy_registry_is_atomic_and_private(tmp_path, monkeypatch):
 
     path = tmp_path / ".co" / "proxy-shares.json"
     monkeypatch.setattr(proxy_commands, "STATE_PATH", path)
-    proxy_commands._save({"0xtest": {"password": "secret"}})
+    proxy_commands._save({"0xtest": {"state": "attached"}})
 
-    assert json.loads(path.read_text()) == {"0xtest": {"password": "secret"}}
+    assert json.loads(path.read_text()) == {"0xtest": {"state": "attached"}}
     if os.name != "nt":
         assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
 
-@pytest.mark.asyncio
-async def test_the_share_listens_where_a_peer_can_reach_it():
-    """A browser on another machine has to be able to connect.
+def test_a_share_signs_a_grant_the_host_can_hold():
+    """The grant is what the host checks; it must name that host and be signed
+    by this computer, or an attach from anyone else with the grant in hand would
+    be accepted."""
+    laptop, host = address.generate(), address.generate()
+    share = ProxyShare(host["address"], keys=laptop, ttl=60)
 
-    The host-private gateway binds loopback on purpose — nothing outside that
-    machine may drive the browser's proxy. A share is the opposite: it exists
-    to be reached from elsewhere, and one bound to loopback is reachable by
-    nothing and would fail only once a remote agent tried to use it.
-    """
-    async with ProxyEgressService() as share:
-        endpoint = share.endpoint
-        assert endpoint.host == local_egress_address()
-        assert endpoint.host != "127.0.0.1"
-        assert endpoint.url == f"http://{endpoint.host}:{endpoint.port}"
-        # The credential is not in the address handed to the peer.
-        assert endpoint.password not in endpoint.url
+    grant = share._grant()
+    assert grant["holder"] == host["address"]
+    assert grant["grantor"] == laptop["address"]
+    assert grant["expires_at"].endswith("Z")
+    # Re-minted on every reconnect, but never with a later expiry.
+    assert share._grant()["expires_at"] == grant["expires_at"]
 
 
 @pytest.mark.asyncio
@@ -78,34 +59,12 @@ async def test_a_share_still_refuses_the_sharer_s_own_network():
     connection is not offering their router, their NAS, or whatever else
     answers on their LAN.
     """
-    async with ProxyEgressService(bind_host="127.0.0.1") as share:
-        endpoint = share.endpoint
-        reader, writer = await asyncio.open_connection(endpoint.host, endpoint.port)
-        writer.write(
-            (
-                "CONNECT 192.168.0.1:80 HTTP/1.1\r\nHost: 192.168.0.1:80\r\n"
-                f"Proxy-Authorization: {_auth(endpoint)}\r\n\r\n"
-            ).encode("ascii")
-        )
-        await writer.drain()
-        response = await asyncio.wait_for(reader.read(200), timeout=5)
-        writer.close()
+    share = ProxyShare(address.generate()["address"], keys=address.generate())
 
-    assert b"403" in response
-    assert b"DESTINATION_ADDRESS_DENIED" in response
-
-
-@pytest.mark.asyncio
-async def test_an_unauthenticated_neighbour_cannot_use_the_share():
-    async with ProxyEgressService(bind_host="127.0.0.1") as share:
-        endpoint = share.endpoint
-        reader, writer = await asyncio.open_connection(endpoint.host, endpoint.port)
-        writer.write(b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
-        await writer.drain()
-        response = await asyncio.wait_for(reader.read(200), timeout=5)
-        writer.close()
-
-    assert b"407" in response
+    with pytest.raises(GatewayRefusal, match="DESTINATION_ADDRESS_DENIED"):
+        await share._policy.connect_destination("192.168.0.1", 80)
+    with pytest.raises(GatewayRefusal, match="DESTINATION_ADDRESS_DENIED"):
+        await share._policy.connect_destination("127.0.0.1", 443)
 
 
 @pytest.mark.asyncio
@@ -113,58 +72,11 @@ async def test_laptop_dns_refuses_a_name_that_resolves_into_its_lan():
     async def private_answer(_host, _port):
         return ("192.168.0.1",)
 
-    async with ProxyEgressService(
-        bind_host="127.0.0.1", resolver=private_answer
-    ) as share:
-        resolve = remote_proxy_resolver(share.endpoint)
-        with pytest.raises(OSError, match="refused remote DNS"):
-            await resolve("public-looking.example.net", 443)
-
-
-@pytest.mark.asyncio
-async def test_traffic_leaves_through_the_share_rather_than_the_host():
-    """The end-to-end property: the destination sees the sharer, not the host.
-
-    Both hops are real here — a host-private gateway whose dialer is the share,
-    and a share that dials the destination. What proves it is the origin's own
-    record of who connected to it, and the share's request counter moving.
-    """
-    origin, port, seen = await _origin()
-
-    async def to_origin(endpoint, timeout):
-        # Stands in for the sharer's own internet: the share dials out from
-        # this machine, and the origin records who arrived.
-        assert endpoint.address == "8.8.8.8", endpoint
-        return await asyncio.open_connection("127.0.0.1", port)
-
-    async def public(host, port_):
-        return ("8.8.8.8",)
-
-    async with ProxyEgressService(
-        bind_host="127.0.0.1", resolver=public, dialer=to_origin
-    ) as share:
-        gateway = shared_egress_gateway(share.endpoint, allowed_ports=(80, 443))
-        endpoint = await gateway.start()
-        try:
-            reader, writer = await asyncio.open_connection(endpoint.host, endpoint.port)
-            writer.write(
-                (
-                    "GET http://example.com/ HTTP/1.1\r\n"
-                    "Host: example.com\r\n"
-                    f"Proxy-Authorization: {_auth(endpoint)}\r\n\r\n"
-                ).encode("ascii")
-            )
-            await writer.drain()
-            await asyncio.wait_for(reader.read(400), timeout=5)
-            writer.close()
-        finally:
-            await gateway.stop()
-            origin.close()
-            await origin.wait_closed()
-        # The share decided the request too — the policy applies on both hops,
-        # so a host cannot reach through a share to somewhere the share refuses.
-        assert share.handled_requests >= 1, "the host did not go through the share"
-    assert seen, "the destination was never reached"
+    share = ProxyShare(
+        address.generate()["address"], keys=address.generate(), resolver=private_answer
+    )
+    with pytest.raises(GatewayRefusal, match="DESTINATION_ADDRESS_DENIED"):
+        await share._policy.resolve_destination("public-looking.example.net", 443)
 
 
 @pytest.mark.asyncio
@@ -189,7 +101,6 @@ async def test_dns_runs_on_the_laptop_then_the_host_asks_for_one_numeric_address
 
     fake_share = await asyncio.start_server(recorder, "127.0.0.1", 0)
     port = fake_share.sockets[0].getsockname()[1]
-    from connectonion.network.proxy_egress import ShareEndpoint
 
     share = ShareEndpoint("127.0.0.1", port, "u", "p")
     gateway = EgressGateway(
@@ -221,89 +132,16 @@ async def test_dns_runs_on_the_laptop_then_the_host_asks_for_one_numeric_address
     assert connect_line == "CONNECT 8.8.8.8:443 HTTP/1.1"
 
 
-def test_the_reachable_address_is_not_loopback():
-    address = local_egress_address()
-    assert address != "127.0.0.1"
-    socket.inet_aton(address)
+def test_the_share_command_needs_an_identity_to_sign_with(tmp_path, monkeypatch, capsys):
+    """Without keys there is nothing to sign the grant with, so the command
+    says so and stops instead of dialing a host it could never attach to."""
+    import importlib
 
+    from connectonion.cli.commands import proxy_commands
 
-def test_the_share_command_serves_instead_of_reporting_and_exiting(tmp_path, monkeypatch):
-    """`co proxy share` must still be listening when it says it is sharing.
+    connect_module = importlib.import_module("connectonion.network.connect")
+    monkeypatch.setattr(proxy_commands, "STATE_PATH", tmp_path / "proxy-shares.json")
+    monkeypatch.setattr(connect_module, "_this_callers_identity", lambda: None)
 
-    The share is a socket owned by this process. Printing "sharing" and
-    returning closes it the moment the shell gets its prompt back, so every
-    later command reads a registry entry for something nothing serves — and the
-    remote browser silently falls back to failing every request. Measured that
-    way once: the command reported success and a connect to its own advertised
-    address answered ConnectionRefusedError.
-    """
-    import json
-    import subprocess
-    import sys
-    import time
-
-    home = tmp_path / "home"
-    (home / ".co").mkdir(parents=True)
-    env = {**__import__("os").environ, "HOME": str(home)}
-    process = subprocess.Popen(
-        [
-            sys.executable,
-            "-m",
-            "connectonion.cli.main",
-            "proxy",
-            "share",
-            "to",
-            "0xtest",
-            "--bind",
-            "127.0.0.1",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        env=env,
-        text=True,
-    )
-    try:
-        registry = home / ".co" / "proxy-shares.json"
-        for _ in range(100):
-            if registry.exists():
-                break
-            time.sleep(0.1)
-        assert registry.exists(), "the share never registered"
-        url = json.loads(registry.read_text())["0xtest"]["url"]
-        host, port = url.rsplit("//", 1)[1].split(":")
-
-        probe = socket.socket()
-        probe.settimeout(3)
-        try:
-            probe.connect((host, int(port)))
-        finally:
-            probe.close()
-        stopped = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "connectonion.cli.main",
-                "proxy",
-                "stop",
-                "0xtest",
-            ],
-            env=env,
-            text=True,
-            capture_output=True,
-            timeout=15,
-        )
-        assert stopped.returncode == 0, stopped.stdout + stopped.stderr
-        process.wait(timeout=15)
-        refused = socket.socket()
-        refused.settimeout(1)
-        with pytest.raises(OSError):
-            refused.connect((host, int(port)))
-        refused.close()
-    finally:
-        if process.poll() is None:
-            process.terminate()
-            process.wait(timeout=15)
-
-    # And a stopped share does not stay in the registry claiming to be live.
-    remaining = json.loads(registry.read_text()) if registry.exists() else {}
-    assert "0xtest" not in remaining
+    assert proxy_commands._share("0xtest", False, None) == 2
+    assert "co init" in capsys.readouterr().err

--- a/tests/unit/test_proxy_egress.py
+++ b/tests/unit/test_proxy_egress.py
@@ -50,6 +50,43 @@ def test_a_share_signs_a_grant_the_host_can_hold():
     assert share._grant()["expires_at"] == grant["expires_at"]
 
 
+class _Socket:
+    """A host that pushes its profile before answering the attach."""
+
+    def __init__(self, frames):
+        self.frames = list(frames)
+        self.sent = []
+
+    async def recv(self):
+        return json.dumps(self.frames.pop(0))
+
+    async def send(self, raw):
+        self.sent.append(json.loads(raw))
+
+
+@pytest.mark.asyncio
+async def test_the_attach_answer_is_read_past_the_hosts_other_frames():
+    """A real host sends AGENT_PROFILE (and pings) right after CONNECTED. The
+    first frame after PROXY_ATTACH is not the answer; the first PROXY_ATTACHED
+    or ERROR is. Taking the profile as a refusal broke the very first
+    two-machine run."""
+    laptop, host = address.generate(), address.generate()
+    share = ProxyShare(host["address"], keys=laptop, ttl=60)
+    ws = _Socket([
+        {"type": "AGENT_PROFILE", "name": "host"},
+        {"type": "PING"},
+        {"type": "PROXY_ATTACHED", "expires_at": "2030-01-01T00:00:00Z"},
+    ])
+
+    reply = await share._attach_reply(ws)
+
+    assert reply["type"] == "PROXY_ATTACHED"
+    assert ws.sent == [{"type": "PONG"}]
+
+    refused = _Socket([{"type": "AGENT_PROFILE"}, {"type": "ERROR", "message": "proxy attach refused: no"}])
+    assert (await share._attach_reply(refused))["message"] == "proxy attach refused: no"
+
+
 @pytest.mark.asyncio
 async def test_a_share_still_refuses_the_sharer_s_own_network():
     """Lending a connection must not lend the network behind it.

--- a/tests/unit/test_proxy_share_e2e.py
+++ b/tests/unit/test_proxy_share_e2e.py
@@ -1,0 +1,163 @@
+"""A laptop share attached over a real WebSocket, carrying a real request.
+
+Everything that runs in production runs here, in one process: the host's
+`run_ws_session` behind a `websockets` server, `ProxyShare` dialing it with a
+signed CONNECT and PROXY_ATTACH, the host-private `EgressGateway` fed by the
+attached channel, and a browser stand-in doing an HTTP GET through that
+gateway. The bytes go host → laptop → origin and back; the origin records who
+arrived. Only the laptop's DNS and dial are stubbed, so the "internet" is a
+local socket.
+"""
+
+import asyncio
+import base64
+import json
+
+import pytest
+import websockets
+
+from connectonion import address
+from connectonion.network.host.proxy_channel import ProxyChannelRegistry
+from connectonion.network.host.ws_router import session
+from connectonion.network.proxy_egress import ProxyShare, shared_egress_gateway
+
+pytestmark = pytest.mark.slow
+
+
+class _Trust:
+    def is_admin(self, _address):
+        return False
+
+    def get_level(self, _address):
+        return "contact"
+
+
+async def _serve_host(host_keys, registry, monkeypatch, laptop_address):
+    async def fake_connect(data, send, conn, *args):
+        conn.update(
+            authenticated=True,
+            agent_address=laptop_address,
+            signed_commands=True,
+            recipient_address=host_keys["address"],
+            session_id="oip-session",
+        )
+        await send({"type": "CONNECTED"})
+
+    monkeypatch.setattr(session, "handle_connect", fake_connect)
+
+    async def handler(ws):
+        async def recv():
+            try:
+                return json.loads(await ws.recv())
+            except websockets.exceptions.ConnectionClosed:
+                return None
+
+        async def send(message):
+            await ws.send(json.dumps(message))
+
+        await session.run_ws_session(
+            send,
+            recv,
+            route_handlers={
+                "proxy_channels": registry,
+                "trust_agent": _Trust(),
+                "agent_metadata": {"address": host_keys["address"]},
+            },
+            storage=None,
+            registry=None,
+            trust=None,
+            enable_ping=False,
+            transport="direct",
+        )
+
+    return await websockets.serve(handler, "127.0.0.1", 0)
+
+
+async def _origin():
+    seen = []
+
+    async def handler(reader, writer):
+        seen.append(writer.get_extra_info("peername")[0])
+        await reader.readuntil(b"\r\n\r\n")
+        writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 14\r\nConnection: close\r\n\r\nthrough laptop")
+        await writer.drain()
+        writer.close()
+
+    server = await asyncio.start_server(handler, "127.0.0.1", 0)
+    return server, server.sockets[0].getsockname()[1], seen
+
+
+async def _get_through(endpoint) -> bytes:
+    reader, writer = await asyncio.open_connection(endpoint.host, endpoint.port)
+    auth = base64.b64encode(f"{endpoint.username}:{endpoint.password}".encode()).decode()
+    writer.write(
+        (
+            "GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n"
+            f"Proxy-Authorization: Basic {auth}\r\nConnection: close\r\n\r\n"
+        ).encode("ascii")
+    )
+    await writer.drain()
+    response = await asyncio.wait_for(reader.read(), timeout=10)
+    writer.close()
+    return response
+
+
+async def _until(condition, timeout=10):
+    async def poll():
+        while not condition():
+            await asyncio.sleep(0.02)
+
+    await asyncio.wait_for(poll(), timeout=timeout)
+
+
+@pytest.mark.asyncio
+async def test_a_page_fetched_on_the_host_leaves_from_the_laptop(monkeypatch):
+    laptop, host = address.generate(), address.generate()
+    registry = ProxyChannelRegistry()
+    ws_server = await _serve_host(host, registry, monkeypatch, laptop["address"])
+    ws_port = ws_server.sockets[0].getsockname()[1]
+    origin, origin_port, seen = await _origin()
+
+    async def laptop_dns(name, port):
+        return ("8.8.8.8",)
+
+    async def laptop_dial(endpoint, timeout):
+        assert endpoint.address == "8.8.8.8"
+        return await asyncio.open_connection("127.0.0.1", origin_port)
+
+    states = []
+    share = ProxyShare(
+        host["address"],
+        keys=laptop,
+        ttl=60,
+        resolver=laptop_dns,
+        dialer=laptop_dial,
+        on_state=lambda state, detail: states.append((state, detail)),
+    )
+    # No relay lookup in a test: the host is right here.
+    share.remote._resolved_endpoint = f"ws://127.0.0.1:{ws_port}"
+    share.remote._endpoint_resolved = True
+
+    stop = asyncio.Event()
+    serving = asyncio.create_task(share.serve(stop))
+    await _until(lambda: registry.endpoint_for(laptop["address"]) is not None)
+
+    gateway = shared_egress_gateway(registry.endpoint_for(laptop["address"]), allowed_ports=(80,))
+    endpoint = await gateway.start()
+    try:
+        response = await _get_through(endpoint)
+    finally:
+        await gateway.stop()
+
+    stop.set()
+    await asyncio.wait_for(serving, timeout=10)
+    await _until(lambda: registry.endpoint_for(laptop["address"]) is None)
+    ws_server.close()
+    await ws_server.wait_closed()
+    origin.close()
+    await origin.wait_closed()
+
+    assert response.endswith(b"through laptop"), response
+    assert seen == ["127.0.0.1"], "the origin was not reached from the laptop side"
+    assert share.handled_requests >= 2, "resolve and connect both go to the laptop"
+    assert [state for state, _ in states] == ["connecting", "attached", "stopped"]

--- a/tests/unit/test_remote_browser_service.py
+++ b/tests/unit/test_remote_browser_service.py
@@ -1,8 +1,22 @@
 import json
 
 from connectonion.network.host.remote_browser import RemoteBrowserService
+from connectonion.network.proxy_egress import ShareEndpoint
 
 UNSET = object()
+
+
+class AttachedShare:
+    """What the registry holds once a laptop's `co proxy share` has attached:
+    the loopback gateway the host opened for that laptop's channel."""
+
+    def __init__(self, owner, port=43123, password="secret-value"):
+        self.owner = owner
+        self.endpoint = ShareEndpoint("127.0.0.1", port, "laptop", password)
+
+
+def attach(remote, owner, **kwargs):
+    remote.proxy_channels.attach(AttachedShare(owner, **kwargs))
 
 
 class Daemon:
@@ -134,11 +148,11 @@ def test_relay_fails_before_daemon_or_registry_mutation(tmp_path):
 
 def test_non_direct_proxy_and_navigation_are_not_silently_enabled(tmp_path):
     remote, daemon = service(tmp_path)
-    # `shared` is a real mode now, but it cannot be assumed: the caller's share
-    # endpoint has to arrive with the request, because only the caller knows
-    # where its own connection is reachable. Asking for shared egress without
-    # one must not quietly fall back to this host's address — that would send
-    # traffic from the data centre while the caller believed it left from home.
+    # `shared` is a real mode now, but it cannot be assumed: the caller's
+    # computer has to be attached to this host (`co proxy share`) first. Asking
+    # for shared egress without one must not quietly fall back to this host's
+    # address — that would send traffic from the data centre while the caller
+    # believed it left from home.
     shared = remote.handle(
         request("start", args={"proxy": "shared"}),
         owner="0xalice",
@@ -154,7 +168,8 @@ def test_non_direct_proxy_and_navigation_are_not_silently_enabled(tmp_path):
         owner="0xalice",
         transport="direct",
     )
-    assert shared["code"] == "REMOTE_SESSION_SHARE_MISSING"
+    assert shared["code"] == "REMOTE_SESSION_PROXY_NOT_ATTACHED"
+    assert shared["next_actions"][0]["command"] == "co proxy share"
     assert unknown["code"] == "REMOTE_SESSION_PROXY_LOCKED"
     assert navigation["code"] == "INVALID_ARGUMENT"
     assert daemon.calls == []
@@ -164,14 +179,11 @@ def test_shared_start_pins_the_laptop_proxy_without_persisting_its_secret(tmp_pa
     daemon = Daemon()
     remote = RemoteBrowserService(tmp_path / "sessions.json")
     remote.daemon_request = daemon
-    share = {
-        "url": "http://192.0.2.10:43123",
-        "username": "laptop",
-        "password": "secret-value",
-    }
+    attach(remote, "0xalice")
+    attach(remote, "0xbob", port=43999, password="bobs")
 
     started = remote.handle(
-        request("start", args={"proxy": "shared", "share": share}),
+        request("start", args={"proxy": "shared"}),
         owner="0xalice",
         transport="direct",
     )
@@ -184,8 +196,9 @@ def test_shared_start_pins_the_laptop_proxy_without_persisting_its_secret(tmp_pa
     assert session["proxy_mode"] == "shared"
     assert len(session["proxy_binding"]) == 64
     assert "secret-value" not in repr(saved)
+    # The browser is pointed at the caller's own share, on this host's loopback.
     config = json.loads(remote.daemon_target.shared_proxy_path.read_text())
-    assert config["host"] == "192.0.2.10"
+    assert config["host"] == "127.0.0.1"
     assert config["port"] == 43123
     assert config["password"] == "secret-value"
 
@@ -210,18 +223,9 @@ def test_failed_first_shared_start_leaves_no_stale_proxy_selection(tmp_path):
         return 1, "browser rejected start"
 
     remote.daemon_request = rejected
+    attach(remote, "0xalice")
     result = remote.handle(
-        request(
-            "start",
-            args={
-                "proxy": "shared",
-                "share": {
-                    "url": "http://192.0.2.10:43123",
-                    "username": "laptop",
-                    "password": "secret-value",
-                },
-            },
-        ),
+        request("start", args={"proxy": "shared"}),
         owner="0xalice",
         transport="direct",
     )
@@ -234,19 +238,9 @@ def test_failed_first_shared_start_leaves_no_stale_proxy_selection(tmp_path):
 def test_one_wtf_runtime_cannot_mix_direct_and_shared_sessions(tmp_path):
     remote, daemon = service(tmp_path)
     first = remote.handle(request("start"), owner="0xalice", transport="direct")
+    attach(remote, "0xbob")
     second = remote.handle(
-        request(
-            "start",
-            request_id="req-shared",
-            args={
-                "proxy": "shared",
-                "share": {
-                    "url": "http://192.0.2.10:43123",
-                    "username": "u",
-                    "password": "p",
-                },
-            },
-        ),
+        request("start", request_id="req-shared", args={"proxy": "shared"}),
         owner="0xbob",
         transport="direct",
     )


### PR DESCRIPTION
- **Proposed target version:** 1.8.0b1
- **Estimated release window:** next beta, after the two-machine acceptance

Closes #1036 (cross-network part).

## Problem

`co proxy share` listened on the laptop and told the host its address. Behind home NAT that address is unreachable, so the share only ever worked when both machines sat on one network. The machine that can never accept a connection is the laptop.

## Change

The laptop dials **out** to the host over the ordinary direct WebSocket, attaches with a grant (`network/proxy/grants.py`, previously unwired), and stays on the socket. The host multiplexes its resolver/dialer calls down that socket as `PROXY_STREAM` frames.

- `network/proxy/stream.py` — wire format: `PROXY_ATTACH`, `PROXY_ATTACHED`, `PROXY_STREAM` with ops `resolve | connect | data | eof | close | error`; bounds `MAX_STREAMS=64`, 32 KiB per data frame.
- `host/proxy_channel.py` — `ProxyChannel`: an `EgressGateway` on host loopback whose resolver/dialer are the channel, exposed as a `ShareEndpoint`; enforces `expires_at`, `max_bytes`, stream bound; `close()` fails every open stream (`PROXY_DETACHED`). `ProxyChannelRegistry` keyed by laptop address.
- `host/ws_router/proxy.py` — attach refused unless: authenticated, signed commands, `transport == "direct"`, trust ≥ contact, grant verifies with the host as holder, grantor == socket identity. Detached in the session `finally`.
- `host/remote_browser.py` — `start --proxy shared` looks up the caller's own channel; none → `REMOTE_SESSION_PROXY_NOT_ATTACHED` with next action `co proxy share`. The `share` dict in the request is gone.
- `host/egress_gateway.py` — `resolve_destination` / `connect_destination`: the same policy without a listener, used by the laptop end.
- `network/proxy_egress.py` — `ProxyShare` (dial, CONNECT, attach, serve, reconnect with 1 s→60 s backoff, fixed expiry across reconnects) replaces `ProxyEgressService`.
- `co proxy share`: `--bind` removed (nothing listens); `--ttl` default 24 h; `status`/`diagnose` report `connecting | attached | reconnecting` and whether the process is alive.

Unchanged: the host-private browser gateway, the daemon, pinned `shared-proxy.json`, double classification, `transport != "direct"` gate, DD-056 fail-closed rule. Host→laptop frames are unsigned (TLS to a verified endpoint); laptop→host frames are signed like every command.

## Tests

- `tests/unit/test_proxy_channel.py` (9), `tests/unit/test_proxy_share_e2e.py` (1, `slow`: real `run_ws_session` behind `websockets.serve`, real `EgressGateway` both ends, origin sees the laptop side).
- Updated `test_proxy_egress.py`, `test_remote_browser_service.py`, `test_cli_remote_browser.py`, `tests/e2e/test_native_egress_preflight_real_driver.py`.
- Red before: both new files fail at collection on the base commit and 5 modified tests fail; all green after. Unit suite: 7256 passed.

## Not in this PR

The two-machine acceptance (GCP host + Mac behind home NAT, no ports, no VPN): site sees the Mac's IP, DNS resolved on the Mac, stopping the share cuts the browser's network rather than falling back. That run gates `1.8.0b1`, not this merge; results will be posted on #1036.

Design journal: `docs/blog/2026-09-02-the-laptop-dials-out.md`.
