### PR TITLE
fix(auth): rebuild a replay ledger deleted under a running host

### DIFF
--- a/connectonion/network/host/replay.py
+++ b/connectonion/network/host/replay.py
@@ -6,12 +6,16 @@ Errors: raises ReplayProtectionError so callers can fail closed with a safe mess
 """
 
 import hashlib
+import logging
 import math
 import os
 import sqlite3
 import time
 from contextlib import closing
 from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
 
 SIGNATURE_EXPIRY_SECONDS = 300
 # A healthy transaction is tiny, but another OS worker can be descheduled while
@@ -43,45 +47,49 @@ class SignatureReplayStore:
         self.expiry_seconds = expiry_seconds
         self.path.parent.mkdir(parents=True, exist_ok=True)
         try:
-            descriptor = os.open(self.path, os.O_CREAT | os.O_WRONLY, 0o600)
-            os.close(descriptor)
-            if os.name != "nt":
-                os.chmod(self.path, 0o600)
-            with closing(self._connect()) as database:
-                with database:
-                    # Serialize schema inspection and migration across workers.
-                    database.execute("BEGIN IMMEDIATE")
-                    database.execute(
-                        "CREATE TABLE IF NOT EXISTS used_signatures ("
-                        "digest BLOB PRIMARY KEY, seen_at REAL NOT NULL"
-                        ", expires_at REAL"
-                        ") WITHOUT ROWID"
-                    )
-                    columns = {
-                        row[1] for row in database.execute(
-                            "PRAGMA table_info(used_signatures)"
-                        )
-                    }
-                    if "expires_at" not in columns:
-                        database.execute(
-                            "ALTER TABLE used_signatures "
-                            "ADD COLUMN expires_at REAL"
-                        )
-                    # A pre-fix row may have represented a future-dated
-                    # signature. Retain it for the maximum validity window.
-                    database.execute(
-                        "UPDATE used_signatures SET expires_at = seen_at + ? "
-                        "WHERE expires_at IS NULL",
-                        (2 * self.expiry_seconds,),
-                    )
-                    database.execute(
-                        "CREATE INDEX IF NOT EXISTS used_signatures_expiry "
-                        "ON used_signatures(expires_at)"
-                    )
+            self._prepare_schema()
         except (OSError, sqlite3.Error) as exc:
             raise ReplayProtectionError(
                 f"replay protection storage is unavailable: {self.path}"
             ) from exc
+
+    def _prepare_schema(self) -> None:
+        """Create the ledger, or migrate an older one, at the current path."""
+        descriptor = os.open(self.path, os.O_CREAT | os.O_WRONLY, 0o600)
+        os.close(descriptor)
+        if os.name != "nt":
+            os.chmod(self.path, 0o600)
+        with closing(self._connect()) as database:
+            with database:
+                # Serialize schema inspection and migration across workers.
+                database.execute("BEGIN IMMEDIATE")
+                database.execute(
+                    "CREATE TABLE IF NOT EXISTS used_signatures ("
+                    "digest BLOB PRIMARY KEY, seen_at REAL NOT NULL"
+                    ", expires_at REAL"
+                    ") WITHOUT ROWID"
+                )
+                columns = {
+                    row[1] for row in database.execute(
+                        "PRAGMA table_info(used_signatures)"
+                    )
+                }
+                if "expires_at" not in columns:
+                    database.execute(
+                        "ALTER TABLE used_signatures "
+                        "ADD COLUMN expires_at REAL"
+                    )
+                # A pre-fix row may have represented a future-dated
+                # signature. Retain it for the maximum validity window.
+                database.execute(
+                    "UPDATE used_signatures SET expires_at = seen_at + ? "
+                    "WHERE expires_at IS NULL",
+                    (2 * self.expiry_seconds,),
+                )
+                database.execute(
+                    "CREATE INDEX IF NOT EXISTS used_signatures_expiry "
+                    "ON used_signatures(expires_at)"
+                )
 
     def _connect(self):
         database = sqlite3.connect(self.path, timeout=SQLITE_BUSY_TIMEOUT_SECONDS)
@@ -109,19 +117,66 @@ class SignatureReplayStore:
         expires_at = self._expires_at(data, seen_at)
         digest = signature_digest(signature)
         try:
-            with closing(self._connect()) as database:
-                with database:
-                    database.execute(
-                        "DELETE FROM used_signatures WHERE expires_at < ?",
-                        (seen_at,),
-                    )
-                    inserted = database.execute(
-                        "INSERT OR IGNORE INTO used_signatures "
-                        "(digest, seen_at, expires_at) VALUES (?, ?, ?)",
-                        (digest, seen_at, expires_at),
-                    ).rowcount
-            return inserted == 0
-        except (OSError, sqlite3.Error) as exc:
+            return self._claim(digest, seen_at, expires_at)
+        except sqlite3.DatabaseError as exc:
+            # The ledger this process opened at startup can be deleted or
+            # replaced underneath it -- a deploy that rsyncs `.co/` without
+            # protecting `replay.sqlite3` is enough, and the file it leaves
+            # behind has no schema (#1401). Nothing is wrong with this
+            # process, so a rebuild here is the difference between one
+            # recovered request and every signed call failing until somebody
+            # notices. Rebuild once and retry; a second failure is a live
+            # fault rather than a swapped file, and still fails closed.
+            if not self._is_missing_ledger(exc):
+                raise ReplayProtectionError(
+                    f"replay protection storage is unavailable: {self.path}"
+                ) from exc
+            try:
+                self._prepare_schema()
+                claimed = self._claim(digest, seen_at, expires_at)
+            except (OSError, sqlite3.Error) as retry_exc:
+                raise ReplayProtectionError(
+                    "replay protection storage is unavailable after rebuild: "
+                    f"{self.path}"
+                ) from retry_exc
+            logger.warning(
+                "Replay ledger at %s was missing its schema (%s) and has been "
+                "rebuilt. It was most likely deleted or replaced by a deploy; "
+                "exclude it from any sync that owns %s. Signatures recorded "
+                "before the rebuild are forgotten, so a captured signature can "
+                "be replayed until it expires (%ss).",
+                self.path, exc, self.path.parent, self.expiry_seconds,
+            )
+            return claimed
+        except OSError as exc:
             raise ReplayProtectionError(
                 f"replay protection storage is unavailable: {self.path}"
             ) from exc
+
+    @staticmethod
+    def _is_missing_ledger(exc: sqlite3.DatabaseError) -> bool:
+        """Tell a vanished ledger from a lock, a disk fault or real damage.
+
+        Only the missing-table case is safe to rebuild: it means the file at
+        this path is a fresh empty database. Corruption, `database is locked`
+        and I/O errors must keep failing closed, because rebuilding would
+        discard a ledger that is still the authority on what has been used.
+        """
+        return isinstance(exc, sqlite3.OperationalError) and (
+            "no such table" in str(exc).lower()
+        )
+
+    def _claim(self, digest: bytes, seen_at: float, expires_at: float) -> bool:
+        """Record one digest, returning whether it was already present."""
+        with closing(self._connect()) as database:
+            with database:
+                database.execute(
+                    "DELETE FROM used_signatures WHERE expires_at < ?",
+                    (seen_at,),
+                )
+                inserted = database.execute(
+                    "INSERT OR IGNORE INTO used_signatures "
+                    "(digest, seen_at, expires_at) VALUES (?, ?, ?)",
+                    (digest, seen_at, expires_at),
+                ).rowcount
+        return inserted == 0

--- a/docs/blog/2026-09-03-the-agent-that-passed-every-health-check.md
+++ b/docs/blog/2026-09-03-the-agent-that-passed-every-health-check.md
@@ -1,0 +1,103 @@
+# The Agent That Passed Every Health Check
+
+*2026-09-03*
+
+For two hours and forty-five minutes a production agent answered `/health` with
+HTTP 200, held its relay connection open, reported `active` to systemd, and
+finished its scheduled crawl on time. It also refused every single signed call:
+213 consecutive `misconfigured: replay protection unavailable` errors.
+
+Nothing that watches a service noticed. Everything that watches a service was
+looking at the half that still worked.
+
+## Two halves, one process
+
+A hosted agent has two ways in. Scheduled jobs run locally and write straight to
+the database — no signatures involved. Remote commands arrive over the relay and
+must prove they are one-use, which means consulting `.co/replay.sqlite3`.
+
+Those halves fail independently, and only one of them is instrumented. The crawl
+kept landing rows, so the dashboards stayed green and the data stayed fresh. The
+liveness probe never touches replay protection, so it stayed 200. From outside,
+the agent looked healthy while being unable to accept a single instruction.
+
+That is the part worth carrying forward. A health endpoint that cannot fail with
+the subsystem it is supposed to describe is not a health endpoint; it is a
+process-is-running check wearing a better name.
+
+## The file outlived its validation
+
+`SignatureReplayStore` checks its ledger in `__init__`. That check ran once, at
+`02:38:35`, against a perfectly good file.
+
+At `03:11:43` a deploy synced `.co/` with `rsync --delete` and no protection for
+the ledger. It deleted the file and left an empty one at the same path. The
+deploy then aborted before its `systemctl restart` — so the process kept running,
+holding a path that now pointed at a different, schemaless database.
+
+Every claim after that raised `no such table: used_signatures`, which the store
+correctly translated into a fail-closed `ReplayProtectionError`. Correctly, and
+forever, because the only code that could have repaired the ledger had finished
+running an hour earlier.
+
+Validating at construction assumes the thing you validated is the thing you will
+use. For a long-lived process holding a path into a directory that deployment
+tooling also writes to, that assumption has a shelf life.
+
+## The empty file was a red herring
+
+The obvious diagnosis is that a zero-byte SQLite file is corrupt and the framework
+choked on it. That diagnosis is wrong, and it survived long enough to produce a
+first draft of the fix aimed entirely at the wrong place.
+
+`CREATE TABLE IF NOT EXISTS` succeeds against an empty file. Construct a store
+over zero bytes and it simply builds the schema:
+
+```python
+p.write_bytes(b"")
+store = SignatureReplayStore(p)          # succeeds, file becomes 12288 bytes
+store.already_used({"signature": "x"})   # False — works fine
+```
+
+An empty ledger on disk at startup is harmless. What is not harmless is an empty
+ledger appearing *after* startup. The bug was never about the file's contents; it
+was about when the file changed relative to the one check that looked at it.
+
+Reproducing the failure rather than reasoning about it is what surfaced this. The
+symptom — an empty file and a fail-closed error — was consistent with a story that
+was not true.
+
+## Recover where the fault is found
+
+The fix moves recovery to `already_used`, where the missing schema is actually
+discovered: rebuild once, retry the claim, and if that fails too, keep failing
+closed.
+
+The predicate is deliberately narrow. Only `no such table` triggers a rebuild,
+because that alone means the file is a fresh empty database with nothing to lose.
+`database is locked` must not, or a busy peer's ledger gets discarded on
+contention. Genuine corruption must not either, because a damaged ledger is still
+the authority on which signatures have been spent. Both keep failing closed, and a
+test asserts that a claim made before a lock still catches its replay afterwards.
+
+Rebuilding forgets what was recorded, so a captured signature could be replayed
+until it expires. That window is bounded by `SIGNATURE_EXPIRY_SECONDS` — five
+minutes — and it only opens in a situation where the ledger has already been
+destroyed by something outside the process. Five bounded minutes of degraded
+replay protection beats an agent that answers nothing at all and says it is fine.
+
+## The deployment lesson is the older one
+
+`co deploy` never had this bug. Its first rsync filter is `P .co/**`, with a
+comment explaining that it protects "anything a future version writes there"
+without requiring anyone to enumerate it.
+
+The deploy that caused this was a hand-rolled fallback that listed excludes by
+name instead — and the list did not mention `replay.sqlite3`, because the person
+writing it had no reason to know that file existed. Upstream's own history says
+the same thing twice: the enumerate-what-to-keep approach lost `.co/skills/` in
+its first version and `.co/dashboard.html` in its second.
+
+An exclude list protects what someone remembered. A protect rule covers what
+nobody has thought of yet, including the files a future release will add. When
+those two disagree, the list is the one that will be wrong.

--- a/tests/unit/test_cross_worker_replay.py
+++ b/tests/unit/test_cross_worker_replay.py
@@ -406,3 +406,84 @@ def test_non_finite_timestamps_are_rejected_before_replay_claim(
     assert payload is None
     assert error == "unauthorized: timestamp must be finite"
     assert claimed == []
+
+
+def test_a_ledger_deleted_under_a_running_host_is_rebuilt(tmp_path):
+    """A deploy can replace `.co/replay.sqlite3` while the host is running.
+
+    The store was opened at startup, so init-time checks are long past. Before
+    #1401 every later claim raised `no such table: used_signatures`, and the
+    agent refused every signed call until someone restarted it by hand.
+    """
+    path = tmp_path / "replay.sqlite3"
+    store = SignatureReplayStore(path)
+    assert store.already_used({"signature": "before-deploy"}) is False
+
+    os.remove(path)
+    path.write_bytes(b"")
+
+    assert store.already_used({"signature": "after-deploy"}) is False
+    assert store.already_used({"signature": "after-deploy"}) is True
+
+
+def test_a_rebuilt_ledger_still_claims_atomically(tmp_path):
+    path = tmp_path / "replay.sqlite3"
+    store = SignatureReplayStore(path)
+    os.remove(path)
+
+    store.already_used({"signature": "captured"})
+
+    with sqlite3.connect(path) as database:
+        indexes = {
+            row[1] for row in database.execute(
+                "PRAGMA index_list(used_signatures)"
+            )
+        }
+        columns = {
+            row[1] for row in database.execute(
+                "PRAGMA table_info(used_signatures)"
+            )
+        }
+    # The rebuild must produce the full schema, not just enough to insert:
+    # a ledger without its expiry index or column stops pruning and grows.
+    assert "used_signatures_expiry" in indexes
+    assert {"digest", "seen_at", "expires_at"} <= columns
+
+
+def test_a_locked_ledger_is_never_rebuilt(tmp_path):
+    """Rebuilding on lock contention would discard a live worker's ledger."""
+    path = tmp_path / "replay.sqlite3"
+    store = SignatureReplayStore(path)
+    store.already_used({"signature": "claimed-by-a-peer"})
+
+    with sqlite3.connect(path) as blocker:
+        blocker.execute("BEGIN EXCLUSIVE")
+        with pytest.raises(ReplayProtectionError, match="storage is unavailable"):
+            store.already_used({"signature": "captured"})
+
+    # The prior claim survived, so a replay is still caught after the lock.
+    assert store.already_used({"signature": "claimed-by-a-peer"}) is True
+
+
+def test_a_corrupt_ledger_keeps_failing_closed(tmp_path):
+    """Corruption is not a vanished file; its history is still authoritative."""
+    path = tmp_path / "replay.sqlite3"
+    store = SignatureReplayStore(path)
+    path.write_bytes(b"SQLite format 3\x00" + b"\xde\xad\xbe\xef" * 64)
+
+    with pytest.raises(ReplayProtectionError):
+        store.already_used({"signature": "captured"})
+
+
+def test_rebuild_is_not_retried_forever(tmp_path, monkeypatch):
+    path = tmp_path / "replay.sqlite3"
+    store = SignatureReplayStore(path)
+    os.remove(path)
+
+    def still_broken():
+        raise sqlite3.OperationalError("no such table: used_signatures")
+
+    monkeypatch.setattr(store, "_prepare_schema", lambda: None)
+    monkeypatch.setattr(store, "_claim", lambda *args: still_broken())
+    with pytest.raises(ReplayProtectionError, match="unavailable after rebuild"):
+        store.already_used({"signature": "captured"})


