### PR TITLE
[1.9.1] feat(listen): co telegram listen / receive / reply beside the existing send

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,9 +178,10 @@ connectonion/
 │   │       ├── tools.py            # Verification tools
 │   │       ├── trust_agent.py      # TrustAgent class
 │   │       └── policies/           # Trust level policy markdown
-│   ├── listen/                     # Chat platforms as mailbox directories (co feishu listen/receive/send)
+│   ├── listen/                     # Chat platforms as mailbox directories (co feishu / co telegram listen, receive, send, reply)
 │   │   ├── mailbox.py              # ~/.co/<provider>/: inbox.jsonl log, new/ queue, cur/, outbox.jsonl
-│   │   └── feishu.py               # Feishu/Lark long connection → files; REST reply
+│   │   ├── feishu.py               # Feishu/Lark long connection → files; REST reply
+│   │   └── telegram.py             # Telegram getUpdates long poll → files; sendMessage reply
 │   ├── tui/                        # Terminal UI components
 │   ├── logger.py                   # Unified logging facade (terminal + file + YAML sessions)
 │   ├── console.py                  # Low-level terminal output with Rich

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -155,7 +155,7 @@ def _show_help():
     console.print("  [green]sms[/green]               Pair a phone and read encrypted SMS")
     console.print("  [green]transfer[/green]          Send credits to another agent address")
     console.print("  [green]gmail[/green]             Send and read Gmail (co auth google)")
-    console.print("  [green]telegram[/green]          Send a message from your Telegram bot")
+    console.print("  [green]telegram[/green]          Telegram bot as a mailbox: listen, receive, send, reply")
     console.print("  [green]feishu[/green]            Feishu bot as a mailbox: listen, receive, send, reply")
     console.print("  [green]gdrive[/green]            List and transfer Google Drive files (co auth google)")
     console.print("  [green]syno[/green]              Browse and transfer Synology NAS files (co syno login)")
