### PR TITLE
docs: record the two-machine Remote Browser measurement

### DIFF
--- a/docs/blog/2026-09-02-a-release-talks-to-production.md
+++ b/docs/blog/2026-09-02-a-release-talks-to-production.md
@@ -31,10 +31,23 @@ repository yet, so a compatibility layer would have been code protecting nobody.
 The production catalogue simply gained one entry, and ConnectOnion's pin moved
 from 0.0.12 to 0.0.13.
 
-## What it enables
+## Measured
 
 The two-machine Remote Browser acceptance — a laptop behind a home router
-lending its connection to a browser on a GCP host — was stuck at exactly this
-point: attached, session started, page blocked. With a client that can pay, the
-next step is the one the whole feature is about: the page's traffic leaving from
-the laptop's address.
+lending its connection to a browser on a GCP host — had been stuck at exactly
+this point: attached, session started, page blocked. With a client that can
+pay, the run went through in one sitting:
+
+```text
+Mac egress            129.94.43.159
+host egress           35.229.135.74
+tab → api.ipify.org   129.94.43.159
+tab → ifconfig.me/ip  129.94.43.159
+co proxy stop; reload ERR_TUNNEL_CONNECTION_FAILED
+/api/v1/usage         total_cost_usd: 0.025
+```
+
+The last two lines are the ones worth keeping. Stopping the share breaks the
+tab instead of quietly sending it out of the data centre, and a session that
+lived a few minutes cost exactly one interval. The docs now carry this run in
+place of the earlier same-network figure.

--- a/docs/network/remote-browser.md
+++ b/docs/network/remote-browser.md
@@ -54,8 +54,11 @@ you, so this works from behind any home or office NAT. The share is keyed by
 your identity on the host — `start --proxy shared` from the same identity
 finds it by itself, and nothing about it travels in the start request.
 
-Measured on a Google Cloud server egressing through a laptop in Sydney: the
-server's own address is `34.21.243.229`, and the site saw `129.94.43.159`.
+Measured 2026-09-02 on a Google Cloud server (`35.229.135.74`) with the paid
+Onion engine, egressing through a laptop behind a home NAT in Sydney:
+`https://api.ipify.org` and `https://ifconfig.me/ip` both saw `129.94.43.159`.
+After `co proxy stop` the same tab got `ERR_TUNNEL_CONNECTION_FAILED` — no
+fallback to the server's address. The session cost one interval, $0.025.
 
 `--proxy direct` (the default) keeps the host on its own connection. Asking for
 `shared` while your computer is not attached answers


### PR DESCRIPTION
Replaces the earlier same-network figure with today's cross-NAT run on the paid engine (Onionwright 0.0.13): two sites saw the laptop's address, and stopping the share broke the tab instead of falling back. Evidence in #1036.

**Proposed target version:** 1.8.0b1
**Estimated release window:** this week