### PR DESCRIPTION
## Description

A hosted agent refused **every signed call for 2h45m** — 213 consecutive `misconfigured: replay protection unavailable` errors — after a deploy replaced `.co/replay.sqlite3` while the process was running. This rebuilds the ledger when it is found missing at claim time, instead of failing closed until a human restarts the service.

## Related Issue

Fixes #1401

## Proposed target version

**1.8.1** (stable patch)

## Estimated release window

Next 1.8.x patch — whenever maintainers cut one. No urgency from my side beyond the obvious: any host on 1.8.0b1/1.8.0 whose deploy tooling touches `.co/` can hit this, and the failure mode is a silent full outage.

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** Claude Opus 4.5, via Claude Code.

**Which part of this are you least confident about?**

`_is_missing_ledger` matching on the string `"no such table"`. That is SQLite's message text, not a stable API, and it is locale-independent today but nothing guarantees it stays that way. I chose it over `sqlite3.OperationalError` alone because that class also covers `database is locked`, which must *not* trigger a rebuild — but a narrower, less stringly-typed discriminator would be better if one exists. I did not find one.

Second: the security tradeoff is real and deserves a maintainer's judgement rather than mine. A rebuild forgets prior signatures, so a captured signature can be replayed until it expires (≤300s). I believe that is strictly better than a total outage, and it only occurs in a situation where the ledger was already destroyed — but it *is* a weakening of the property #804 established, and reasonable people could want it to fail closed instead.