@@ -958,7 +958,7 @@ def transfer(
 
 # Telegram command group. The bot is the user's own (@BotFather), so the token
 # lives in their keys.env -- no OpenOnion credential and nothing billed.
-telegram_app = _typer_app(help="Send a message from your Telegram bot.")
+telegram_app = _typer_app(help="Telegram bot as a mailbox: listen, receive, send, reply.")
 app.add_typer(telegram_app, name="telegram")
 
 
@@ -975,8 +975,10 @@ def telegram_send(
 # Mailbox providers: feishu, lark. One directory per provider under ~/.co/,
 # the same eight verbs on each. The tool knows nothing about agents; anything
 # that can read a file consumes it (DD-063).
-def _mailbox_group(name: str, help_text: str) -> typer.Typer:
-    group = _typer_app(help=help_text)
+def _mailbox_group(name: str, help_text: str, *, group=None, with_send: bool = True) -> typer.Typer:
+    """The eight verbs on a fresh group, or on an existing one that already
+    has its own `send` (Telegram shipped `co telegram send` first)."""
+    group = group if group is not None else _typer_app(help=help_text)
 
     @group.command("listen")
     def _listen(raw: bool = typer.Option(False, "--raw", help="Keep the provider payload in inbox.jsonl")):
@@ -993,7 +995,6 @@ def _mailbox_group(name: str, help_text: str) -> typer.Typer:
         from .commands.listen_commands import handle_receive
         handle_receive(name, timeout=timeout, start=not no_start)
 
-    @group.command("send")
     def _send(
         chat: str = typer.Argument(..., help="Chat id"),
         text: Optional[str] = typer.Argument(None, help="The text; omitted means stdin"),
@@ -1002,6 +1003,9 @@ def _mailbox_group(name: str, help_text: str) -> typer.Typer:
         """Send text to a chat. Prints the new message id."""
         from .commands.listen_commands import handle_send
         handle_send(name, chat, text, reply_to=reply_to)
+
+    if with_send:
+        group.command("send")(_send)
 
     @group.command("reply")
     def _reply(
@@ -1051,6 +1055,9 @@ def _mailbox_group(name: str, help_text: str) -> typer.Typer:
 
 app.add_typer(_mailbox_group("feishu", "Feishu bot as a mailbox: listen, receive, send, reply."), name="feishu")
 app.add_typer(_mailbox_group("lark", "Lark (global Feishu) bot as a mailbox: listen, receive, send, reply."), name="lark")
+# Telegram keeps the `send` it shipped with (its output is part of its contract)
+# and gains the other seven verbs on the same group, same token.
+_mailbox_group("telegram", "", group=telegram_app, with_send=False)
 
 
 # Gmail command group. `co gmail` (no args) shows the Gmail inbox.

--- a/connectonion/listen/__init__.py
+++ b/connectonion/listen/__init__.py
@@ -15,6 +15,7 @@ from .mailbox import Mailbox, Message
 PROVIDERS = {
     "feishu": ("connectonion.listen.feishu", "Feishu", {"domain": "feishu"}),
     "lark": ("connectonion.listen.feishu", "Feishu", {"domain": "lark"}),
+    "telegram": ("connectonion.listen.telegram", "Telegram", {}),
 }
 
 

--- a/connectonion/listen/telegram.py
+++ b/connectonion/listen/telegram.py
@@ -1,0 +1,188 @@
+"""
+Purpose: Telegram as a mailbox — getUpdates long polling writes files, replies go through sendMessage
+LLM-Note:
+  Dependencies: imports from [os, time, datetime, requests, listen/mailbox.py] | imported by [listen/__init__.py via provider()] | tested by [tests/unit/test_listen_telegram.py]
+  Data flow: run(mailbox) → GET /bot<token>/getUpdates?offset&timeout=50 → to_message() → mailbox.deliver() → offset = update_id + 1 | send() → POST /bot<token>/sendMessage → message id
+  State/Effects: reads TELEGRAM_BOT_TOKEN, the same token `co telegram send` uses | one outbound long poll at a time, so no port is opened | the offset lives only in memory: Telegram keeps unacknowledged updates for 24 hours, and re-randomises ids after a week idle, so a persisted cursor would be wrong more often than useful
+  Integration: message ids are "<chat>.<message_id>" because Telegram's message_id is only unique within a chat; reply parses that back | a group message counts as mentioned when it @s the bot's username or replies to one of its messages; in a private chat everything is
+  Errors: check() names the missing token and the BotFather steps | a transport error in the poll loop is logged and retried with backoff up to 30 s | send() raises RuntimeError with Telegram's own description, minus the token, after honouring one retry_after
+"""
+
+import os
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+import requests
+
+from .mailbox import Mailbox, Message
+
+API = "https://api.telegram.org"
+
+NO_TOKEN = (
+    "TELEGRAM_BOT_TOKEN is not set. Create a bot by messaging @BotFather on "
+    "Telegram, then put the token it gives you in ~/.co/keys.env as "
+    "TELEGRAM_BOT_TOKEN. The bot is yours — nothing is billed to it."
+)
+
+# Long poll length. Telegram holds the request open this long when nothing
+# is happening; 50 keeps well under the usual 60 s proxy idle limit.
+POLL_SECONDS = 50
+
+_MEDIA = ("photo", "document", "voice", "audio", "video", "sticker", "animation", "location", "contact")
+
+
+class Telegram:
+    """One bot, the user's own, from @BotFather."""
+
+    name = "telegram"
+
+    def __init__(self):
+        self.token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+        self._me: Optional[dict] = None
+
+    # ---- setup -------------------------------------------------------------
+
+    def missing(self) -> list:
+        return [] if self.token else [NO_TOKEN]
+
+    def check(self) -> list:
+        problems = self.missing()
+        if problems:
+            return problems
+        try:
+            self.me()
+        except Exception as exc:
+            problems.append(f"Telegram did not accept the token: {exc}")
+        return problems
+
+    def me(self) -> dict:
+        """The bot's own id and username, for telling an @mention of us from
+        one of someone else."""
+        result = self._call("getMe", {}, method_kind="get")
+        self._me = {"id": result.get("id"), "username": result.get("username")}
+        return self._me
+
+    # ---- inbound -----------------------------------------------------------
+
+    def run(self, mailbox: Mailbox, *, raw: bool = False) -> None:
+        """Long-poll forever, writing every message. Blocks."""
+        try:
+            me = self.me()
+            mailbox.log(f"connected as @{me.get('username')}")
+        except Exception as exc:
+            mailbox.log(f"getMe failed: {exc}")
+        offset = None
+        delay = 1.0
+        while True:
+            try:
+                updates = self._call(
+                    "getUpdates",
+                    {"timeout": POLL_SECONDS, "offset": offset, "allowed_updates": ["message"]},
+                    timeout=POLL_SECONDS + 10,
+                )
+                delay = 1.0
+            except Exception as exc:
+                mailbox.log(f"getUpdates failed: {exc}; retrying in {delay:.0f}s")
+                time.sleep(delay)
+                delay = min(delay * 2, 30)
+                continue
+            for update in updates:
+                # A redelivered older update must not move the cursor back.
+                offset = max(offset or 0, int(update.get("update_id", 0)) + 1)
+                message = self.to_message(update, raw=raw)
+                if message is None:
+                    continue
+                if mailbox.deliver(message, raw=raw):
+                    mailbox.log(f"received {message.id} chat={message.chat} sender={message.sender}")
+                else:
+                    mailbox.log(f"duplicate {message.id} dropped")
+
+    def to_message(self, update: dict, *, raw: bool = False) -> Optional[Message]:
+        """One update as a Message, or None when it is not a person talking
+        to us (bots, channel posts, edits, service messages)."""
+        m = update.get("message")
+        if not isinstance(m, dict):
+            return None
+        sender = m.get("from") or {}
+        chat = m.get("chat") or {}
+        if not sender or sender.get("is_bot") or "id" not in chat:
+            return None
+        text = m.get("text") or m.get("caption") or ""
+        if not text:
+            kind = next((k for k in _MEDIA if k in m), None)
+            if kind is None:
+                return None
+            text = f"[{kind}]"
+        private = chat.get("type") == "private"
+        return Message(
+            id=f"{chat['id']}.{m.get('message_id')}",
+            chat=str(chat["id"]),
+            thread=str(m["message_thread_id"]) if m.get("is_topic_message") and m.get("message_thread_id") else None,
+            sender=str(sender.get("id", "")),
+            text=text,
+            mentioned=True if private else self._mentions_us(m, text),
+            at=_iso(m.get("date")),
+            raw=update if raw else None,
+        )
+
+    def _mentions_us(self, m: dict, text: str) -> bool:
+        me = self._me or {}
+        replied = (m.get("reply_to_message") or {}).get("from") or {}
+        if me.get("id") and replied.get("id") == me["id"]:
+            return True
+        handles = []
+        for entity in m.get("entities") or m.get("caption_entities") or []:
+            if entity.get("type") in ("mention", "bot_command"):
+                offset, length = entity.get("offset", 0), entity.get("length", 0)
+                handles.append(text[offset:offset + length])
+        if not me.get("username"):
+            return any(h.startswith("@") for h in handles)
+        needle = f"@{me['username']}".lower()
+        return any(h.lower() == needle or h.lower().endswith(needle) for h in handles)
+
+    # ---- outbound ----------------------------------------------------------
+
+    def send(self, chat: str, text: str, *, reply_to: Optional[str] = None) -> str:
+        """Send text to a chat, quoting a received message when reply_to is
+        one of our "<chat>.<message_id>" ids. Returns the new message id."""
+        body = {"chat_id": chat, "text": text}
+        if reply_to and "." in reply_to:
+            body["reply_parameters"] = {"message_id": int(reply_to.rsplit(".", 1)[1])}
+        result = self._call("sendMessage", body)
+        return f"{chat}.{result.get('message_id')}"
+
+    # ---- REST -------------------------------------------------------------
+
+    def _call(self, method: str, body: dict, *, timeout: float = 15, method_kind: str = "post") -> dict:
+        url = f"{API}/bot{self.token}/{method}"
+        for attempt in range(2):
+            try:
+                if method_kind == "get":
+                    response = requests.get(url, timeout=timeout)
+                else:
+                    response = requests.post(url, json=body, timeout=timeout)
+            except requests.RequestException as exc:
+                # The URL carries the token; the class name is the diagnosis.
+                raise RuntimeError(f"Telegram request failed ({type(exc).__name__})") from None
+            try:
+                payload = response.json()
+            except ValueError:
+                raise RuntimeError(f"Telegram returned HTTP {response.status_code} without JSON")
+            if payload.get("ok"):
+                return payload.get("result")
+            retry_after = (payload.get("parameters") or {}).get("retry_after")
+            if response.status_code == 429 and retry_after and attempt == 0:
+                time.sleep(float(retry_after))
+                continue
+            description = str(payload.get("description", f"HTTP {response.status_code}"))
+            raise RuntimeError(f"Telegram refused: {description.replace(self.token, '[redacted]')}")
+        raise RuntimeError("Telegram rate-limited this chat twice; try again later")
+
+
+def _iso(date) -> str:
+    try:
+        stamp = datetime.fromtimestamp(int(date), timezone.utc)
+    except (TypeError, ValueError):
+        stamp = datetime.now(timezone.utc)
+    return stamp.replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/connectonion/listen/telegram.py
+++ b/connectonion/listen/telegram.py
@@ -1,7 +1,7 @@
 """
 Purpose: Telegram as a mailbox — getUpdates long polling writes files, replies go through sendMessage
 LLM-Note:
-  Dependencies: imports from [os, time, datetime, requests, listen/mailbox.py] | imported by [listen/__init__.py via provider()] | tested by [tests/unit/test_listen_telegram.py]
+  Dependencies: imports from [os, time, requests, listen/mailbox.py, useful_tools/telegram.py (API, NO_TOKEN)] | imported by [listen/__init__.py via provider()] | tested by [tests/unit/test_listen_telegram.py]
   Data flow: run(mailbox) → GET /bot<token>/getUpdates?offset&timeout=50 → to_message() → mailbox.deliver() → offset = update_id + 1 | send() → POST /bot<token>/sendMessage → message id
   State/Effects: reads TELEGRAM_BOT_TOKEN, the same token `co telegram send` uses | one outbound long poll at a time, so no port is opened | the offset lives only in memory: Telegram keeps unacknowledged updates for 24 hours, and re-randomises ids after a week idle, so a persisted cursor would be wrong more often than useful
   Integration: message ids are "<chat>.<message_id>" because Telegram's message_id is only unique within a chat; reply parses that back | a group message counts as mentioned when it @s the bot's username or replies to one of its messages; in a private chat everything is
@@ -10,20 +10,12 @@ LLM-Note:
 
 import os
 import time
-from datetime import datetime, timezone
 from typing import Optional
 
 import requests
 
-from .mailbox import Mailbox, Message
-
-API = "https://api.telegram.org"
-
-NO_TOKEN = (
-    "TELEGRAM_BOT_TOKEN is not set. Create a bot by messaging @BotFather on "
-    "Telegram, then put the token it gives you in ~/.co/keys.env as "
-    "TELEGRAM_BOT_TOKEN. The bot is yours — nothing is billed to it."
-)
+from ..useful_tools.telegram import API, NO_TOKEN
+from .mailbox import Mailbox, Message, iso_utc
 
 # Long poll length. Telegram holds the request open this long when nothing
 # is happening; 50 keeps well under the usual 60 s proxy idle limit.
@@ -131,11 +123,14 @@ class Telegram:
         replied = (m.get("reply_to_message") or {}).get("from") or {}
         if me.get("id") and replied.get("id") == me["id"]:
             return True
+        # Telegram counts entity offsets in UTF-16 code units, so an emoji
+        # before the @ is two units, not one; slice the UTF-16 form.
+        utf16 = text.encode("utf-16-le")
         handles = []
         for entity in m.get("entities") or m.get("caption_entities") or []:
             if entity.get("type") in ("mention", "bot_command"):
-                offset, length = entity.get("offset", 0), entity.get("length", 0)
-                handles.append(text[offset:offset + length])
+                offset, length = int(entity.get("offset", 0)), int(entity.get("length", 0))
+                handles.append(utf16[2 * offset:2 * (offset + length)].decode("utf-16-le", "replace"))
         if not me.get("username"):
             return any(h.startswith("@") for h in handles)
         needle = f"@{me['username']}".lower()
@@ -156,7 +151,8 @@ class Telegram:
 
     def _call(self, method: str, body: dict, *, timeout: float = 15, method_kind: str = "post") -> dict:
         url = f"{API}/bot{self.token}/{method}"
-        for attempt in range(2):
+        retried = False
+        while True:
             try:
                 if method_kind == "get":
                     response = requests.get(url, timeout=timeout)
@@ -172,17 +168,16 @@ class Telegram:
             if payload.get("ok"):
                 return payload.get("result")
             retry_after = (payload.get("parameters") or {}).get("retry_after")
-            if response.status_code == 429 and retry_after and attempt == 0:
+            if response.status_code == 429 and retry_after and not retried:
+                retried = True  # honour Telegram's own wait once, then report
                 time.sleep(float(retry_after))
                 continue
             description = str(payload.get("description", f"HTTP {response.status_code}"))
             raise RuntimeError(f"Telegram refused: {description.replace(self.token, '[redacted]')}")
-        raise RuntimeError("Telegram rate-limited this chat twice; try again later")
 
 
 def _iso(date) -> str:
     try:
-        stamp = datetime.fromtimestamp(int(date), timezone.utc)
+        return iso_utc(int(date))
     except (TypeError, ValueError):
-        stamp = datetime.now(timezone.utc)
-    return stamp.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        return iso_utc()

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -340,9 +340,10 @@ Worth saying out loud on any page that sells to a business:
 - `@expose` has a design document and no implementation.
 - `logger.load_messages()` has no callers, so "replay a past run" is a data format,
   not a feature. `co eval` is the real replay path.
-- `co feishu listen / receive / send / reply` (`cli/commands/listen_commands.py`,
-  `listen/`) is wired and unit-tested but has not passed the live acceptance run
-  in #1310 against a real Feishu group. Until it has, it is a preview, not a claim.
+- `co feishu listen / receive / send / reply` and `co telegram listen / receive / reply`
+  (`cli/commands/listen_commands.py`, `listen/`) are wired and unit-tested but have
+  not passed a live acceptance run against a real group (#1310, #352). Until they
+  have, they are a preview, not a claim.
 
 ### One security finding, not a marketing note
 

--- a/docs/blog/2026-09-02-a-message-id-is-not-unique.md
+++ b/docs/blog/2026-09-02-a-message-id-is-not-unique.md
@@ -1,0 +1,42 @@
+# A Message Id Is Not Unique
+
+Feishu numbers every message once. Telegram numbers them per chat: the
+first message in any conversation is `1`, the second is `2`, and a bot in
+two groups will see `message_id: 55` twice before lunch. The mailbox dedupes
+on the message id, so the second `55` would have been dropped as a
+redelivery of the first, silently, in another group.
+
+That is why a Telegram message in `~/.co/telegram/` is called
+`-100123.55`: the chat, a dot, the message. It is unique across the bot,
+`reply` can parse it back into the `reply_parameters` Telegram wants, and a
+person reading `ls new/` can tell which group it came from without opening
+the file. The change is one line in the provider and nothing in the mailbox,
+which is what a provider boundary is for.
+
+Telegram also solves a problem the tool then declines to solve. Its
+`getUpdates` long poll keeps unacknowledged updates for a day and hands them
+back in order, with an `update_id` that increases by one. The obvious move
+is to persist that cursor so a restarted listener resumes exactly where it
+stopped. The documentation then says that after a week with no updates the
+next id is chosen at random. A persisted cursor would be right for a busy
+bot and wrong for a quiet one, and a quiet bot is the one whose owner will
+not notice. So the offset lives in memory, a restart asks for everything
+Telegram still holds, and the mailbox's own dedup drops what it has already
+seen. One mechanism, not two that disagree.
+
+The other difference is what "mentioned" means. Feishu's `group_at_msg`
+scope means the platform itself delivers only messages that @ the bot.
+Telegram's privacy mode does something similar for commands and replies,
+but a group where privacy mode is off delivers everything. The provider
+therefore checks the entities Telegram attaches to each message: a
+`mention` or `bot_command` whose text ends with the bot's own username,
+learned from `getMe` at start, or a reply to one of the bot's own messages.
+A private chat is always addressed to the bot. The consumer sees the same
+`mentioned` boolean it sees from Feishu and does not need to know how it
+was computed.
+
+`co telegram send` already existed and stays exactly as it was, because
+scripts depend on its output. The new verbs, `listen`, `receive`, `reply`,
+`check`, `ls`, `log` and `serve`, sit beside it under the same group and
+use the same token from the same `keys.env`. A bot that could only talk can
+now also listen, and the person who set it up in July has nothing to redo.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -259,11 +259,14 @@ process; server storage remains ciphertext-only. See [sms.md](sms.md).
 
 ---
 
-#### `co telegram` - Send from Your Telegram Bot
+#### `co telegram` - Your Telegram Bot as a Directory of Files
 
 ```bash
 co telegram send 123456789 "The deployment needs attention"
 co telegram send @my_channel "Version 1.7 is ready for review"
+co telegram listen                       # every message → ~/.co/telegram/
+m=$(co telegram receive)                 # next message as one JSON line
+echo "done" | co telegram reply -100123.55
 ```
 
 Uses your own BotFather token from `TELEGRAM_BOT_TOKEN`; no OpenOnion credits

--- a/docs/cli/telegram.md
+++ b/docs/cli/telegram.md
@@ -53,5 +53,36 @@ if not result["success"]:
 ```
 
 Messages are sent as plain text; no HTML or Markdown parse mode is enabled.
-Inbound Telegram messages triggering an agent are a separate feature tracked
-in issue #352.
+
+## Listen: the bot as a directory of files
+
+The same bot can receive. `co telegram listen` long-polls Telegram with the
+same token and writes every message into `~/.co/telegram/`: one line in
+`inbox.jsonl` (the log, never deleted) and one file in `new/` (the queue).
+Anything that can read a file can answer; the verbs are the same as
+[`co feishu`](feishu.md):
+
+```bash
+co telegram listen                 # hold the long poll, write the directory; Ctrl-C stops
+m=$(co telegram receive)           # block for the next message, take it, print one JSON line
+echo "on it" | co telegram reply -100123.55     # quote the message it answers, in its chat
+co telegram serve -- claude -p     # one command per message, stdout is the reply
+co telegram check | ls | log -f
+```
+
+```json
+{"id":"-100123.55","chat":"-100123","thread":null,"sender":"4242",
+ "text":"@OpsBot look at the deploy","mentioned":true,"at":"2026-09-02T10:31:07Z"}
+```
+
+Telegram numbers messages per chat, so the id is `<chat>.<message_id>`.
+`thread` is the forum topic when there is one. `mentioned` is true in a private
+chat, and in a group when the message @s the bot's username or replies to one
+of its messages. With privacy mode on (the BotFather default) a group delivers
+only commands and replies to the bot anyway; turn it off with `/setprivacy` and
+re-add the bot if you want it to see everything.
+
+`receive` starts a listener if none is running. Telegram keeps unacknowledged
+updates for a day, so a listener that was down for an hour catches up; the
+mailbox drops anything it has already logged. The full directory layout and
+the `serve` contract are in [feishu.md](feishu.md); only the ids differ.

--- a/tests/unit/test_listen_telegram.py
+++ b/tests/unit/test_listen_telegram.py
@@ -1,0 +1,190 @@
+"""Unit tests for the Telegram mailbox provider.
+
+LLM-Note: Tests for connectonion.listen.telegram
+
+What it tests:
+- A getUpdates update becomes the seven-field Message; ids carry the chat because Telegram's message_id does not
+- Group messages count as mentioned only when they @ the bot or reply to it; private chats always
+- The poll loop advances the offset, delivers once, and survives a transport error
+- send() quotes the received message, honours retry_after once, and never echoes the token
+
+Components under test:
+- Module: connectonion/listen/telegram.py
+"""
+
+import pytest
+
+from connectonion.listen import telegram as telegram_module
+from connectonion.listen.mailbox import Mailbox
+from connectonion.listen.telegram import Telegram
+
+
+@pytest.fixture
+def bot(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:ABC")
+    t = Telegram()
+    t._me = {"id": 777, "username": "OpsBot"}
+    return t
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+
+def update(*, text="@OpsBot look at the deploy", chat_type="supergroup", entities=None, update_id=10,
+           message_id=55, sender=None, reply_to=None, extra=None):
+    m = {
+        "message_id": message_id,
+        "date": 1756808267,
+        "chat": {"id": -100123, "type": chat_type},
+        "from": sender or {"id": 4242, "is_bot": False, "first_name": "Aaron"},
+        "text": text,
+    }
+    if entities is not None:
+        m["entities"] = entities
+    if reply_to:
+        m["reply_to_message"] = reply_to
+    if extra:
+        m.update(extra)
+    return {"update_id": update_id, "message": m}
+
+
+def test_a_group_mention_becomes_a_message_whose_id_carries_the_chat(bot):
+    message = bot.to_message(update(entities=[{"type": "mention", "offset": 0, "length": 7}]))
+
+    assert message.to_dict() == {
+        "id": "-100123.55", "chat": "-100123", "thread": None, "sender": "4242",
+        "text": "@OpsBot look at the deploy", "mentioned": True, "at": "2025-09-02T10:17:47Z",
+    }
+
+
+def test_mentioning_someone_else_or_nobody_is_not_mentioning_us(bot):
+    other = bot.to_message(update(text="@alice look", entities=[{"type": "mention", "offset": 0, "length": 6}]))
+    nobody = bot.to_message(update(text="just chatting"))
+
+    assert other.mentioned is False
+    assert nobody.mentioned is False
+
+
+def test_replying_to_the_bot_counts_as_a_mention(bot):
+    message = bot.to_message(update(text="yes do it", reply_to={"message_id": 50, "from": {"id": 777, "is_bot": True}}))
+    assert message.mentioned is True
+
+
+def test_a_command_addressed_to_us_counts(bot):
+    message = bot.to_message(update(text="/status@OpsBot", entities=[{"type": "bot_command", "offset": 0, "length": 14}]))
+    assert message.mentioned is True
+
+
+def test_a_private_chat_is_always_addressed_to_us(bot):
+    assert bot.to_message(update(text="hi", chat_type="private")).mentioned is True
+
+
+def test_a_forum_topic_is_the_thread(bot):
+    message = bot.to_message(update(extra={"is_topic_message": True, "message_thread_id": 9}))
+    assert message.thread == "9"
+
+
+def test_bots_edits_and_channel_posts_are_dropped_and_media_is_named(bot):
+    assert bot.to_message(update(sender={"id": 1, "is_bot": True})) is None
+    assert bot.to_message({"update_id": 1, "edited_message": {}}) is None
+    photo = update(text=None, extra={"photo": [{"file_id": "x"}]})
+    del photo["message"]["text"]
+    assert bot.to_message(photo).text == "[photo]"
+
+
+def test_the_poll_loop_delivers_once_and_advances_the_offset(bot, tmp_path, monkeypatch):
+    box = Mailbox("telegram", home=tmp_path / "telegram")
+    calls = []
+    batches = iter([
+        FakeResponse({"ok": True, "result": [update(update_id=10), update(update_id=11, message_id=56)]}),
+        FakeResponse({"ok": True, "result": [update(update_id=10)]}),  # a redelivery
+        KeyboardInterrupt(),
+    ])
+
+    def fake_post(url, json=None, timeout=None):
+        calls.append(json)
+        item = next(batches)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    monkeypatch.setattr(telegram_module.requests, "post", fake_post)
+    monkeypatch.setattr(telegram_module.requests, "get", lambda url, timeout=None: FakeResponse(
+        {"ok": True, "result": {"id": 777, "username": "OpsBot"}}))
+
+    with pytest.raises(KeyboardInterrupt):
+        bot.run(box)
+
+    assert [c["offset"] for c in calls] == [None, 12, 12]
+    assert [p.name.split("-", 1)[1] for p in box.unread()] == ["-100123.55", "-100123.56"]
+    assert "duplicate -100123.55 dropped" in box.logfile.read_text()
+    assert "connected as @OpsBot" in box.logfile.read_text()
+
+
+def test_a_transport_error_in_the_loop_is_logged_and_retried(bot, tmp_path, monkeypatch):
+    box = Mailbox("telegram", home=tmp_path / "telegram")
+    slept = []
+    monkeypatch.setattr(telegram_module.time, "sleep", lambda s: slept.append(s))
+    attempts = iter([telegram_module.requests.ConnectionError("boom http://api.telegram.org/bot123:ABC"),
+                     KeyboardInterrupt()])
+
+    def fake_post(url, json=None, timeout=None):
+        raise next(attempts)
+
+    monkeypatch.setattr(telegram_module.requests, "post", fake_post)
+    monkeypatch.setattr(telegram_module.requests, "get", lambda url, timeout=None: FakeResponse(
+        {"ok": True, "result": {"id": 777, "username": "OpsBot"}}))
+
+    with pytest.raises(KeyboardInterrupt):
+        bot.run(box)
+
+    log = box.logfile.read_text()
+    assert "getUpdates failed: Telegram request failed (ConnectionError)" in log
+    assert "123:ABC" not in log
+    assert slept == [1.0]
+
+
+def test_reply_quotes_the_received_message(bot, monkeypatch):
+    posted = {}
+
+    def fake_post(url, json=None, timeout=None):
+        posted.update(url=url, json=json)
+        return FakeResponse({"ok": True, "result": {"message_id": 99}})
+
+    monkeypatch.setattr(telegram_module.requests, "post", fake_post)
+
+    assert bot.send("-100123", "fixed", reply_to="-100123.55") == "-100123.99"
+    assert posted["url"] == "https://api.telegram.org/bot123:ABC/sendMessage"
+    assert posted["json"] == {"chat_id": "-100123", "text": "fixed", "reply_parameters": {"message_id": 55}}
+
+
+def test_a_rate_limit_is_honoured_once_and_a_refusal_keeps_telegrams_words_minus_the_token(bot, monkeypatch):
+    slept = []
+    monkeypatch.setattr(telegram_module.time, "sleep", lambda s: slept.append(s))
+    responses = iter([
+        FakeResponse({"ok": False, "parameters": {"retry_after": 3}}, status_code=429),
+        FakeResponse({"ok": False, "description": "Bad Request: chat not found for 123:ABC"}),
+    ])
+    monkeypatch.setattr(telegram_module.requests, "post", lambda url, json=None, timeout=None: next(responses))
+
+    with pytest.raises(RuntimeError, match=r"chat not found for \[redacted\]"):
+        bot.send("-1", "hi")
+    assert slept == [3.0]
+
+
+def test_missing_token_names_botfather_and_check_reports_a_bad_token(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    (problem,) = Telegram().missing()
+    assert "@BotFather" in problem and "TELEGRAM_BOT_TOKEN" in problem
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bad")
+    monkeypatch.setattr(telegram_module.requests, "get", lambda url, timeout=None: FakeResponse(
+        {"ok": False, "description": "Unauthorized"}, status_code=401))
+    (problem,) = Telegram().check()
+    assert "Unauthorized" in problem

--- a/tests/unit/test_listen_telegram.py
+++ b/tests/unit/test_listen_telegram.py
@@ -188,3 +188,17 @@ def test_missing_token_names_botfather_and_check_reports_a_bad_token(monkeypatch
         {"ok": False, "description": "Unauthorized"}, status_code=401))
     (problem,) = Telegram().check()
     assert "Unauthorized" in problem
+
+
+def test_a_mention_after_an_emoji_is_still_ours(bot):
+    """Telegram counts entity offsets in UTF-16 code units: the rocket is
+    two units, so offset 3 means "after the emoji and a space"."""
+    message = bot.to_message(update(text="🚀 @OpsBot deploy", entities=[{"type": "mention", "offset": 3, "length": 7}]))
+    assert message.mentioned is True
+
+
+def test_the_missing_token_message_is_the_one_co_telegram_send_already_uses(monkeypatch):
+    from connectonion.useful_tools.telegram import NO_TOKEN
+
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    assert Telegram().missing() == [NO_TOKEN]


### PR DESCRIPTION
## Current release decision — 2026-09-15

Target approximately **1.8.8**, tentative, under #1463. Removed from 1.8.6; the replacement 1.8.6 plan is #1555. WhatsApp existing-group access #1543 is a separate 1.8.6 workstream. This supersedes earlier release dates below.

---

## Description

The second provider on the mailbox contract from DD-063 (#1399) and the Feishu PR (#1398). `co telegram` keeps the `send` it shipped with, unchanged, and gains `listen`, `receive`, `reply`, `done`, `check`, `ls`, `log` and `serve` on the same group with the same `TELEGRAM_BOT_TOKEN`.

```bash
co telegram listen                          # getUpdates long poll → ~/.co/telegram/
m=$(co telegram receive)                    # {"id":"-100123.55","chat":"-100123",...}
echo "on it" | co telegram reply -100123.55 # quotes the message it answers, in its chat
co telegram serve -- claude -p
```

Three Telegram-specific decisions, each one line in the provider and nothing in the mailbox:

- **Ids are `<chat>.<message_id>`** because Telegram's `message_id` is only unique within a chat; the mailbox dedupes on id, so a bare `55` from a second group would have been dropped as a redelivery.
- **The offset stays in memory.** Telegram keeps unacknowledged updates for a day and re-randomises ids after a week idle, so a persisted cursor is wrong for exactly the quiet bots whose owners would not notice. A restart re-reads what Telegram still holds and the mailbox's dedup drops what it has logged. A redelivered older update never moves the offset back.
- **`mentioned`** is true in a private chat; in a group when a `mention`/`bot_command` entity ends with the bot's username (from `getMe`) or the message replies to one of the bot's own. Entity offsets are UTF-16 code units, so the slice is taken on the UTF-16 form.

Stacked on #1398; the diff here is the Telegram provider, its registration, docs and tests.

## Related Issue

Part of #1389. Implements #352.

## Labels and target release (required)

- **Suggested labels:** feature, platform
- **Proposed target version:** After 1.8.5 (exact version unassigned)
- **Estimated release window:** After 1.8.5, once dependencies and live provider acceptance are complete
- **Milestone:** maintainer assigns
- **Why this release:** additive; `co telegram send` and its tests are untouched; no new dependency (Telegram is plain HTTPS via `requests`, already a dependency). `NO_TOKEN` and `API` are imported from `useful_tools/telegram.py`, not copied.
- **Forward-port tracking issue (stable patches only):** #1411

## How this was written

- [ ] I wrote this myself
- [ ] AI-assisted — I reviewed every line and can explain why each change is there
- [x] Mostly AI-generated

**Which model?** Claude Code in a remote session. The session's policy withholds the model name from repository artifacts.

- **Least confident:** `reply_parameters` requires Bot API 7.0+; older self-hosted Bot API servers want `reply_to_message_id`.
- **Not verified:** no live bot was polled. The loop, the offset handling and the redelivery path are exercised with a fake `requests.post`; `check`, `receive` and the help output were run against the real CLI without a token.
- **If wrong, what breaks first:** a group message that should count as mentioned arriving with `mentioned: false`; visible in `inbox.jsonl`, and the consumer still receives it.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Dev Blog (required)

> docs/blog/2026-09-02-a-message-id-is-not-unique.md

## Changes Made
- `connectonion/listen/telegram.py`: `Telegram` provider with `missing`/`check`/`me`, `run` (long poll, backoff on transport errors, offset never moves back), `to_message` (UTF-16-aware entity slicing), `send` (quotes via `reply_parameters`, honours one `retry_after`, never echoes the token).
- `connectonion/listen/__init__.py`: registers `telegram`.
- `connectonion/cli/main.py`: `_mailbox_group()` can attach to an existing group without its own `send`; Telegram gets the other verbs; help text.
- Docs: `docs/cli/telegram.md` listen section, CLI index, `PRODUCT.md` §11, `CLAUDE.md` tree.
- Tests: `tests/unit/test_listen_telegram.py`.

## Testing

```
$ .venv/bin/python -m pytest tests/unit/test_listen_telegram.py tests/unit/test_listen_mailbox.py tests/unit/test_listen_feishu.py tests/unit/test_listen_commands.py tests/unit/test_telegram.py tests/e2e/cli/test_cli_help.py -q
102 passed in 3.82s

$ co telegram --help | grep -oE "^│ (listen|receive|send|reply|done|check|ls|log|serve) "
send listen receive reply done check ls log serve
$ co telegram check          # no token
✗ TELEGRAM_BOT_TOKEN is not set. Create a bot by messaging @BotFather ...
exit=3
$ co telegram receive --no-start -t 0
exit=124
```

GitHub Actions on the current head: test matrix, browser and egress matrices, lockfile, blog-gate green.

- [x] I have added tests for new functionality

## Scope

`connectonion/listen/telegram.py` (new), one line in `listen/__init__.py`, a small change to `_mailbox_group` in `cli/main.py`, docs, tests.

## Checklist
- [x] I proposed at least one label and a target version above
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have made corresponding changes to the documentation
- [x] This PR ships its dev-blog post under docs/blog/
- [ ] Every piece of evidence the linked issue requires is attached — a live bot run is still owed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaAFWfbdhFGiYo64Hvn1gn

## Release scheduling update — 2026-09-05

All new messaging adapters are deferred until **after 1.8.5**. They are excluded from 1.8.2, 1.8.3, 1.8.4, and 1.8.5. The exact later version is not assigned yet. This supersedes earlier release estimates below; existing functionality is unaffected. Provider acceptance and dependency gates still apply. Coordination: #1389 and #1411.


