### PR TITLE
Paying for a browser is opt-in: the default engine is system Chrome

### DIFF
--- a/connectonion/cli/commands/browser_commands.py
+++ b/connectonion/cli/commands/browser_commands.py
@@ -19,7 +19,7 @@ USAGE = (
     "co browser — drive one persistent browser from the shell\n"
     "\n"
     "  co browser [-t TAB] <function> [args]    run a browser function (bare = the shared 'main' tab)\n"
-    "  co browser --engine auto|system|onion <function> [args]\n"
+    "  co browser --engine onion <function> [args]   pay for the WTF Browser (default: system Chrome)\n"
     '  co browser [-t TAB] do "<instruction>"   let the AI agent do it — same targeting grammar\n'
     '  co browser tab open [NAME] [--who <agent>] [--for "<purpose>"]   register a tab; prints its name\n'
     "  co browser tab ls [--json]               the board: every tab, who runs it, last command\n"

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -318,7 +318,11 @@ def doctor(
 @app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 def browser(
     headless: bool = typer.Option(False, "--headless/--no-headless", help="Run browser headless"),
-    engine: str = typer.Option("auto", "--engine", help="Browser engine: auto, system, or onion"),
+    engine: str = typer.Option(
+        "auto",
+        "--engine",
+        help="Browser engine: system Chrome by default; --engine onion pays for the WTF Browser",
+    ),
     args: List[str] = typer.Argument(None, help="Browser function + args, or: do \"<instruction>\""),
 ):
     """Drive one persistent browser. Run a function directly (co browser go_to x.com),

--- a/connectonion/useful_tools/browser_tools/engine.py
+++ b/connectonion/useful_tools/browser_tools/engine.py
@@ -18,6 +18,7 @@ MIN_ONIONWRIGHT_VERSION = "0.0.13"
 
 class Reason:
     SYSTEM_REQUESTED = "system_requested"
+    SYSTEM_DEFAULT = "system_default"
     ONION_READY = "onion_ready"
     INVALID_MODE = "invalid_engine_mode"
     ONIONWRIGHT_MISSING = "onionwright_missing"
@@ -47,7 +48,17 @@ class Resolution:
 
     @property
     def fallback(self) -> bool:
-        return self.requested == AUTO and self.resolved == SYSTEM
+        """Whether a paid engine was attempted and could not be used.
+
+        The plain default is not a fallback: since paying became opt-in,
+        `auto` resolves to system Chrome without attempting anything, and
+        calling that a fallback would report a failure that never happened.
+        """
+        return (
+            self.requested == AUTO
+            and self.resolved == SYSTEM
+            and self.reason != Reason.SYSTEM_DEFAULT
+        )
 
     @property
     def artifact_id(self) -> str | None:
@@ -70,11 +81,9 @@ class Resolution:
     def interval_usd(self) -> float | None:
         """What one billing interval costs, when the server said.
 
-        Surfaced so a paid session can say what it costs. `auto` resolves to
-        the paid engine whenever preparation succeeds, so an ordinary command
-        can start a billable session; spending money without saying so in the
-        output is the part of that which is wrong however the default is
-        settled (#1327).
+        Surfaced so a paid session can say what it costs. Only an explicit
+        `onion` request reaches a paid session now (#1327), and it still has to
+        say what that session costs.
         """
         capability = getattr(self.prepared, "capability", None)
         price = getattr(capability, "interval_usd", None)
@@ -132,6 +141,13 @@ def _system(requested: str, reason: str, next_action: str) -> Resolution:
 
 
 def _unavailable(requested: str, reason: str, next_action: str) -> Resolution:
+    """Report a paid engine that could not be prepared.
+
+    Only an explicit `onion` request reaches this now, and an explicit request
+    never becomes system silently. The `auto` branch is kept because the
+    fallback shape is what makes an added mode safe by default rather than
+    billable by accident.
+    """
     if requested == ONION:
         raise BrowserEngineError(reason, next_action)
     return _system(requested, reason, next_action)
@@ -147,11 +163,13 @@ def resolve(
 ) -> Resolution:
     """Resolve one immutable engine choice without starting a paid session.
 
-    `system` returns before importing Onionwright, loading a token, calling the
-    server, or touching the paid cache. `auto` and `onion` run Onionwright's
-    complete non-billing `prepare`: exact signed manifest, compatibility,
-    download, checksum, extraction, and executable readiness. Only the later
-    `launch()` call is allowed to create and charge a session.
+    `system` and `auto` return before importing Onionwright, loading a token,
+    calling the server, or touching the paid cache: the default engine is the
+    installed system Chrome, and money is never spent unless the caller asks
+    for it by name. `onion` runs Onionwright's complete non-billing `prepare`:
+    exact signed manifest, compatibility, download, checksum, extraction, and
+    executable readiness, and fails with a typed error rather than falling back.
+    Only the later `launch()` call is allowed to create and charge a session.
     """
     if requested not in MODES:
         raise BrowserEngineError(
@@ -163,6 +181,21 @@ def resolve(
             SYSTEM,
             Reason.SYSTEM_REQUESTED,
             "Start Patchright with the installed system Chrome.",
+        )
+    if requested == AUTO:
+        # Paying is opt-in. `auto` used to resolve to the paid engine whenever
+        # preparation succeeded, which meant an ordinary `co browser go_to`
+        # could open a billable session on a machine that merely had
+        # Onionwright installed (#1327 named the problem and left the default
+        # to be settled). It is settled here: nothing charges unless the caller
+        # names `onion`. `auto` stays a valid mode because the CLI, the client
+        # and the daemon all use it as the wire value for "not chosen", so a
+        # warm paid daemon still serves later verbs that name no engine.
+        return _system(
+            AUTO,
+            Reason.SYSTEM_DEFAULT,
+            "Start Patchright with the installed system Chrome; "
+            "use --engine onion to start a paid WTF Browser session.",
         )
 
     paid_home = home or Path.home() / ".onionwright"

--- a/docs/blog/2026-09-05-the-default-that-could-spend-your-money.md
+++ b/docs/blog/2026-09-05-the-default-that-could-spend-your-money.md
@@ -1,0 +1,88 @@
+# The default that could spend your money
+
+`co browser go_to example.com` is the first browser command anyone runs. Until
+today, on a machine that happened to have Onionwright installed and a little
+credit in the account, that command could open a paid session and start
+charging $0.025 every fifteen minutes. Nobody had asked for the paid browser.
+They had asked for a web page.
+
+The mechanism was `--engine`, which takes `auto`, `system` or `onion` and
+defaulted to `auto`. `auto` meant "use the paid Onion browser whenever its
+preflight succeeds, otherwise fall back to system Chrome". That is a sensible
+sentence in isolation. It is a different sentence when you notice that `auto`
+is also what a command sends when it says nothing at all about engines.
+
+The code said so plainly, in the docstring of the property that reports the
+price:
+
+> `auto` resolves to the paid engine whenever preparation succeeds, so an
+> ordinary command can start a billable session; spending money without saying
+> so in the output is the part of that which is wrong however the default is
+> settled.
+
+That comment is from #1327, which found the problem, fixed the silence, and
+left the default itself for someone to decide. This is that decision: nothing
+charges unless the caller writes `--engine onion`.
+
+## The fix that looks right and isn't
+
+The obvious change is one character of the CLI: make the `--engine` option
+default to `system` instead of `auto`. It is one line, it is easy to review,
+and it does not fix the problem.
+
+An Agent driving a browser does not go through the CLI option. It constructs
+the browser core directly, and that constructor has its own default:
+
+```python
+engine_mode: str = browser_engine.AUTO,
+```
+
+Change only the CLI and every human typing `co browser` is safe while every
+agent using the browser tool still resolves to the paid engine. The thing
+being defaulted is not the flag. It is what `auto` *means*.
+
+## Why `auto` survived
+
+The tempting follow-up is to delete `auto` and leave two honest modes. Reading
+the client is what stopped that. `auto` is not only a user-facing choice: it is
+the wire value for "the caller named no engine". The client omits `--engine`
+entirely when the mode is `auto`, and spawns the daemon without one:
+
+```python
+if engine_mode != "auto":
+    request_kwargs["engine_mode"] = engine_mode
+```
+
+A browser daemon is pinned to the engine it started with and refuses to swap
+engines while warm — for good reason, since the alternative is a session whose
+billing changes underneath it. So if every ordinary verb started sending an
+explicit `system`, then `co browser --engine onion go_to ...` followed by a
+plain `co browser get_text` would stop working: the warm paid daemon would
+refuse the second command as a hot swap. The multi-step paid workflow would
+need `--engine onion` typed on every line.
+
+Keeping `auto` as the wire sentinel and changing where it *resolves* keeps that
+workflow intact. A cold start with no engine gives you system Chrome. A paid
+session you opened on purpose keeps serving the verbs that follow it.
+
+## What was checked before changing it
+
+Two things could have made this change break something quietly.
+
+The remote browser needs the Onion engine to exist — its egress gateway has no
+meaning without it — so if that path relied on `auto` reaching the paid engine,
+this change would have broken it. It does not: the private daemon has always
+demanded an explicit `onion`, and a test asserts that both `auto` and `system`
+are rejected there before any runtime is created.
+
+And `Resolution.fallback` was defined as "requested auto, resolved system",
+which after this change would be true of every ordinary command. A status field
+that reports a failed paid attempt on a run where nothing was attempted is
+worse than no field, so it now excludes the plain default.
+
+## The shape of the lesson
+
+A default is not the value written next to the flag. It is every path that
+reaches the code when nobody made a choice — the CLI option, the library
+constructor, the wire value for "unspecified". Fixing the one you can see is
+how you ship a fix and keep the bug.

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -18,10 +18,13 @@ The browser stays open **between commands**. Each `co browser ...` call drives t
 ConnectOnion 1.8 resolves the engine once when the browser daemon starts:
 
 ```bash
-co browser --engine auto go_to example.com    # default
-co browser --engine system go_to example.com  # always Patchright + system Chrome
-co browser --engine onion go_to example.com   # strict paid Onion Browser
+co browser go_to example.com                  # default: Patchright + system Chrome, $0
+co browser --engine system go_to example.com  # the same thing, said explicitly
+co browser --engine onion go_to example.com   # paid WTF Browser, and only when asked
 ```
+
+Paying is opt-in. An ordinary command never starts a billable session, even on
+a machine where Onionwright is installed and in credit.
 
 The paid path requires Onionwright 0.0.13 or newer. Install or upgrade the real
 private wheel explicitly:
@@ -39,9 +42,13 @@ artifact endpoint, not the public PyPI placeholder.
 
 | mode | behavior |
 |---|---|
-| `auto` | Run Onionwright's non-billing compatibility/artifact preflight. Use the exact verified Onion artifact when ready; otherwise use system Chrome and report a typed fallback reason. |
-| `system` | Return before importing Onionwright, reading paid credentials, calling oo-api, downloading an artifact, or creating a paid session. Cost: $0 browser runtime. |
+| `auto` | The default, and what every command that names no engine sends. Resolves to system Chrome without importing Onionwright, reading paid credentials, calling oo-api, or downloading an artifact. Cost: $0. |
+| `system` | The same resolution, requested explicitly. |
 | `onion` | Require the compatible Onion artifact and enough balance. Any preflight failure is returned as a typed error; there is no silent system fallback. |
+
+A daemon is pinned to the engine it started with, so `--engine onion go_to ...`
+followed by a plain `co browser get_text` keeps using the paid browser you
+opened. Starting fresh with no engine gives you system Chrome again.
 
 Artifact checking and download do not charge. A paid session starts only after
 the complete artifact is locally ready, then prepays $0.025 for one 15-minute

--- a/tests/unit/test_browser_engine_choice.py
+++ b/tests/unit/test_browser_engine_choice.py
@@ -36,10 +36,10 @@ def test_system_returns_before_token_or_onionwright():
     assert not result.fallback
 
 
-def test_auto_ready_selects_exact_prepared_onion_artifact(tmp_path):
+def test_explicit_onion_selects_exact_prepared_artifact(tmp_path):
     client = Client(prepared(artifact_id="chrome/150.0/linux-x86_64.tar.zst"))
     result = engine.resolve(
-        engine.AUTO,
+        engine.ONION,
         token_loader=lambda: "token",
         client_factory=lambda token, home: client,
         home=tmp_path,
@@ -48,6 +48,29 @@ def test_auto_ready_selects_exact_prepared_onion_artifact(tmp_path):
     assert result.client is client
     assert result.artifact_id == "chrome/150.0/linux-x86_64.tar.zst"
     assert client.calls == [engine.BROWSER_REVISION]
+
+
+def test_default_engine_cannot_reach_the_paid_path_even_when_it_would_succeed(tmp_path):
+    """The default must not spend money on a machine that merely could.
+
+    A ready paid client is offered and must go untouched: `auto` is what every
+    ordinary `co browser ...` sends, and it resolves to system Chrome without
+    a token, an Onionwright import, or a preflight call.
+    """
+    def forbidden(*args):
+        pytest.fail("the default engine touched the paid path")
+
+    result = engine.resolve(
+        engine.AUTO,
+        token_loader=forbidden,
+        client_factory=forbidden,
+        home=tmp_path,
+    )
+    assert result.resolved == engine.SYSTEM
+    assert result.reason == engine.Reason.SYSTEM_DEFAULT
+    assert result.client is None
+    assert result.interval_usd is None
+    assert not result.fallback
 
 
 @pytest.mark.parametrize("reason", [
@@ -59,18 +82,16 @@ def test_auto_ready_selects_exact_prepared_onion_artifact(tmp_path):
     "checksum_mismatch",
     "insufficient_balance",
 ])
-def test_auto_preflight_failure_falls_back_before_billing(reason, tmp_path):
+def test_explicit_onion_preflight_failure_is_typed_before_billing(reason, tmp_path):
     client = Client(prepared(ready=False, reason=reason, action="use system"))
-    result = engine.resolve(
-        engine.AUTO,
-        token_loader=lambda: "token",
-        client_factory=lambda token, home: client,
-        home=tmp_path,
-    )
-    assert result.resolved == engine.SYSTEM
-    assert result.fallback
-    assert result.reason == reason
-    assert result.client is None
+    with pytest.raises(engine.BrowserEngineError) as caught:
+        engine.resolve(
+            engine.ONION,
+            token_loader=lambda: "token",
+            client_factory=lambda token, home: client,
+            home=tmp_path,
+        )
+    assert caught.value.reason == reason
 
 
 def test_explicit_onion_never_falls_back(tmp_path):
@@ -86,13 +107,13 @@ def test_explicit_onion_never_falls_back(tmp_path):
     assert caught.value.next_action == "top up"
 
 
-def test_auto_without_credentials_is_typed_system_fallback():
-    result = engine.resolve(
-        engine.AUTO,
-        token_loader=lambda: (_ for _ in ()).throw(RuntimeError("no token")),
-    )
-    assert result.resolved == engine.SYSTEM
-    assert result.reason == engine.Reason.LICENSE_UNAVAILABLE
+def test_explicit_onion_without_credentials_is_typed_and_explicit():
+    with pytest.raises(engine.BrowserEngineError) as caught:
+        engine.resolve(
+            engine.ONION,
+            token_loader=lambda: (_ for _ in ()).throw(RuntimeError("no token")),
+        )
+    assert caught.value.reason == engine.Reason.LICENSE_UNAVAILABLE
 
 
 def test_invalid_mode_is_never_guessed():
@@ -104,13 +125,13 @@ def test_invalid_mode_is_never_guessed():
 def test_installed_old_onionwright_is_typed_incompatible_before_preflight():
     client = Client(prepared())
     client.client_version = "0.0.10"
-    result = engine.resolve(
-        engine.AUTO,
-        token_loader=lambda: "token",
-        client_factory=lambda token, home: client,
-    )
-    assert result.resolved == engine.SYSTEM
-    assert result.reason == engine.Reason.ONIONWRIGHT_INCOMPATIBLE
+    with pytest.raises(engine.BrowserEngineError) as caught:
+        engine.resolve(
+            engine.ONION,
+            token_loader=lambda: "token",
+            client_factory=lambda token, home: client,
+        )
+    assert caught.value.reason == engine.Reason.ONIONWRIGHT_INCOMPATIBLE
     assert client.calls == []
 
 
@@ -128,19 +149,19 @@ def test_installed_sync_only_onionwright_is_rejected_before_client_or_preflight(
         "onionwright",
         SimpleNamespace(PaidSessionClient=paid_client),
     )
-    result = engine.resolve(
-        engine.AUTO,
-        token_loader=lambda: "token",
-    )
-    assert result.resolved == engine.SYSTEM
-    assert result.reason == engine.Reason.ONIONWRIGHT_INCOMPATIBLE
+    with pytest.raises(engine.BrowserEngineError) as caught:
+        engine.resolve(
+            engine.ONION,
+            token_loader=lambda: "token",
+        )
+    assert caught.value.reason == engine.Reason.ONIONWRIGHT_INCOMPATIBLE
     assert constructed == []
 
 
 def test_public_status_contains_no_client_token_or_local_path(tmp_path):
     client = Client(prepared())
     result = engine.resolve(
-        engine.AUTO,
+        engine.ONION,
         token_loader=lambda: "super-secret",
         client_factory=lambda token, home: client,
         home=tmp_path,

--- a/tests/unit/test_browser_engine_resolve.py
+++ b/tests/unit/test_browser_engine_resolve.py
@@ -92,16 +92,17 @@ def test_system_resolution_cannot_cross_the_billing_boundary():
         engine.launch(result, "playwright", "key")
 
 
-def test_client_constructor_import_failure_is_auto_fallback():
-    result = engine.resolve(
-        engine.AUTO,
-        token_loader=lambda: "token",
-        client_factory=lambda token, home: (_ for _ in ()).throw(
-            ModuleNotFoundError("No module named 'onionwright'")
-        ),
-    )
-    assert result.resolved == engine.SYSTEM
-    assert result.reason == engine.Reason.ONIONWRIGHT_MISSING
+def test_missing_onionwright_is_named_rather_than_silently_free():
+    """An explicit paid request says what to install instead of going free."""
+    with pytest.raises(engine.BrowserEngineError) as caught:
+        engine.resolve(
+            engine.ONION,
+            token_loader=lambda: "token",
+            client_factory=lambda token, home: (_ for _ in ()).throw(
+                ModuleNotFoundError("No module named 'onionwright'")
+            ),
+        )
+    assert caught.value.reason == engine.Reason.ONIONWRIGHT_MISSING
 
 
 def test_prepare_exception_is_typed_and_explicit_onion_fails():


### PR DESCRIPTION
Closes the `auto`-charges-money item in #1396 (item E).

## What changed

`resolve()` mapped `auto` to the paid Onion engine whenever Onionwright was installed and its preflight succeeded, so an ordinary `co browser go_to example.com` could open a billable session on a machine whose owner never asked to spend anything. The `interval_usd` docstring said so in as many words: "`auto` resolves to the paid engine whenever preparation succeeds, so an ordinary command can start a billable session". #1327 named the problem and left the default to be settled. This settles it: nothing charges unless the caller writes `--engine onion`.

## Why `auto` stays a mode

`auto` is not only a user-facing choice, it is the wire value for "engine not chosen": `client.py` omits `--engine` and spawns the daemon without one when the mode is `auto` (`client.py:417`, `:747`, `:756`), and the daemon defaults to it. Removing it would make every ordinary verb send an explicit `system`, which a warm daemon pinned to `onion` refuses as a hot swap. Keeping it means `--engine onion go_to ...` followed by a plain `co browser get_text` still drives the paid browser you opened, while a cold start with no engine is system Chrome.

Checked before changing it: the private/remote browser path already required an explicit `onion` and never relied on `auto` reaching the paid engine (`daemon.py:254`, and `test_private_daemon_rejects_every_non_onion_engine_before_runtime` asserts both `auto` and `system` are rejected there). `Resolution.fallback` has no consumer outside `engine.public_status()`.

## Also

- `Resolution.fallback` is false for the plain default. It used to be `requested == AUTO and resolved == SYSTEM`, which after this change would report a paid attempt that never happened.
- Tests that exercised the paid preflight through `auto` now request `onion`, which is the only way to reach it. A new test offers a ready paid client to `auto` and fails if the token loader or client factory is touched at all.
- `docs/cli/browser.md` and the CLI help say the default is system Chrome and that paying is opt-in.

## Verification

`713 passed` across every browser/engine unit test (`-k "browser or engine"`), including the remote-browser, paid-launch-seam, status and sync-facade suites.

Note for reviewers: this changes `auto`'s meaning rather than the CLI's default value, and those are different fixes. Changing only the CLI default would leave library callers (`AsyncBrowserCore(engine_mode=AUTO)`, which is the default an Agent gets) still able to charge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmCtowqB3DqGVPpTb1VU3S



**Proposed target version:** 1.8.1a1 / next preview
**Estimated release window:** the 1.8.1a1 preview once #1405 is clear, then 1.8.1 stable after it is exercised
