### PR TITLE
fix(remote-browser): recover sessions after daemon restart

### DIFF
--- a/connectonion/network/host/remote_browser.py
+++ b/connectonion/network/host/remote_browser.py
@@ -103,6 +103,31 @@ class RemoteBrowserService:
         # registers and, in its finally, detaches; `start` with
         # `proxy: shared` only reads it.
         self.proxy_channels = ProxyChannelRegistry()
+        self._reconcile_dead_daemon(self._load())
+
+    def _daemon_is_running(self) -> bool | None:
+        """Return private daemon liveness, or None for an embedded test seam."""
+        if self.daemon_target is None:
+            return None
+        from ...cli.browser_agent.client import _owner_alive
+
+        return _owner_alive(self.daemon_target.address)
+
+    def _reconcile_dead_daemon(self, state: dict) -> None:
+        """Drop runtime-only locks left by a daemon that did not survive a restart."""
+        if self._daemon_is_running() is not False:
+            return
+        now = int(self.clock())
+        changed = False
+        for session in state["sessions"].values():
+            if session.get("status") == "active":
+                session["status"] = "stopped"
+                session["updated_at"] = now
+                changed = True
+        if changed:
+            self._save(state)
+            if self.daemon_target is not None and self.daemon_target.shared_proxy_path is not None:
+                self.daemon_target.shared_proxy_path.unlink(missing_ok=True)
 
     @staticmethod
     def _share_binding(endpoint) -> str:
@@ -281,6 +306,7 @@ class RemoteBrowserService:
             )
         with self._lock:
             state = self._load()
+            self._reconcile_dead_daemon(state)
             for session in state["sessions"].values():
                 if (
                     session.get("owner") == owner
@@ -310,7 +336,7 @@ class RemoteBrowserService:
                     request_id,
                     "start",
                     "REMOTE_SESSION_PROXY_LOCKED",
-                    "The running WTF Browser is already pinned to another proxy.",
+                    "The running Remote Browser is already pinned to another proxy.",
                     state={"fallback_applied": False},
                 )
             if share_endpoint is not None and self.daemon_target is not None:

--- a/docs/blog/2026-09-02-remote-browser-restart.md
+++ b/docs/blog/2026-09-02-remote-browser-restart.md
@@ -1,0 +1,32 @@
+# When a Remote Browser Restarted, the Lock Did Not
+
+The failure looked like a proxy problem, but it began one restart earlier. A
+host process had opened a shared Remote Browser session, then the machine
+restarted. The session registry survived because it is deliberately persisted;
+the private browser daemon did not. On the next start, the registry still said
+that an active session owned the shared proxy, so the new daemon was refused
+before it could do useful work. Every later attempt received
+`REMOTE_SESSION_PROXY_LOCKED`, even though there was no browser left to hold
+the lock.
+
+The misleading part was the source of truth. The session file is durable
+history, not proof that a runtime is alive. Treating its `active` status as a
+live daemon claim made a clean host restart indistinguishable from a real
+concurrent browser. The error message also called the product “WTF Browser,”
+which made the recovery path harder to recognize.
+
+The fix makes the boundary explicit at the start of a new session. When the
+service has a private daemon target, it checks the daemon's existing liveness
+sidecar before applying the proxy lock. If the owner is gone, runtime-only
+active sessions become stopped, their timestamps are updated, and the stale
+shared-proxy selection is removed. Only then does the normal start path bind a
+new session to the new daemon. Embedded test seams keep their existing
+behavior because they do not own a private daemon target to inspect.
+
+The regression test exercises the failure as a restart: it creates a persisted
+shared session, leaves the daemon liveness record absent, verifies the stale
+proxy file is cleared, and starts a replacement session with a different proxy
+binding. The focused unit and daemon lifecycle tests pass together (15 passed),
+and the lock message now names Remote Browser consistently. The durable session
+file still records the old session as stopped, so later status and stop calls
+retain an auditable tombstone instead of silently forgetting what happened.

--- a/tests/unit/test_remote_browser_service.py
+++ b/tests/unit/test_remote_browser_service.py
@@ -118,6 +118,34 @@ def test_owner_can_reconnect_from_a_new_service_instance(tmp_path):
     assert status["state"]["session"] == "active"
 
 
