### PR TITLE
feat: backport canonical oo useful skill to 1.7.2

### DIFF
--- a/connectonion/cli/commands/copy_commands.py
+++ b/connectonion/cli/commands/copy_commands.py
@@ -104,6 +104,7 @@ SKILLS = {
     "co-mail-and-drive": "co-mail-and-drive",
     "commit": "commit",
     "install-connectonion": "install-connectonion",
+    "oo": "oo",
     "review-pr": "review-pr",
     "ship-feature": "ship-feature",
 }

--- a/connectonion/cli/commands/sub_commands.py
+++ b/connectonion/cli/commands/sub_commands.py
@@ -299,9 +299,10 @@ def _resolve_target(target: str) -> tuple[str, Optional[str]]:
         if alias == target:
             return addr, alias
     console.print(
-        f"[red]'{target}' is not a 0x address and I don't have it in subscriptions.txt.[/red]\n"
-        "Alias resolution on the relay isn't available yet — paste the full 0x address."
+        f"[red]'{target}' is not a 0x address and I don't have it in subscriptions.txt.[/red]"
     )
+    console.print("Get the full address from the publisher, then run:")
+    console.print("  [cyan]co sub sync <0xaddress>[/cyan]")
     raise SystemExit(1)
 
 
@@ -373,7 +374,8 @@ def handle_sub_list() -> None:
     """Show ~/.co/subscriptions.txt with local version info."""
     subs = _read_subs()
     if not subs:
-        console.print(f"\n[dim]No subscriptions. Subscribe with `co sub 0x...`[/dim]\n")
+        console.print("\n[dim]No subscriptions.[/dim]")
+        console.print("Follow one with: [cyan]co sub sync <0xaddress>[/cyan]\n")
         return
 
     table = Table(title="Subscriptions", show_lines=False, header_style="bold")
@@ -403,6 +405,7 @@ def handle_sub_remove(target: str) -> None:
     match = next(((a, al) for a, al in subs if a == target or al == target), None)
     if match is None:
         console.print(f"[yellow]Not subscribed to '{target}'.[/yellow]")
+        console.print("See local subscriptions: [cyan]co sub list[/cyan]")
         return
     address, alias = match
 

--- a/connectonion/useful_skills/oo/SKILL.md
+++ b/connectonion/useful_skills/oo/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: oo
+description: Connect to a remote ConnectOnion agent, set up a publishable identity, publish selected skills, or follow and sync another publisher. Use for a 0x agent address, /oo, co announce, or co sub workflows; not for ordinary local-agent tasks.
+---
+
+# Connect, publish, and follow with `oo`
+
+Route the request before running anything:
+
+| User wants | Action |
+|---|---|
+| Ask or delegate to a remote `0x...` agent | Use the Connect flow |
+| Create the global identity and skill library | Use Setup |
+| Share selected local skills | Use Publish |
+| Follow a publisher for the first time | Run `co sub sync <0xaddress>` |
+| Refresh one already-pinned publisher | Run `co sub sync <address-or-local-alias>` |
+| Refresh everyone | Run `co sub` |
+| See or remove subscriptions | Run `co sub list` or `co sub remove <address-or-local-alias>` |
+| Accept or reject a follower | Explain that public subscriptions have no publisher-approval step |
+
+## Keep the protocol layers straight
+
+- OIP is the live, authenticated Agent protocol: CONNECT, INPUT, EXEC, events,
+  OUTPUT, session ownership, modes, approvals, and cancellation.
+- ANNOUNCE publishes a signed public profile to the relay. `co announce` adds a
+  portable `profile-v2` signature and monotonic revision.
+- `co sub` is a local pull/sync relationship. It is not a SUBSCRIBE message,
+  push channel, access-control handshake, or proof that the content is safe.
+
+Do not recreate HTTP endpoints, signing, profile verification, rollback state,
+or fan-out in ad-hoc Python. The `co` CLI owns those details.
+
+## Connect
+
+Require one exact 66-character address (`0x` plus 64 hex characters) and a task.
+Use the installed SDK; it already probes safe direct endpoints and falls back to
+the relay:
+
+```python
+from connectonion import connect
+
+remote = connect("0x...")
+response = remote.input("the user's task", timeout=300)
+print(response.text)
+print("done=", response.done)
+```
+
+`connect()` uses the current project's identity, then `~/.co`. If neither
+identity exists, tell the user to run `co init` for a project identity or Setup
+below for a global publishable identity. Never generate an identity silently.
+
+When `response.done` is false, return the remote question to the user. Keep the
+same `remote` object for the answer when the execution environment supports a
+persistent Python process. Otherwise include the prior question and answer in a
+new request; do not pretend the old session was resumed.
+
+## Setup
+
+Ask for or infer a lowercase alias and a useful one-line bio, then show the exact
+command before running it:
+
+```bash
+co setup --name <alias> --bio "<one-line bio>"
+```
+
+`co setup` creates or refreshes the global `~/.co/` identity, profile, and skill
+library. If `~/.co/agent.json` already exists, do not use `--force` until the
+user sees the conflicting alias/bio; the command backs up the file, but it still
+replaces the active profile.
+
+## Publish
+
+Publishing is public. Before changing any `publish` flag, inspect
+`~/.co/agent.json` and the corresponding `~/.co/skills/<name>/SKILL.md` files.
+
+Only publish a skill now when all of these are true:
+
+- its `SKILL.md` is useful and self-contained without `scripts/`, `references/`,
+  `assets/`, local private files, or undisclosed MCP/app dependencies;
+- it contains no secrets, customer data, private contacts, machine-specific
+  paths, or personal instructions that should stay local;
+- it preserves user authorization at the action boundary and does not treat the
+  publisher's permission preferences as the subscriber's permission;
+- its name and description are meaningful when shown publicly.
+
+Current distribution carries only `SKILL.md`. A skill that needs sibling files
+is not portable yet; leave it unpublished rather than shipping a broken copy.
+
+Important visibility rule: every skill's name and description are listed in the
+public profile. `publish: true` controls whether its full `SKILL.md` body is also
+public. `publish: false` does not make the metadata private.
+
+After the user approves the exact bodies, change only their existing
+`agent.json.skills[].publish` values. Then validate and publish:
+
+```bash
+co announce --dry-run
+co announce
+```
+
+Read the dry-run payload and confirm the alias, bio, listed skill count, public
+body count, names, and absence of private content. `co announce` creates the
+signed revision; a human-readable `version` is display metadata, not the
+rollback mechanism.
+
+Give the publisher's full `0x` address to subscribers through a trusted channel.
+Do not tell first-time subscribers to resolve an alias.
+
+## Follow and sync
+
+First-time follow requires the publisher's full address:
+
+```bash
+co sub sync <0xaddress>
+```
+
+The command fetches the public profile and bodies, verifies the publisher's
+`profile-v2` signature against that pinned address, rejects rollback or
+equivocation, mirrors the bundle under `~/.co/subs/`, removes a subscribed
+skill's `tools:` grant, and fans it out to detected coding agents.
+
+After the first valid sync, the signed alias is stored locally and may be used as
+a refresh shortcut:
+
+```bash
+co sub sync <local-alias>
+co sub
+co sub list
+co sub remove <address-or-local-alias>
+```
+
+The relationship is pull-based. There is no publisher accept/reject queue and no
+automatic BUNDLE_UPDATE push. Re-run `co sub` to get updates. Removing a
+subscription deliberately retains `~/.co/subscription-state/<address>.json` so
+unsubscribe/resubscribe cannot erase rollback memory.
+
+If the command installs anything into a coding agent, tell the user to restart
+that agent. If it says only that bodies were mirrored or no skills were
+installed, do not claim a restart is required.
+
+## Trust and recovery
+
+- A valid signature proves who published the bytes, not that the instructions
+  are safe, high quality, compatible, or appropriate for the user's machine.
+- If a first-time target is an alias, obtain the full address out of band and run
+  `co sub sync <0xaddress>`.
+- If a profile is unsigned or `profile-v1`, the publisher must update
+  ConnectOnion and run `co announce` again.
+- On rollback or equivocation, do not delete the local watermark. Verify with the
+  publisher; intentional old content must be re-announced at a higher revision.
+- `co sub list` with no entries and `co sub remove` for an unknown target are
+  successful no-op outcomes, so read their output rather than inferring state
+  only from exit code.

--- a/docs/blog/2026-09-01-a-follow-button-is-not-a-handshake.md
+++ b/docs/blog/2026-09-01-a-follow-button-is-not-a-handshake.md
@@ -1,0 +1,57 @@
+# A Follow Button Is Not a Handshake
+
+The awkward bug was not in the subscription code. It was in the instructions
+that told an Agent what the subscription code meant.
+
+Our old `oo` skills described a familiar social shape: ask to subscribe, wait
+for the publisher to accept, then receive updates when the publisher pushes a
+new bundle. It sounded coherent enough that an AI could confidently explain
+it. The trouble was that ConnectOnion had never implemented that protocol.
+
+The real 1.8 path has three separate layers. OIP carries a live authenticated
+conversation between Agents. `co announce` publishes a signed public profile
+and selected skill bodies. `co sub` pins a publisher address and explicitly
+pulls that profile into local storage. Those layers touch the same identity,
+but they do not have the same lifecycle or trust meaning.
+
+That distinction changes what a useful skill should do. A first follow needs
+the full `0x` address from a trusted channel; an alias is only a local shortcut
+after a signed profile has pinned it. There is no publisher inbox to accept or
+reject. There is no automatic bundle-update push. Refresh means running
+`co sub` again. A valid signature proves who published the bytes, not that the
+instructions are wise or safe to run.
+
+The audit found another boundary that was easier to miss. The current announce
+format distributes a `SKILL.md` body, not an arbitrary skill directory. A skill
+that depends on sibling scripts, reference files, assets, machine paths, or an
+undeclared application can look complete on the publisher's computer and arrive
+broken everywhere else. The new workflow therefore treats portability as a
+publication gate: self-contained files can be reviewed and shared; everything
+else stays private for now.
+
+Metadata has its own sharp edge. Every configured skill name and description is
+part of the public profile. The `publish` flag decides whether the full body is
+included; it does not hide the metadata. That sentence now sits beside the
+publication steps because a privacy boundary is useful only where the decision
+is made.
+
+We consolidated the workflow into one canonical `oo` useful skill and made it
+installable with `co copy oo`. The skill delegates networking, signatures,
+rollback protection, and fan-out to the SDK and CLI instead of copying protocol
+snippets into instructions that can drift. We also corrected three CLI tips so
+their suggested next commands are literal commands that work, including when
+output is piped into another Agent.
+
+The proof was deliberately broader than a prose review. The skill validator and
+97 focused protocol, copy, announce, and fan-out tests passed. Another 7,042
+unit tests passed after excluding seven files whose socket and user-home access
+is unavailable in the review sandbox. More importantly, regression tests now
+fail if the skill reintroduces the invented approval endpoints or stops naming
+the actual 1.8 commands.
+
+Documentation for an Agent is executable product surface. If it invents a
+state transition, the model will often make that fiction sound more certain
+than a normal command-line typo. The durable fix is not more elaborate prose.
+It is one owner for the workflow, explicit boundaries between protocols, and
+tests that keep every promised command tied to something the product really
+does.

--- a/docs/cli/sub.md
+++ b/docs/cli/sub.md
@@ -153,7 +153,7 @@ Idempotent — removing something you haven't subscribed to prints `Not subscrib
 ```
 # ~/.co/subscriptions.txt — agents you follow
 # Format: <address> <alias>
-# Managed by `co sub`. Re-run `co sub <address>` to refresh.
+# Managed by `co sub`. Re-run `co sub sync <address>` to refresh one.
 0xcd92510bb6cc090374ecc345ef8c19b9d3797624fd1fbf7e078a9372fc31bdc1 changxing
 0xabc...                                                              alice
 ```

--- a/docs/useful_skills/README.md
+++ b/docs/useful_skills/README.md
@@ -10,6 +10,7 @@ Pre-built skills you can copy into your project and invoke with `/skill-name`.
 | [cli-skill-design](cli-skill-design.md) | Design a `co <thing>` command surface and its SKILL.md together — tip-tested discoverability and self-diagnosing errors, both as checks you run | `/cli-skill-design` |
 | [co-browser](co-browser.md) | Drive one persistent, logged-in browser from the shell — solo or multi-agent | `/co-browser` |
 | [install-connectonion](install-connectonion.md) | Install & fully set up ConnectOnion so every `co` command works (init+auth→keys.env, email, browser) for a possibly non-technical user — auto-corrects, ends with a plain-language summary | `/install-connectonion` |
+| [oo](oo.md) | Connect to remote Agents, publish selected self-contained skills, and follow signed publisher profiles without confusing OIP with skill distribution | `/oo` |
 | [ship-feature](ship-feature.md) | Ship a feature end-to-end: tests → docs → docs-site → release | `/ship-feature` |
 
 ## How to Use