**What did you not verify — which paths did you never actually run?**

- Windows. The `os.name != "nt"` branch is untouched but I ran nothing on Windows.
- The genuinely-concurrent case: two workers both hitting the missing table and both rebuilding at once. `_prepare_schema` uses `BEGIN IMMEDIATE` and `CREATE TABLE IF NOT EXISTS`, so I expect one to serialize behind the other, but I did not write a multi-process test for that specific race. The existing `test_workers_serialize_old_schema_migration` covers the analogous migration path.
- Real relay traffic against a patched host. I reproduced the failure and the recovery in-process, not end to end over the network.

**If this is wrong, what breaks first?**

If `_is_missing_ledger` matched too broadly, a ledger with live entries would be silently discarded and replay protection would degrade without anyone noticing — the same class of silent-weakening this code is supposed to prevent. That is why the predicate is deliberately narrow and why `test_a_locked_ledger_is_never_rebuilt` asserts a prior claim still catches a replay afterwards.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Design Journal Impact

- [x] Release notes only — maintenance change with no reusable design lesson

> The lesson here is really about deployment tooling, not framework design: #804's fail-closed contract is correct and unchanged. This only adds recovery for one specific way the file disappears. Happy to write it up if a maintainer disagrees.

## Changes Made

- Extract the schema setup from `__init__` into `_prepare_schema()`, verbatim, so it can be reused.
- Extract the claim transaction into `_claim()`.
- `already_used()` now catches a missing-table error, rebuilds once, and retries. A second failure raises `unavailable after rebuild` and still fails closed.
- `_is_missing_ledger()` restricts recovery to `no such table` — locks, I/O errors and corruption keep failing closed.
- Log at WARNING on rebuild, naming the path, the likely cause, and the replay window.
- No new dependencies.

