### PR TITLE
fix: keep project environment consistent from subdirectories

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -2,10 +2,10 @@
 Purpose: Main package entry point exposing public API for ConnectOnion framework
 LLM-Note:
   Dependencies: imports from [core/, logger.py, llm_do.py, transcribe.py, prompts.py, debug/, useful_tools/, network/, address.py] | imported by [user code, tests/, examples/] | no direct tests (integration tests import from here)
-  Data flow: loads cwd .env then ~/.co/keys.env via load_dotenv() (first file to define a key wins) → exports all public API symbols → user imports `from connectonion import Agent, llm_do, ...`
-  State/Effects: auto-loads both the cwd .env (NOT module directory) and the global ~/.co/keys.env at import time
+  Data flow: loads project-root .env then ~/.co/keys.env via load_dotenv() (existing process values win) → exports all public API symbols → user imports `from connectonion import Agent, llm_do, ...`
+  State/Effects: auto-loads the canonical project .env and global ~/.co/keys.env at import time, without crossing repository or home boundaries
   Integration: exposes complete public API: Agent, LLM, Logger, create_tool_from_function, llm_do, transcribe, xray, event decorators, built-in tools, networking functions | __all__ defines explicit public exports
-  Performance: .env loading happens once at first import (dotenv caches)
+  Performance: .env loading happens at first package import
   Errors: none (import errors bubble from submodules)
 ConnectOnion - A simple agent framework with behavior tracking.
 """
@@ -19,12 +19,15 @@ import sys as _sys
 from types import ModuleType as _ModuleType
 from dotenv import load_dotenv
 from pathlib import Path as _Path
+from .project import project_root as _project_root
 
 # Load BOTH the project .env and the global ~/.co/keys.env, in that order.
 # load_dotenv never overrides an already-set variable, so the first file to
 # define a key wins: the project .env overrides, keys.env fills in the rest.
 # Loading only one of them silently hid every credential that lives solely in
 # keys.env (OAuth tokens land there) from any project that had its own .env.
+# Resolve the same project as identity/status/auth. A command started inside
+# src/ must not miss the project's keys or pick up src/.env from another app.
 # The [env] diagnostic answers "which file won?" for a human at a terminal.
 # It is written to stderr only when stderr IS a terminal: agents drive `co`
 # through bash, which appends any stderr to the tool result as "STDERR:" no
@@ -32,8 +35,8 @@ from pathlib import Path as _Path
 # successful command look like it had failed. CO_DEBUG_ENV=1 forces it on for
 # piped or redirected debugging.
 _show_env = _sys.stderr.isatty() or _os.getenv("CO_DEBUG_ENV") == "1"
-for _env_file in (_Path.cwd() / ".env", _Path.home() / ".co" / "keys.env"):
-    if _env_file.exists():
+for _env_file in (_project_root() / ".env", _Path.home() / ".co" / "keys.env"):
+    if _env_file.is_file():
         load_dotenv(_env_file)
         if _show_env:
             print(f"[env] {_env_file.resolve()}", file=_sys.stderr)

--- a/connectonion/cli/commands/gdrive_commands.py
+++ b/connectonion/cli/commands/gdrive_commands.py
@@ -24,9 +24,10 @@ LIST_CACHE = Path.home() / ".co" / "gdrive_last_list.json"
 def _gdrive():
     """Load GOOGLE_* credentials from .env files and return a GDrive instance. Exits 1 with a hint if not connected."""
     from dotenv import load_dotenv
+    from ...project import project_root
 
-    for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
-        if env_path.exists():
+    for env_path in [project_root() / ".env", Path.home() / ".co" / "keys.env"]:
+        if env_path.is_file():
             load_dotenv(env_path)
 
     if not os.getenv("GOOGLE_ACCESS_TOKEN"):

--- a/connectonion/cli/commands/gmail_commands.py
+++ b/connectonion/cli/commands/gmail_commands.py
@@ -26,9 +26,10 @@ INBOX_CACHE = Path.home() / ".co" / "gmail_last_inbox.json"
 def _gmail():
     """Load GOOGLE_* credentials from .env files and return a Gmail instance. Exits 1 with a hint if not connected."""
     from dotenv import load_dotenv
+    from ...project import project_root
 
-    for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
-        if env_path.exists():
+    for env_path in [project_root() / ".env", Path.home() / ".co" / "keys.env"]:
+        if env_path.is_file():
             load_dotenv(env_path)
 
     if not os.getenv("GOOGLE_ACCESS_TOKEN"):

--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -25,9 +25,10 @@ INBOX_CACHE = Path.home() / ".co" / "outlook_last_inbox.json"
 def _outlook(required_scope: str = "Mail"):
     """Load Microsoft credentials and require the Graph scope this command needs."""
     from dotenv import load_dotenv
+    from ...project import project_root
 
-    for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
-        if env_path.exists():
+    for env_path in [project_root() / ".env", Path.home() / ".co" / "keys.env"]:
+        if env_path.is_file():
             load_dotenv(env_path)
 
     if not os.getenv("MICROSOFT_ACCESS_TOKEN"):

--- a/connectonion/cli/commands/synology_commands.py
+++ b/connectonion/cli/commands/synology_commands.py
@@ -24,9 +24,10 @@ LIST_CACHE = Path.home() / ".co" / "syno_last_list.json"
 def _syno():
     """Load SYNOLOGY_* credentials from .env files and return a Synology instance. Exits 1 with a hint if not connected."""
     from dotenv import load_dotenv
+    from ...project import project_root
 
-    for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
-        if env_path.exists():
+    for env_path in [project_root() / ".env", Path.home() / ".co" / "keys.env"]:
+        if env_path.is_file():
             load_dotenv(env_path)
 
     if not os.getenv("SYNOLOGY_URL"):

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -26,7 +26,6 @@ from pathlib import Path
 from typing import List, Optional
 
 import typer
-from dotenv import load_dotenv
 from rich.console import Console
 
 # From _version, not from the package: `from .. import __version__` pulled in
@@ -35,13 +34,9 @@ from rich.console import Console
 from .._version import __version__
 from ..core.usage import DEFAULT_MODEL
 
-# Load both env files for all CLI commands. keys.env stays first — that is
-# already the CLI's effective precedence, since commands that load .env do so
-# after this import and load_dotenv never overrides. Adding .env here only
-# fills in keys it alone defines.
-for _env_file in (Path.home() / ".co" / "keys.env", Path.cwd() / ".env"):
-    if _env_file.exists():
-        load_dotenv(_env_file)
+# Package startup already loads project-root .env, then global keys.env,
+# without overriding the process environment. Do not reload cwd/.env here:
+# inside a subdirectory it belongs to neither the selected project nor identity.
 
 console = Console()
 

--- a/docs/blog/2026-09-02-one-project-one-environment.md
+++ b/docs/blog/2026-09-02-one-project-one-environment.md
@@ -1,0 +1,44 @@
+---
+title: "One project, one environment"
+date: "2026-09-02"
+description: "The identity walk already knew where a project ended. Dotenv loading needed to use it too."
+---
+
+Changing into `src/` should not change which account a project uses. Yet the
+environment-loading audit found two different answers to where that project
+was. Identity, auth, and status used the directory containing `.co/`. Package
+startup read `.env` from the working directory instead.
+
+A project key could disappear simply because a command ran one directory
+lower. A global key filled the gap; if the subdirectory had its own `.env`,
+that file won instead. The account-mismatch guard still protected managed
+OpenOnion requests, but it could not make the environment itself consistent,
+and third-party provider keys had the same directory-dependent selection.
+
+The first regression used fake credentials in three places: the project,
+its `src/` directory, and a temporary home. Importing the SDK from the project
+selected the project value. Importing it from `src/` selected the nested value.
+Running the CLI import repeated the failure. No service or real key was needed
+to demonstrate the mismatch.
+
+Changing package startup alone was not enough. The CLI loaded the working
+directory again, and Gmail, Outlook, GDrive, and Synology each had their own
+reload. Even when the project value was already present, those later reads
+could introduce variables found only in the nested file. The patch removes the
+redundant CLI-startup read and makes each integration use the existing project
+root resolver.
+
+That resolver is deliberately bounded: it stops at a Git repository or home
+boundary, recognizes worktree `.git` files, and does not mistake `~/.co` for a
+parent project. Creating another unbounded dotenv search would have restored
+the same bug in a different form.
+
+The ordering stays familiar: an explicitly supplied process variable wins,
+then the project `.env`, then global `keys.env`. Outside a configured project,
+the current directory's `.env` still works. The regression suite checks those
+boundaries, nested projects, absent project files, and all four integration
+reloads. It tests source selection, not the contents of anyone's credentials.
+
+The lesson is small: a correct project boundary is useful only when every
+loader uses it. A second definition of the project can undo the first without
+ever raising an exception.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -759,11 +759,26 @@ The CLI automatically detects providers:
 
 ### Priority Order
 
-1. `--key` flag
-2. Environment variables
-3. `~/.co/keys.env` (global)
-4. Interactive prompt
-5. Skip (add later)
+For runtime environment loading, the first source defining a variable wins:
+
+1. Existing process environment (shell, container, or service configuration)
+2. The project's `.env`
+3. `~/.co/keys.env` (global fallback)
+
+The project is the nearest directory containing `.co/`, bounded by the current
+Git repository and home directory. Running `co` from `project/src/` loads
+`project/.env`, not `project/src/.env`; Python imports use the same rule.
+Outside a project, `.env` in the current directory is still supported. Loading
+never searches across another repository or treats `~/.co` as a parent project.
+
+Gmail, Outlook, GDrive, and Synology CLI loaders use this same boundary. A
+subdirectory `.env` cannot add missing values behind the project's back.
+Explicit API-key arguments remain caller-controlled; setup commands can prompt
+for missing credentials. No existing environment value is overwritten.
+
+Use `co status` or `co doctor` for redacted credential diagnostics. Set
+`CO_DEBUG_ENV=1` to show the dotenv file paths loaded at startup, even when
+output is piped. It does not print secret values.
 
 ### Backend selection
 

--- a/tests/e2e/test_the_wheel_works_when_installed.py
+++ b/tests/e2e/test_the_wheel_works_when_installed.py
@@ -127,6 +127,36 @@ class TestItIsTheWheelBeingTested:
         assert "False" in result.stdout, "the source tree shadowed the installed package"
 
 
+def test_installed_cli_and_sdk_share_the_project_env(installed, tmp_path):
+    """The public entry point must not fall back to a subdirectory's secrets."""
+    python, bin_dir, _, _ = installed
+    home = tmp_path / "home"
+    (home / ".co").mkdir(parents=True)
+    (home / ".co" / "keys.env").write_text("CO_WHEEL_ENV=global\n", encoding="utf-8")
+    project = home / "project"
+    (project / ".co").mkdir(parents=True)
+    (project / ".env").write_text("CO_WHEEL_ENV=project\n", encoding="utf-8")
+    nested = project / "src"
+    nested.mkdir()
+    (nested / ".env").write_text("CO_WHEEL_ENV=nested\n", encoding="utf-8")
+    env = {key: os.environ[key] for key in ("PATH", "SYSTEMROOT") if key in os.environ}
+    env.update(HOME=str(home), USERPROFILE=str(home), CO_DEBUG_ENV="1")
+    result = subprocess.run(
+        [str(python), "-c", "import connectonion, os; print(os.environ['CO_WHEEL_ENV'])"],
+        cwd=nested, env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "project"
+    co = bin_dir / ("co.exe" if os.name == "nt" else "co")
+    result = subprocess.run(
+        [str(co), "--version"], cwd=nested, env=env,
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert f"[env] {(project / '.env').resolve()}" in result.stderr
+    assert f"[env] {(nested / '.env').resolve()}" not in result.stderr
+
+
 class TestTheDataFilesShipped:
     """Every non-.py file the runtime loads."""
 

--- a/tests/unit/test_project_env_loading.py
+++ b/tests/unit/test_project_env_loading.py
@@ -1,0 +1,128 @@
+"""Startup and CLI loaders must use the same project boundary as identity."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def env_project(tmp_path):
+    home = tmp_path / "home"
+    (home / ".co").mkdir(parents=True)
+    (home / ".co" / "keys.env").write_text(
+        "CO_TEST_KEY=global\nCO_TEST_GLOBAL=fallback\n", encoding="utf-8"
+    )
+    project = home / "project"
+    (project / ".co").mkdir(parents=True)
+    (project / ".env").write_text("CO_TEST_KEY=project\n", encoding="utf-8")
+    nested = project / "src"
+    nested.mkdir()
+    (nested / ".env").write_text(
+        "CO_TEST_KEY=nested\nCO_TEST_NESTED=unexpected\n", encoding="utf-8"
+    )
+    return home, project, nested
+
+
+def _probe(home, cwd, entry, extra=None):
+    env = {
+        "HOME": str(home),
+        "USERPROFILE": str(home),
+        "PATH": os.environ.get("PATH", ""),
+        "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
+    }
+    env.update(extra or {})
+    code = (
+        f"import {entry}\n"
+        "import json, os\n"
+        "print(json.dumps({k: os.getenv(k) for k in "
+        "['CO_TEST_KEY', 'CO_TEST_GLOBAL', 'CO_TEST_NESTED']}))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], cwd=cwd, env=env,
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(result.stdout)
+
+
+@pytest.mark.parametrize("entry", ["connectonion", "connectonion.cli.main"])
+def test_nested_startup_uses_project_env_not_nested_env(env_project, entry):
+    home, project, nested = env_project
+    expected = {"CO_TEST_KEY": "project", "CO_TEST_GLOBAL": "fallback", "CO_TEST_NESTED": None}
+    assert _probe(home, project, entry) == expected
+    assert _probe(home, nested, entry) == expected
+
+
+@pytest.mark.parametrize("entry", ["connectonion", "connectonion.cli.main"])
+def test_explicit_process_env_wins(env_project, entry):
+    home, _, nested = env_project
+    assert _probe(home, nested, entry, {"CO_TEST_KEY": "shell"}) == {
+        "CO_TEST_KEY": "shell", "CO_TEST_GLOBAL": "fallback", "CO_TEST_NESTED": None,
+    }
+
+
+def test_missing_project_env_does_not_load_nested_env(env_project):
+    home, project, nested = env_project
+    (project / ".env").unlink()
+    assert _probe(home, nested, "connectonion.cli.main") == {
+        "CO_TEST_KEY": "global", "CO_TEST_GLOBAL": "fallback", "CO_TEST_NESTED": None,
+    }
+
+
+def test_home_dotenv_is_not_a_parent_project(env_project):
+    home, _, _ = env_project
+    (home / ".env").write_text("CO_TEST_KEY=home\n", encoding="utf-8")
+    unrelated = home / "unrelated"
+    unrelated.mkdir()
+    assert _probe(home, unrelated, "connectonion.cli.main")["CO_TEST_KEY"] == "global"
+
+
+def test_nearest_nested_project_owns_its_environment(env_project):
+    home, _, nested = env_project
+    (nested / ".co").mkdir()
+    assert _probe(home, nested, "connectonion.cli.main")["CO_TEST_KEY"] == "nested"
+
+
+@pytest.mark.parametrize("marker", ["directory", "worktree-file"])
+def test_dotenv_does_not_cross_another_repository(env_project, marker):
+    home, _, nested = env_project
+    if marker == "directory":
+        (nested / ".git").mkdir()
+    else:
+        (nested / ".git").write_text("gitdir: unused\n", encoding="utf-8")
+    assert _probe(home, nested, "connectonion") == {
+        "CO_TEST_KEY": "nested", "CO_TEST_GLOBAL": "fallback", "CO_TEST_NESTED": "unexpected",
+    }
+
+
+@pytest.mark.parametrize("module,loader", [
+    ("gmail_commands", "_gmail"),
+    ("outlook_commands", "_outlook"),
+    ("gdrive_commands", "_gdrive"),
+    ("synology_commands", "_syno"),
+])
+def test_integration_reload_uses_project_root(env_project, monkeypatch, module, loader):
+    from importlib import import_module
+    import dotenv
+
+    home, project, nested = env_project
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.chdir(nested)
+    command = import_module(f"connectonion.cli.commands.{module}")
+    loaded = []
+
+    class StopAfterEnv(Exception):
+        pass
+
+    def record(path, *args, **kwargs):
+        loaded.append(Path(path).resolve())
+        if len(loaded) == 2:
+            raise StopAfterEnv
+
+    monkeypatch.setattr(dotenv, "load_dotenv", record)
+    with pytest.raises(StopAfterEnv):
+        getattr(command, loader)()
+    assert loaded == [project / ".env", home / ".co" / "keys.env"]


### PR DESCRIPTION
## Summary

Align dotenv loading with the canonical project root already used by identity, auth, and status. Previously, launching inside `project/src/` missed `project/.env` or selected `src/.env`; global fallback and third-party credentials could silently change with cwd. Remove the redundant CLI startup load and fix the four integration reload paths too. Preserve explicit process-variable precedence and the existing repository/home boundaries.

- **Suggested labels:** bug, tests, documentation
- **Proposed target version:** 1.7.2
- **Estimated release window:** next stable patch, September 2026
- **Forward-port tracking issue (stable patches only):** #1380

## Verification

- New regression suite reproduced 8 failures before the fix (2 boundary cases already passed); now 13 cases pass.
- 217 focused startup, import-cost, project-boundary, integration CLI, and auth tests passed.
- Credential safety/diagnostics selection: 49 passed before adding the last three boundary cases.
- Added an installed-wheel SDK and real co entry-point regression.
- Full suite and hosted cross-platform matrices must pass before release.
- git diff --check passed.

## Documentation and review

Updated docs/cli/README.md and docs/blog/2026-09-02-one-project-one-environment.md. The docs-site checkout is absent locally; the live site has not been changed.

AI-assisted using Codex. The principal compatibility risk is a project intentionally relying on an unconfigured subdirectory .env; it should use the canonical project file, an explicit process variable, or a separately configured nested project. No live provider credentials or mailbox calls were used for these tests. Account-mismatch checks, token persistence, and browser behavior are unchanged.