--- a/docs/useful_skills/oo.md
+++ b/docs/useful_skills/oo.md
@@ -1,0 +1,78 @@
+# oo
+
+Use ConnectOnion's live Agent protocol and its signed public skill distribution
+without confusing the two.
+
+## Install
+
+```bash
+co copy oo
+# → .co/skills/oo/SKILL.md
+```
+
+## Usage
+
+```text
+/oo 0x<64 hex characters> review this API design
+/oo set up my publishable identity
+/oo publish my writing skills
+/oo follow 0x<64 hex characters>
+/oo list my subscriptions
+```
+
+## What it covers
+
+The skill routes five related jobs:
+
+- connect to a remote Agent over OIP;
+- create the global `~/.co/` identity and skill library with `co setup`;
+- review and publish selected skill bodies with `co announce`;
+- follow and refresh a publisher with `co sub`;
+- list or remove local subscriptions.
+
+It deliberately keeps three layers separate:
+
+| Layer | Purpose |
+|---|---|
+| OIP | Live authenticated CONNECT, INPUT, EXEC, events, OUTPUT and session control |
+| ANNOUNCE/profile-v2 | Signed public identity, metadata, bodies and monotonic revision |
+| `co sub` | Address-pinned, verified pull/sync and local coding-agent fan-out |
+
+There is no publisher accept/reject queue and no automatic update push. A
+subscription is a locally stored publisher address plus explicit `co sub` syncs.
+
+## Shareability boundary
+
+ConnectOnion 1.8 publishes the `SKILL.md` body, not a complete skill directory.
+The workflow therefore keeps a skill private if it needs sibling scripts,
+references, assets, private files, secrets, or undeclared applications. Every
+skill's name and description are public profile metadata; `publish: true`
+controls whether the body is public as well.
+
+On sync, the CLI verifies the publisher's profile-v2 signature and monotonic
+revision before exposing content, and strips a remote `tools:` grant before
+fan-out. Authentication proves provenance, not quality or safety.
+
+## Core commands
+
+```bash
+co setup --name <alias> --bio "<one-line bio>"
+co announce --dry-run
+co announce
+
+co sub sync <0xaddress>
+co sub
+co sub list
+co sub remove <address-or-local-alias>
+```
+
+First-time follows require the full address obtained through a trusted channel.
+An alias becomes usable only after a valid profile has pinned it locally.
+
+## See also
+
+- [Skill library and manifests](../cli/skills.md)
+- [Publishing profile format](../network/protocol/announce-message.md)
+- [`co sub`](../cli/sub.md)
+- [OIP WebSocket protocol](../network/websocket-protocol.md)
+- [Built-in Skills](README.md)

--- a/tests/e2e/cli/test_cli_copy.py
+++ b/tests/e2e/cli/test_cli_copy.py
@@ -205,6 +205,19 @@ class TestCopyCommand:
             assert skill_dir.exists()
             assert (skill_dir / "SKILL.md").exists()
 
+    def test_copy_oo_installs_the_single_canonical_skill(self):
+        """The public oo workflow is one self-contained, shareable SKILL.md."""
+        from connectonion.cli.main import cli
+
+        result = self.runner.invoke(cli, ['copy', 'oo'])
+
+        assert result.exit_code == 0
+        skill_file = Path(self.test_dir) / ".co" / "skills" / "oo" / "SKILL.md"
+        assert skill_file.exists()
+        body = skill_file.read_text(encoding="utf-8")
+        assert "co announce --dry-run" in body
+        assert "co sub sync <0xaddress>" in body
+
     def test_copy_unknown_item(self):
         """Test copy shows error for unknown item."""
         from connectonion.cli.main import cli

--- a/tests/unit/test_oo_useful_skill.py
+++ b/tests/unit/test_oo_useful_skill.py
@@ -1,0 +1,43 @@
+"""The shipped oo skill must describe the protocol the 1.8 CLI actually has."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL = ROOT / "connectonion" / "useful_skills" / "oo" / "SKILL.md"
+
+
+def test_oo_is_a_single_file_skill_that_can_travel_through_co_announce():
+    assert SKILL.is_file()
+    assert sorted(path.name for path in SKILL.parent.iterdir()) == ["SKILL.md"]
+
+
+def test_oo_names_only_the_current_publish_and_subscription_cli():
+    body = SKILL.read_text(encoding="utf-8")
+
+    for command in (
+        "co setup --name <alias>",
+        "co announce --dry-run",
+        "co announce",
+        "co sub sync <0xaddress>",
+        "co sub list",
+        "co sub remove <address-or-local-alias>",
+    ):
+        assert command in body
+
+    for removed_surface in (
+        "/api/relay/agents/",
+        "/subscribe/accept",
+        "subscriptions/pending",
+        "from fanout import",
+    ):
+        assert removed_surface not in body
+
+
+def test_oo_states_the_real_publication_and_trust_boundaries():
+    body = SKILL.read_text(encoding="utf-8")
+
+    assert "publish: false` does not make the metadata private" in body
+    assert "Current distribution carries only `SKILL.md`" in body
+    assert "There is no publisher accept/reject queue" in body
+    assert "proves who published the bytes, not that the instructions" in body

--- a/tests/unit/test_sub_commands.py
+++ b/tests/unit/test_sub_commands.py
@@ -144,6 +144,7 @@ def test_list_with_no_subscriptions_does_not_crash(isolated_home, capsys):
     sub.handle_sub_list()
     out = _plain(capsys.readouterr().out)
     assert "No subscriptions" in out
+    assert "co sub sync <0xaddress>" in out
 
 
 def test_list_after_add_shows_alias_version_and_skill_count(isolated_home, fake_relay, capsys):
@@ -186,6 +187,7 @@ def test_remove_unknown_target_is_a_no_op(isolated_home, capsys):
     sub.handle_sub_remove("0x" + "1" * 64)
     out = _plain(capsys.readouterr().out)
     assert "Not subscribed" in out
+    assert "co sub list" in out
 
 
 def test_bare_alias_without_prior_subscription_errors_out(isolated_home, capsys):
@@ -195,6 +197,7 @@ def test_bare_alias_without_prior_subscription_errors_out(isolated_home, capsys)
         sub.handle_sub_sync_one("alice")  # not in subscriptions.txt
     out = _plain(capsys.readouterr().out)
     assert "not a 0x address" in out
+    assert "co sub sync <0xaddress>" in out
 
 
 def test_alias_refresh_works_when_address_already_pinned(isolated_home, fake_relay):

--- a/uv.lock
+++ b/uv.lock
@@ -1462,14 +1462,14 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.15.0"
+version = "6.16.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/17/ee75a92718ec7212de831e71454d702225aa5e474a805cce169806044453/pypdf-6.15.0.tar.gz", hash = "sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79", size = 6993794, upload_time = "2026-08-06T13:06:49.929Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/66/54212e75406afd9f3e933d0dda23072f6aecc55c5a273077dc2e0b028b23/pypdf-6.16.2.tar.gz", hash = "sha256:595647f6191de6f402cfde1d0c455d6cbccbd509aac32b34783009c032de5d6e", size = 7008996, upload_time = "2026-08-23T13:50:07.135Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/72/ce3067ac31e214a66388159f8462ddb8c13dd00170f24d555a1f1ae8ee91/pypdf-6.15.0-py3-none-any.whl", hash = "sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee", size = 378123, upload_time = "2026-08-06T13:06:47.709Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f1/a2da3b55acd4ab737bf728c97edaaed5ec1d3c1236acb639dcdfa97e42c7/pypdf-6.16.2-py3-none-any.whl", hash = "sha256:c8b09a59399062fb45a1b8156c18a787a10a3dae03ac9674397a226712c94604", size = 385060, upload_time = "2026-08-23T13:50:05.349Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Proposed target version:** 1.7.2 / next patch
**Estimated release window:** September 2026, next stable patch
**Forward-port tracking issue (stable patches only):** #1378

## What changed

Backport the canonical `oo` useful skill from main PR #1364 to the stable 1.7 line:

- add the self-contained `oo` skill for OIP connections, identity setup, signed publishing, and pull-based subscriptions
- register `co copy oo`
- document the OIP vs ANNOUNCE/profile-v2 vs `co sub` boundaries and single-file publication limit
- fix stale `co sub` next-step hints
- add the regression tests and Design Journal entry from main
- backport main PR #1370s pure lockfile update from pypdf 6.15.0 to 6.16.2, required because the current audit rejects 6.15.0 for CVE-2026-84309/84310/84311 on every open 1.7 PR

## Compatibility

The 1.7 line already implements profile-v2 signature verification, monotonic revision protection, address-pinned sync, remote `tools:` stripping, and coding-agent fan-out. The only oo cherry-pick conflict was the old empty-subscription hint; it was resolved to the literal working command `co sub sync <0xaddress>`.

## Verification

- skill validator: passed
- focused oo/sub/copy tests: 36 passed
- announce/fanout/default-skill/help regressions: 61 passed
- broad 1.7 unit suite excluding seven sandbox-only socket/user-home files: 6,597 passed, 15 skipped, 15 deselected
- dependency/version tests after the pypdf update: 17 passed, 1 docs-site check skipped
- `uv lock --check`: passed
- `git diff --check`: passed
- manual `co copy --list`: shows `oo`

Main/1.8 already contains the exact feature as commit `95b8f79c6618ad4fa64584f1cd00200d67176a8c` and the pypdf fix as `77864cd7c576d7b97fad1ed55f93a139777802e2`; #1378 records that forward-port state.

The separate docs-site repository is not checked out locally, so this backport updates the package documentation only. This PR does not bump, tag, or publish 1.7.2.