+def test_restart_releases_sessions_when_the_browser_daemon_is_gone(tmp_path):
+    first = RemoteBrowserService(tmp_path / "sessions.json")
+    first.daemon_request = Daemon()
+    attach(first, "0xalice", port=43123, password="old-proxy")
+    started = first.handle(
+        request("start", args={"proxy": "shared"}),
+        owner="0xalice",
+        transport="direct",
+    )
+    assert first.daemon_target.shared_proxy_path.is_file()
+
+    restarted = RemoteBrowserService(tmp_path / "sessions.json", clock=lambda: 1001)
+    restarted.daemon_request = Daemon()
+    attach(restarted, "0xalice", port=43999, password="new-proxy")
+    assert not restarted.daemon_target.shared_proxy_path.exists()
+
+    replacement = restarted.handle(
+        request("start", request_id="req-replacement", args={"proxy": "shared"}),
+        owner="0xalice",
+        transport="direct",
+    )
+
+    assert replacement["ok"] is True
+    saved = json.loads((tmp_path / "sessions.json").read_text())
+    assert saved["sessions"][started["result"]["session_id"]]["status"] == "stopped"
+    assert saved["sessions"][replacement["result"]["session_id"]]["status"] == "active"
+
+
 def test_stop_is_idempotent_and_keeps_a_tombstone(tmp_path):
     remote, daemon = service(tmp_path)
     started = remote.handle(request("start"), owner="0xalice", transport="direct")
@@ -247,6 +275,8 @@ def test_one_wtf_runtime_cannot_mix_direct_and_shared_sessions(tmp_path):
 
     assert first["ok"] is True
     assert second["code"] == "REMOTE_SESSION_PROXY_LOCKED"
+    assert "WTF Browser" not in second["message"]
+    assert "Remote Browser" in second["message"]
     assert len(daemon.calls) == 1
 
 


### PR DESCRIPTION
## Summary / Problem

Fixes #1374. A host restart left persisted Remote Browser sessions marked
active even though their private browser daemon had exited. The stale session
then kept the shared proxy lock and rejected every later start with
`REMOTE_SESSION_PROXY_LOCKED`.

## Changes

- Check the private daemon liveness sidecar before applying the persisted
  session lock.
- Reconcile active sessions to stopped and remove the stale shared proxy file
  when the daemon is gone.
- Use the product name “Remote Browser” in the proxy-lock error.
- Add a regression test covering the persisted session, missing daemon,
  cleanup, and replacement start, plus the required design journal at
  `docs/blog/2026-09-02-remote-browser-restart.md`.

## Tests

- `python -m pytest tests/unit/test_remote_browser_service.py tests/e2e/cli/test_remote_browser_daemon.py -q --basetemp .pytest-tmp-focused6` — 15 passed in 5.91s.
- `python -m ruff check connectonion/network/host/remote_browser.py tests/unit/test_remote_browser_service.py` — All checks passed.
- `git diff --check` — passed; Git emitted only its normal LF-to-CRLF warning for the two edited Python files.
- `$env:PYTHONUTF8='1'; python -m pytest tests --basetemp .pytest-tmp-full-02` — 1,352 passed, 265 failed, 37 skipped, 180 deselected, and 8 collection errors before the run was interrupted after 544.33s. The failures were in unrelated existing Windows, async teardown, external-service, and packaging paths; the Remote Browser tests passed.
- The repository CI-equivalent command `$env:PYTHONUTF8='1'; python -m pytest tests/ -v --tb=short -m "not slow and not real_api and not network"` was attempted, reached 22%, and could not complete within the local execution limit; no passing result is claimed for it.
- GitHub Actions run [33629598472](https://github.com/openonion/connectonion/actions/runs/33629598472) — all repository checks passed, including the Python 3.10–3.13 test matrix, browser e2e, remote-browser-egress matrix, CodeQL, lockfile, and metadata/blog gates.

## Compatibility / Known limitations

- A live private daemon keeps the existing active-session behavior. Embedded
  daemon test seams do not claim private daemon liveness and retain their
  existing behavior.
- **Suggested labels:** `bug`, `browser`
- **Proposed target version:** next alpha
- **Estimated release window:** next alpha
- **Milestone:** maintainer assigns the confirmed release milestone
- **Why this release:** This is a contained lifecycle bug fix with no
  dependency changes; shipping it with the next preview gives users a recovery
  path without changing the public protocol.
- **Forward-port tracking issue (stable patches only):** N/A — this targets the
  preview line rather than a stable patch.
- The local environment is Windows. Real API/network tests were excluded by
  the repository test policy, and Chrome/onionwright-dependent tests were
  skipped because those dependencies were unavailable.
- AI-assisted — GPT-5 via Codex. I reviewed every changed line. Least
  confidence: the daemon PID sidecar is the repository's intended liveness
  signal, but a platform-specific sidecar edge case could still need maintainer
  review. I did not run a real browser after an operating-system restart on
  Linux or macOS. If the liveness signal is wrong, a legitimate live daemon
  could be treated as stopped and a new daemon could attempt to start.

## Issue link

https://github.com/openonion/connectonion/issues/1374
