### PR TITLE
fix(outlook): scheduled replies become a deferred reply draft, not a reply action

### DIFF
--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -2,7 +2,7 @@
 Purpose: Outlook integration tool for email and contact management via Microsoft Graph API
 LLM-Note:
   Dependencies: imports from [os, html, httpx] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth microsoft' | tested by [tests/unit/test_outlook.py]
-  Data flow: Agent calls Outlook methods → _get_access_token() uses a cached Microsoft access token while its expiry is valid or unknown, preemptively refreshing near expiry via oo-api and refreshing after a Graph 401 → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | download_attachments() decodes Graph fileAttachment bytes into a caller-selected project directory without overwriting existing paths | send()/reply() with attachments share _encoded_attachments() (validate, size-check, base64) and place fileAttachments on the sent message — reply() puts them on the reply action's message so Graph still threads it | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
+  Data flow: Agent calls Outlook methods → _get_access_token() uses a cached Microsoft access token while its expiry is valid or unknown, preemptively refreshing near expiry via oo-api and refreshing after a Graph 401 → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | download_attachments() decodes Graph fileAttachment bytes into a caller-selected project directory without overwriting existing paths | send()/reply() with attachments share _encoded_attachments() (validate, size-check, base64) and place fileAttachments on the sent message — reply() puts them on the reply action's message so Graph still threads it | send()/reply() with send_at never use the one-shot sendMail / reply actions (they delivered at once, #1198): send() creates a draft carrying PidTagDeferredSendTime (SystemTime 0x3FEF) and PidTagDeferredDeliveryTime (0x000F) and submits it; reply() does createReply → POST attachments → PATCH the same two properties → send, so Exchange holds the exact draft until then (needs Mail.ReadWrite) | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
   State/Effects: reads MICROSOFT_* env vars for OAuth tokens/scopes | makes HTTP calls to Microsoft Graph API | can modify mailbox state (mark read, archive, send emails), create contacts, and write downloaded attachments inside the project boundary | token refresh rewrites ~/.co/keys.env
   Integration: exposes Outlook class with email methods plus add_contact(), list_contacts(), search_contacts() | structured list methods feed cli/commands/outlook_commands.py | used as agent tool via Agent(tools=[Outlook()]) | reply(email_id, body, send_at, *, attachments) keeps send_at third positional for pre-attachment callers, so attachments is keyword-only
   Performance: network I/O per API call | batch fetching for list operations | email body fetched separately
@@ -789,7 +789,8 @@ class Outlook:
             email_id: Outlook message ID to reply to
             body: Reply message body (plain text)
             send_at: Optional UTC ISO time (e.g. "2026-07-06T15:30:00Z") to
-                schedule delivery — Exchange holds the reply until then
+                schedule delivery — the reply becomes a deferred draft that
+                Exchange holds until then (needs the Mail.ReadWrite scope)
             attachments: Optional list of local file paths to attach — same
                 files and ~3MB total Graph limit as send()
 
@@ -801,32 +802,51 @@ class Outlook:
         paragraphs = [html.escape(p.strip()).replace("\n", "<br>") for p in body.split("\n\n") if p.strip()]
         body = "".join(f"<p>{p}</p>" for p in paragraphs)
 
-        endpoint = f"/me/messages/{email_id}/reply"
+        # Encode first: a rejected file must not leave a reply already sent
+        # (or a draft already created) and unattached.
+        encoded = self._encoded_attachments(attachments) if attachments else []
+        suffix = self._attachment_suffix(attachments)
+
+        if send_at:
+            self._scheduled_reply(email_id, body, encoded, send_at)
+            return f"Reply scheduled for {send_at}{suffix}"
+
         # The reply action takes writable message properties beside the
         # comment, so attachments ride along without giving up the threading
         # Graph does for us (In-Reply-To, References, same conversation).
-        reply_message = {}
-        if attachments:
-            # Encode first: a rejected file must not leave a reply already
-            # sent and unattached.
-            reply_message["attachments"] = self._encoded_attachments(attachments)
-        if send_at:
-            # Same deferred-send property as send(); the reply action accepts
-            # message properties alongside the comment.
-            reply_message["singleValueExtendedProperties"] = [
-                {"id": "SystemTime 0x3FEF", "value": send_at}
-            ]
-
         data = {"comment": body}