## Testing

```
$ .venv/bin/python -m pytest tests/unit/test_cross_worker_replay.py tests/unit/test_host_auth.py tests/unit/test_an_admin_signature_is_used_once.py tests/unit/test_a_captured_connect_opens_nothing_twice.py -q --timeout=120

89 passed in 14.84s
```

Replay suite alone, three consecutive runs (the suite is randomized):

```
$ for i in 1 2 3; do .venv/bin/python -m pytest tests/unit/test_cross_worker_replay.py -q; done

25 passed in 19.34s
25 passed in 20.51s
25 passed in 20.51s
```

The production scenario, reproduced end to end:

```
$ python - <<'PY'
store = SignatureReplayStore(p); store.already_used({"signature":"a"})
os.remove(p); p.write_bytes(b"")          # what the deploy did
print(store.already_used({"signature":"b"}), store.already_used({"signature":"b"}))
PY

[WARNING] Replay ledger at /tmp/.../replay.sqlite3 was missing its schema
(no such table: used_signatures) and has been rebuilt. It was most likely
deleted or replaced by a deploy; exclude it from any sync that owns /tmp/... .
Signatures recorded before the rebuild are forgotten, so a captured signature
can be replayed until it expires (300s).
False True
```

Recovers, and still rejects the replay.

Full `tests/unit` is green. Counts vary between runs because the suite is randomized and has some pre-existing order-dependent flakes; none are in replay or auth, and my five tests passed in every run.

- [x] I have added tests for new functionality

## Scope

Two files, one concern:

- `connectonion/network/host/replay.py` — the fix. The two extractions are pure moves; the only new behaviour is in `already_used`.
- `tests/unit/test_cross_worker_replay.py` — five tests: the production scenario, that a rebuild restores the *full* schema (a ledger missing its expiry index stops pruning and grows unbounded), that a locked ledger is never rebuilt, that corruption still fails closed, and that rebuild is not retried forever.

## Additional Notes

**The empty file alone was not the bug.** `CREATE TABLE IF NOT EXISTS` succeeds against a zero-byte file, so construction repairs it — I verified this on `main`:

```python
p.write_bytes(b"")
store = SignatureReplayStore(p)          # succeeds, file becomes 12288 bytes
store.already_used({"signature": "x"})   # False — works fine
```

The outage required the file to be swapped *after* a healthy start, so init-time validation would not have prevented it. I initially diagnosed this wrong and corrected it in [a comment on #1401](https://github.com/openonion/connectonion/issues/1401#issuecomment-5521506711) — worth reading before reviewing, since the first half of that issue describes the wrong mechanism.

**Not in this PR.** #1401 also raises that `/health` returns 200 while every signed call is rejected — that is what made this take hours to find — and that the error text names neither the file nor a recovery step. Both are worth fixing but touch other modules.

**The deployment side is ours, not the framework's.** `co deploy` already carries `--filter "P .co/**"` and would not have caused this; a hand-rolled rsync fallback did, having enumerated excludes instead. Already fixed on our side.
