### PR TITLE
tests(youcom): patch httpx on the imported module so Python 3.10 passes

### DIFF
--- a/docs/blog/2026-09-05-the-function-that-hid-its-own-module.md
+++ b/docs/blog/2026-09-05-the-function-that-hid-its-own-module.md
@@ -1,0 +1,32 @@
+# The Function That Hid Its Own Module
+
+The You.com tools landed on `main` this morning with fifteen passing tests.
+Two hours later the Python 3.10 job on an unrelated docs pull request went
+red with twelve failures, all in that new test file, all the same line:
+
+```
+AttributeError: <function youcom_search at 0x7f83...> does not have the attribute 'httpx'
+```
+
+The tests patch `connectonion.useful_tools.youcom_search.httpx`. Read as a
+path, that names the `httpx` import inside the `youcom_search` module. But
+the package's `__init__` also does `from .youcom_search import youcom_search`,
+which rebinds the package attribute `youcom_search` from the submodule to the
+function of the same name. From then on `connectonion.useful_tools.youcom_search`
+means the function if you get there by attribute access, and the module if
+you get there through `sys.modules`.
+
+Which one you get depends on the interpreter. Python 3.11 changed
+`unittest.mock` to resolve dotted targets with `pkgutil.resolve_name`, which
+imports the module. Python 3.10 walks the path with `getattr` and stops on the
+function. So the same test file passed on 3.11, 3.12 and 3.13 in CI, passed
+on the contributor's machine, passed in the reviewer's 3.11 virtualenv, and
+failed only on the one version nobody ran locally.
+
+That last part is the actual lesson. This was a fork pull request, so its
+workflow runs needed a maintainer's approval click that never happened; the
+review substituted a local run. A local run on one Python version is not the
+matrix. The fix is one line, `patch.object(importlib.import_module(...),
+"httpx")`, which lands on the same object everywhere. The rule that comes out
+of it is that a substitute for CI has to cover what CI covers, and this repo's
+CI starts at 3.10.

--- a/tests/unit/test_youcom_search.py
+++ b/tests/unit/test_youcom_search.py
@@ -1,5 +1,6 @@
 """Tests for the You.com function tools."""
 
+import importlib
 from unittest.mock import Mock, patch
 
 import httpx as _real_httpx
@@ -15,8 +16,15 @@ MODULE = "connectonion.useful_tools.youcom_search"
 
 def _mock_httpx():
     """Patch httpx in the module but keep the real exception classes so the
-    module's `except httpx.RequestError` clause works."""
-    patcher = patch(f"{MODULE}.httpx")
+    module's `except httpx.RequestError` clause works.
+
+    The package re-exports a *function* named youcom_search, so the dotted
+    path "connectonion.useful_tools.youcom_search" resolves to that function
+    on Python 3.10, where mock.patch walks it with getattr; 3.11+ resolves
+    it through pkgutil and finds the module. Import the module explicitly
+    so the patch lands on the same object on every supported version.
+    """
+    patcher = patch.object(importlib.import_module(MODULE), "httpx")
     mock_httpx = patcher.start()
     mock_httpx.RequestError = _real_httpx.RequestError
     return patcher, mock_httpx


### PR DESCRIPTION
## Description

`main` is red on the `test (3.10)` job since #1128 merged: all twelve You.com tests that mock `httpx` fail with

```
AttributeError: <function youcom_search at 0x...> does not have the attribute 'httpx'
```

The tests patch the dotted path `connectonion.useful_tools.youcom_search.httpx`. The package `__init__` re-exports a *function* named `youcom_search`, which shadows the submodule of the same name on the package object. Python 3.10's `mock.patch` resolves dotted targets with `getattr` and stops on the function; 3.11+ uses `pkgutil.resolve_name` and finds the module, which is why 3.11/3.12/3.13 were green and the fork PR's local review run (3.11) missed it.

Fix: `patch.object(importlib.import_module(MODULE), "httpx")`, which patches the same object on every supported version. No source change.

## Related Issue

Follow-up to #1128. First seen on #1133's CI (docs-only PR rebased onto today's `main`).

## Labels and target release (required)

- **Suggested labels:** tests
- **Proposed target version:** 1.8.x line on `main`, ships with the next release cut from `main`
- **Estimated release window:** next release from main
- **Milestone:** maintainer assigns the confirmed release milestone
- **Why this release:** `main` cannot merge anything until the 3.10 job is green again. Test-only change, no runtime behaviour touched.
- **Forward-port tracking issue (stable patches only):** N/A — `main` only; the You.com tools do not exist on the 1.7 line.

## How this was written

- [x] AI-assisted — reviewed every line and can explain why each change is there

Least confident: nothing in the fix itself; the uncertainty was the diagnosis, which is now pinned by the reproduction below.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dev Blog (required)

> docs/blog/2026-09-05-the-function-that-hid-its-own-module.md

## Changes Made

- `tests/unit/test_youcom_search.py`: `_mock_httpx()` patches the module object obtained via `importlib.import_module` instead of a dotted string; docstring explains the shadowing.
- `docs/blog/2026-09-05-the-function-that-hid-its-own-module.md`: the story, including the review lesson (a local run on one Python version is not the CI matrix).

## Testing

Reproduced before fixing, in a fresh `uv sync --extra dev` environment on `/usr/bin/python3.10`:

| | Python 3.10 | Python 3.11 |
|---|---|---|
| `main` (before) | 12 failed, 3 passed | 15 passed |
| this branch | 15 passed | 15 passed |

`ruff check` clean on the test file.

## Scope

- `tests/unit/test_youcom_search.py`
- `docs/blog/2026-09-05-the-function-that-hid-its-own-module.md`

## Example Usage

Not applicable.

## Checklist

- [x] I proposed at least one label and a target version above
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (#1128)
- [x] Not a stable patch-line target, so no forward-port tracker is required

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The same module-vs-function shadowing exists for `ask_user` (`useful_tools/ask_user.py` exports `ask_user`); nothing patches it by dotted path today, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaAFWfbdhFGiYo64Hvn1gn

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaAFWfbdhFGiYo64Hvn1gn)_