-        if reply_message:
-            data["message"] = reply_message
-
-        self._request("POST", endpoint, json=data)
-
-        suffix = self._attachment_suffix(attachments)
-        if send_at:
-            return f"Reply scheduled for {send_at}{suffix}"
+        if encoded:
+            data["message"] = {"attachments": encoded}
+        self._request("POST", f"/me/messages/{email_id}/reply", json=data)
         return f"Reply sent successfully{suffix}"
+
+    def _scheduled_reply(self, email_id: str, body: str, encoded: list, send_at: str) -> str:
+        """Create a reply draft, set the deferred-send properties, submit it.
+
+        The reply action is create-and-send in one step, like sendMail was
+        for send() (#1198): Graph does not list either as a place to set an
+        extended property, so the deferred-send time never reached the copy
+        that went out.  A draft is where the property is documented to live:
+        createReply keeps the threading, PATCH is the documented way to put an
+        extended property on an existing message, and send submits that exact
+        draft.  Returns the draft id.
+        """
+        self._require_scope("Mail.ReadWrite")
+        draft = self._request("POST", f"/me/messages/{email_id}/createReply", json={"comment": body})
+        draft_id = draft.get("id")
+        if not draft_id:
+            raise ValueError("Microsoft Graph createReply response did not include an id")
+        for attachment in encoded:
+            # PATCH does not take attachments; the attachments collection does.
+            self._request("POST", f"/me/messages/{draft_id}/attachments", json=attachment)
+        self._request("PATCH", f"/me/messages/{draft_id}", json={
+            "singleValueExtendedProperties": [
+                {"id": "SystemTime 0x3FEF", "value": send_at},
+                {"id": "SystemTime 0x000F", "value": send_at},
+            ]
+        })
+        self._request("POST", f"/me/messages/{draft_id}/send")
+        return draft_id
 
     def get_scheduled(self, max_results: int = 25) -> list:
         """List emails waiting for scheduled delivery (deferred-send drafts).

--- a/docs/blog/2026-09-05-a-reply-is-a-send-too.md
+++ b/docs/blog/2026-09-05-a-reply-is-a-send-too.md
@@ -1,0 +1,46 @@
+# A Reply Is a Send Too
+
+On September 4 we merged the fix for #1198. `co outlook send --at` had been
+delivering the email immediately and leaving a second, deferred copy in
+Drafts. The cause was the endpoint: `sendMail` creates and sends in one
+step, and the deferred-send time we hung on it never reached the copy that
+went out. The fix creates a draft, sets the time on the draft, and submits
+that exact draft. A contributor validated it on a live mailbox: nothing
+before the requested time, exactly one message after it.
+
+Then the review notes said, in effect, "replies are unchanged on purpose."
+That was honest scoping, and it was also the next bug. `co outlook reply --at`
+went through `POST /me/messages/{id}/reply`, with the same property tucked
+into the `message` block. The reply action is `sendMail` with threading
+attached. It creates and sends in one step. Nothing about it suggests the
+deferred time would fare any better there than it did on `sendMail`.
+
+We went looking for a reason to believe otherwise and did not find one.
+Graph's page on creating extended properties lists every request that can
+carry one: `POST /me/messages`, `PATCH /me/messages/{id}`, and a dozen
+siblings. Neither `sendMail` nor the `reply` action is on the list. The
+`reply` page says the `message` parameter takes "any writeable properties to
+update in the reply message" and then never names one. The only community
+report we found of an extended property surviving a reply came from someone
+who set it *after* `createReply`, with a `PATCH`, and sent the draft next.
+
+So the reply path now walks the documented road. `createReply` makes a draft
+that already knows its conversation. Attachments go to the draft's
+attachments collection, because `PATCH` does not accept them. Then one
+`PATCH` puts `PidTagDeferredSendTime` and `PidTagDeferredDeliveryTime` on the
+draft, and `send` submits it. Four requests instead of one, and the draft
+lands in `co outlook scheduled` beside the scheduled sends, where `cancel`
+can reach it.
+
+Two smaller things fell out. Draft creation needs `Mail.ReadWrite`, so the
+scheduled branch checks the scope before touching the network: a token that
+only carries `Mail.Send` fails with a re-consent hint instead of a Graph 403
+after a reply may already have gone. And the docs page still promised that
+scheduling "works with just the `Mail.Send` scope." It did, back when the
+schedule was not being honoured. It does not now, and the page says so.
+
+What we have not done is watch this one on a real mailbox. The unit tests pin
+the four requests, their order, their payloads, and the early scope failure.
+They do not prove Exchange holds a reply draft the way it holds a new one.
+That is the check we are asking for before this ships, the same check that
+earned the `send` fix its merge.

--- a/docs/cli/outlook.md
+++ b/docs/cli/outlook.md
@@ -116,7 +116,9 @@ co outlook reply 3 "Sounds good, see you then."
 
 Sends a threaded reply to an email from your last listing. Use `-` as the
 message to read the reply body from stdin, and `--at +2h` (or a UTC ISO
-time) to schedule the reply like a scheduled send.
+time) to schedule the reply like a scheduled send. A scheduled reply is a
+reply draft that Exchange holds until then, so it needs the `Mail.ReadWrite`
+scope and shows up in `co outlook scheduled` like any other scheduled send.
 
 **Options**
 - `--attach, -a FILE` — attach a local file; repeat for multiple
@@ -131,7 +133,8 @@ co outlook reply 3 "Signed copy attached." \
 
 The files ride on Graph's reply action, so the message stays in the original
 conversation instead of going out as a new email. Attachments and `--at`
-combine — a scheduled reply keeps its files.
+combine — a scheduled reply keeps its files (they are added to the reply
+draft before it is scheduled).
 
 ### `co outlook send <to> <subject> <message>` — Send
 
@@ -159,8 +162,10 @@ co outlook send bob@example.com "Report" "See attached." \
 > the CLI may explicitly name a file outside the project; agent-facing
 > `Outlook()` tools remain limited to project files.
 
-**Scheduling** — Exchange holds delivery until the time you give (deferred
-send), so it works with just the `Mail.Send` scope and no extra setup:
+**Scheduling** — the message is created as a draft carrying a deferred-send
+time, and Exchange holds it until then. Creating the draft needs the
+`Mail.ReadWrite` scope, which `co auth microsoft` grants by default; a token
+issued before that scope was added needs one more `co auth microsoft`:
 
 ```bash
 co outlook send bob@example.com "Reminder" "Standup in 30." --at +30m

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -810,14 +810,18 @@ class TestOutlookReply:
 
     @patch('connectonion.useful_tools.outlook.httpx')
     def test_reply_scheduled(self, mock_httpx):
-        """Test scheduled reply carries the deferred-send property."""
-        mock_response = MagicMock()
-        mock_response.status_code = 202
-        mock_response.text = ""
-        mock_httpx.request.return_value = mock_response
+        """A scheduled reply is a reply draft that carries the deferred-send
+        properties and is submitted as that exact draft — never the one-shot
+        reply action, which delivered at once the way sendMail did (#1198)."""
+        mock_httpx.request.side_effect = [
+            MagicMock(status_code=201, text='{"id": "reply-draft-1"}',
+                      json=MagicMock(return_value={"id": "reply-draft-1"})),
+            MagicMock(status_code=200, text=""),   # PATCH
+            MagicMock(status_code=202, text=""),   # send
+        ]
 
         with patch.dict(os.environ, {
-            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_SCOPES": "Mail.ReadWrite,Mail.Send",
             "MICROSOFT_ACCESS_TOKEN": "test-token",
             "MICROSOFT_REFRESH_TOKEN": "test-refresh",
             "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z"
@@ -827,10 +831,54 @@ class TestOutlookReply:
             result = outlook.reply("msg-1", "See you then", send_at="2026-07-06T15:30:00Z")
 
             assert "scheduled" in result.lower()
-            payload = mock_httpx.request.call_args.kwargs["json"]
-            assert payload["comment"] == "<p>See you then</p>"
-            prop = payload["message"]["singleValueExtendedProperties"][0]
-            assert prop == {"id": "SystemTime 0x3FEF", "value": "2026-07-06T15:30:00Z"}
+            calls = mock_httpx.request.call_args_list
+            assert [(c.args[0], c.args[1].split("/v1.0")[1]) for c in calls] == [
+                ("POST", "/me/messages/msg-1/createReply"),
+                ("PATCH", "/me/messages/reply-draft-1"),
+                ("POST", "/me/messages/reply-draft-1/send"),
+            ]
+            assert calls[0].kwargs["json"] == {"comment": "<p>See you then</p>"}
+            assert calls[1].kwargs["json"] == {"singleValueExtendedProperties": [
+                {"id": "SystemTime 0x3FEF", "value": "2026-07-06T15:30:00Z"},
+                {"id": "SystemTime 0x000F", "value": "2026-07-06T15:30:00Z"},
+            ]}
+            assert "json" not in calls[2].kwargs
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_reply_scheduled_requires_readwrite_scope(self, mock_httpx):
+        """Draft creation needs Mail.ReadWrite; fail before any request, not
+        with a Graph 403 after the reply action already went out."""
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "test-token",
+            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z"
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+
+            with pytest.raises(ValueError, match="Mail.ReadWrite"):
+                Outlook().reply("msg-1", "See you then", send_at="2026-07-06T15:30:00Z")
+
+        mock_httpx.request.assert_not_called()
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_reply_scheduled_without_draft_id_is_not_sent(self, mock_httpx):
+        """No draft id means nothing to schedule — do not fall back to sending."""
+        mock_httpx.request.return_value = MagicMock(status_code=201, text="{}",
+                                                    json=MagicMock(return_value={}))
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.ReadWrite,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "test-token",
+            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z"
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+
+            with pytest.raises(ValueError, match="createReply"):
+                Outlook().reply("msg-1", "See you then", send_at="2026-07-06T15:30:00Z")
+
+        assert mock_httpx.request.call_count == 1
 
     @patch('connectonion.useful_tools.outlook.httpx')
     def test_reply_immediate_has_no_message_block(self, mock_httpx):
@@ -958,9 +1006,20 @@ class TestOutlookReplyAttachments:
         assert "report.pdf, chart.png" in result
 
     @patch('connectonion.useful_tools.outlook.httpx')
-    def test_scheduled_reply_keeps_both_attachments_and_deferred_send(self, mock_httpx, tmp_path):
-        """--attach and --at are not a choice: one message carries both."""
-        mock_httpx.request.return_value = MagicMock(status_code=202, text="")
+    def test_scheduled_reply_keeps_both_attachments_and_deferred_send(self, mock_httpx, tmp_path, monkeypatch):
+        """--attach and --at are not a choice: the reply draft carries both.
+
+        PATCH does not take attachments, so each file is posted to the
+        draft's attachments collection before the deferred-send PATCH."""
+        monkeypatch.setenv("MICROSOFT_SCOPES", "Mail.ReadWrite,Mail.Send")
+        mock_httpx.request.side_effect = [
+            MagicMock(status_code=201, text='{"id": "reply-draft-1"}',
+                      json=MagicMock(return_value={"id": "reply-draft-1"})),
+            MagicMock(status_code=201, text='{"id": "att-1"}',
+                      json=MagicMock(return_value={"id": "att-1"})),
+            MagicMock(status_code=200, text=""),
+            MagicMock(status_code=202, text=""),
+        ]
         signed = tmp_path / "signed.pdf"
         signed.write_bytes(b"%PDF-1.4 fake")
 
@@ -970,11 +1029,30 @@ class TestOutlookReplyAttachments:
         assert "scheduled" in result.lower()
         assert "signed.pdf" in result
 
-        message = mock_httpx.request.call_args.kwargs["json"]["message"]
-        assert message["attachments"][0]["name"] == "signed.pdf"
-        assert message["singleValueExtendedProperties"] == [
-            {"id": "SystemTime 0x3FEF", "value": "2026-07-06T15:30:00Z"}
+        calls = mock_httpx.request.call_args_list
+        assert [(c.args[0], c.args[1].split("/v1.0")[1]) for c in calls] == [
+            ("POST", "/me/messages/msg-1/createReply"),
+            ("POST", "/me/messages/reply-draft-1/attachments"),
+            ("PATCH", "/me/messages/reply-draft-1"),
+            ("POST", "/me/messages/reply-draft-1/send"),
         ]
+        attachment = calls[1].kwargs["json"]
+        assert attachment["@odata.type"] == "#microsoft.graph.fileAttachment"
+        assert attachment["name"] == "signed.pdf"
+        assert calls[2].kwargs["json"]["singleValueExtendedProperties"][0] == {
+            "id": "SystemTime 0x3FEF", "value": "2026-07-06T15:30:00Z"
+        }
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_rejected_attachment_leaves_no_reply_draft(self, mock_httpx, tmp_path, monkeypatch):
+        """A missing file fails before createReply, so no stray draft is left in Drafts."""
+        monkeypatch.setenv("MICROSOFT_SCOPES", "Mail.ReadWrite,Mail.Send")
+
+        with pytest.raises(ValueError, match="Attachment not found"):
+            self._outlook().reply("msg-1", "Tomorrow", attachments=[str(tmp_path / "missing.pdf")],
+                                  send_at="2026-07-06T15:30:00Z")
+
+        mock_httpx.request.assert_not_called()
 
     def test_missing_attachment_reports_no_reply_sent(self, tmp_path):
         """A path that isn't there must fail before anything reaches Graph."""
@@ -1043,19 +1121,27 @@ class TestOutlookReplyPositionalCompatibility:
         return Outlook(allow_external_attachments=True)
 
     @patch('connectonion.useful_tools.outlook.httpx')
-    def test_legacy_third_positional_argument_still_schedules(self, mock_httpx):
+    def test_legacy_third_positional_argument_still_schedules(self, mock_httpx, monkeypatch):
         """A caller written before attachments existed still schedules, not attaches."""
-        mock_httpx.request.return_value = MagicMock(status_code=202, text="")
+        monkeypatch.setenv("MICROSOFT_SCOPES", "Mail.ReadWrite,Mail.Send")
+        mock_httpx.request.side_effect = [
+            MagicMock(status_code=201, text='{"id": "reply-draft-1"}',
+                      json=MagicMock(return_value={"id": "reply-draft-1"})),
+            MagicMock(status_code=200, text=""),
+            MagicMock(status_code=202, text=""),
+        ]
 
         result = self._outlook().reply("msg-1", "See you then", "2026-07-06T15:30:00Z")
 
         assert "scheduled" in result.lower()
-        payload = mock_httpx.request.call_args.kwargs["json"]
-        assert payload["message"]["singleValueExtendedProperties"] == [
-            {"id": "SystemTime 0x3FEF", "value": "2026-07-06T15:30:00Z"}
-        ]
+        urls = [c.args[1] for c in mock_httpx.request.call_args_list]
+        assert urls[0].endswith("/me/messages/msg-1/createReply")
         # The timestamp must never be read as a file path.
-        assert "attachments" not in payload["message"]
+        assert not any(url.endswith("/attachments") for url in urls)
+        patched = mock_httpx.request.call_args_list[1].kwargs["json"]
+        assert patched["singleValueExtendedProperties"][0] == {
+            "id": "SystemTime 0x3FEF", "value": "2026-07-06T15:30:00Z"
+        }
 
     def test_attachments_cannot_be_passed_positionally(self, tmp_path):
         """Keyword-only attachments freeze the positional order for good."""


### PR DESCRIPTION
## Description

`co outlook reply --at` still went through `POST /me/messages/{id}/reply` with the deferred-send property tucked inside `message`. The reply action is create-and-send in one step, exactly like `sendMail` was for `send()` before #1221, and Microsoft Graph lists neither of them among the requests that can carry an extended property. So a scheduled reply had the same shape as the bug #1221 just fixed for `send`.

Scheduled replies now follow the documented draft lifecycle:

```
POST  /me/messages/{id}/createReply      reply draft, threading kept (Mail.ReadWrite)
POST  /me/messages/{draft}/attachments   one per file — PATCH does not accept attachments
PATCH /me/messages/{draft}               SystemTime 0x3FEF + 0x000F (PidTagDeferredSendTime / DeliveryTime)
POST  /me/messages/{draft}/send          submit that exact draft (Mail.Send)
```

Immediate replies are unchanged. The scheduled branch checks `Mail.ReadWrite` before any request, as `send()` does. The scheduled reply draft carries `0x3FEF`, so it appears in `co outlook scheduled` and `co outlook cancel` deletes it.

Sources behind the route:
- Create extended property, supported request syntaxes (no `sendMail`, no `/reply`): https://learn.microsoft.com/en-us/graph/api/singlevaluelegacyextendedproperty-post-singlevalueextendedproperties?view=graph-rest-1.0
- `message: update` — `singleValueExtendedProperties` "Updatable only if isDraft = true": https://learn.microsoft.com/en-us/graph/api/message-update?view=graph-rest-1.0
- `message: createReply`: https://learn.microsoft.com/en-us/graph/api/message-createreply?view=graph-rest-1.0
- `message: send` accepts a reply draft: https://learn.microsoft.com/en-us/graph/api/message-send?view=graph-rest-1.0
- Add attachment to a draft: https://learn.microsoft.com/en-us/graph/api/message-post-attachments?view=graph-rest-1.0

## Related Issue

Fixes #1416 (follow-up to #1198 / #1221)

## Labels and target release (required)

- **Suggested labels:** bug
- **Proposed target version:** 1.8.2
- **Estimated release window:** next patch from `main`
- **Milestone:** maintainer assigns the confirmed release milestone
- **Why this release:** Same bug class as #1198, which shipped its `send` half on `main` in #1221. Only the scheduled-reply transport path changes; immediate replies and sends keep their endpoints. Rollback is a single commit.
- **Forward-port tracking issue (stable patches only):** #1418

## How this was written

- [x] AI-assisted — reviewed every line and can explain why each change is there

- Least confident: no live Microsoft mailbox was available in this environment, so Exchange actually holding a *reply* draft the way it holds a new draft is covered by the mocked HTTP contract only. This PR stays a draft until someone with a mailbox runs the check below.
- If this is wrong, what breaks first? Either `createReply` ignores `comment` on v1.0 (the reply body would be empty), or Exchange sends the reply draft immediately despite the PATCHed properties. Both show up in the live check before anything ships.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dev Blog (required)

> docs/blog/2026-09-05-a-reply-is-a-send-too.md

## Changes Made

- `connectonion/useful_tools/outlook.py`: `reply(send_at=...)` calls a new `_scheduled_reply()` (createReply → attachments → PATCH → send); immediate replies unchanged; attachments are still encoded before any request so a rejected file leaves no stray draft.
- `tests/unit/test_outlook.py`: scheduled-reply tests pin the four requests, order, payloads and empty send body; new tests for the missing-scope failure, a createReply response without an id, and a rejected attachment leaving no draft.
- `docs/cli/outlook.md`: scheduling needs `Mail.ReadWrite` (it no longer claims `Mail.Send` alone suffices); scheduled replies appear in `co outlook scheduled`.
- `docs/blog/2026-09-05-a-reply-is-a-send-too.md`: the story.

## Testing

- `pytest tests/unit/test_outlook.py` — 73 passed (70 on `main` + 3 new)
- `pytest tests/unit/test_outlook_commands.py tests/e2e/cli/test_cli_outlook_reply.py` — 43 passed
- `ruff check` on both touched Python files — same 10 pre-existing findings as `main`, none new

**Live check requested before this leaves draft** (same protocol as #1221):

1. `co outlook reply <#> "..." --at +10m` on a real mailbox.
2. Before the time: the reply is *not* in the recipient's inbox and *not* in Sent Items; it *is* listed by `co outlook scheduled`.
3. After the time: exactly one copy in the recipient's inbox, threaded under the original, exactly one in Sent Items, none left in Drafts.
4. Repeat with `--attach` and confirm the file arrives.
5. Once more, then `co outlook cancel <#>` before the time: nothing is delivered.

## Scope

- `connectonion/useful_tools/outlook.py`
- `tests/unit/test_outlook.py`
- `docs/cli/outlook.md`
- `docs/blog/2026-09-05-a-reply-is-a-send-too.md`

## Example Usage

```bash
co outlook reply 3 "See you then." --at +2h
co outlook scheduled        # the reply draft is listed here
co outlook cancel 1         # deletes it before Exchange sends it
```

## Checklist

- [x] I proposed at least one label and a target version above
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (#1221)
- [x] Forward-port tracker linked (#1418)
- [ ] Live mailbox validation (see Testing) — pending

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Draft on purpose: the unit tests prove the request contract, not Exchange's behaviour on a reply draft. Ready for review once the live check above has been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaAFWfbdhFGiYo64Hvn1gn