### PR TITLE
[1.7] Backport the replay-ledger self-heal

### DIFF
--- a/connectonion/network/host/replay.py
+++ b/connectonion/network/host/replay.py
@@ -6,6 +6,7 @@ Errors: raises ReplayProtectionError so callers can fail closed with a safe mess
 """
 
 import hashlib
+import logging
 import math
 import os
 import sqlite3
@@ -13,6 +14,8 @@ import time
 from contextlib import closing
 from pathlib import Path
 
+
+logger = logging.getLogger(__name__)
 
 SIGNATURE_EXPIRY_SECONDS = 300
 # A healthy transaction is tiny, but another OS worker can be descheduled while
@@ -44,45 +47,49 @@ class SignatureReplayStore:
         self.expiry_seconds = expiry_seconds
         self.path.parent.mkdir(parents=True, exist_ok=True)
         try:
-            descriptor = os.open(self.path, os.O_CREAT | os.O_WRONLY, 0o600)
-            os.close(descriptor)
-            if os.name != "nt":
-                os.chmod(self.path, 0o600)
-            with closing(self._connect()) as database:
-                with database:
-                    # Serialize schema inspection and migration across workers.
-                    database.execute("BEGIN IMMEDIATE")
-                    database.execute(
-                        "CREATE TABLE IF NOT EXISTS used_signatures ("
-                        "digest BLOB PRIMARY KEY, seen_at REAL NOT NULL"
-                        ", expires_at REAL"
-                        ") WITHOUT ROWID"
-                    )
-                    columns = {
-                        row[1] for row in database.execute(
-                            "PRAGMA table_info(used_signatures)"
-                        )
-                    }
-                    if "expires_at" not in columns:
-                        database.execute(
-                            "ALTER TABLE used_signatures "
-                            "ADD COLUMN expires_at REAL"
-                        )
-                    # A pre-fix row may have represented a future-dated
-                    # signature. Retain it for the maximum validity window.
-                    database.execute(
-                        "UPDATE used_signatures SET expires_at = seen_at + ? "
-                        "WHERE expires_at IS NULL",
-                        (2 * self.expiry_seconds,),
-                    )
-                    database.execute(
-                        "CREATE INDEX IF NOT EXISTS used_signatures_expiry "
-                        "ON used_signatures(expires_at)"
-                    )
+            self._prepare_schema()
         except (OSError, sqlite3.Error) as exc:
             raise ReplayProtectionError(
                 f"replay protection storage is unavailable: {self.path}"
             ) from exc
+
+    def _prepare_schema(self) -> None:
+        """Create the ledger, or migrate an older one, at the current path."""
+        descriptor = os.open(self.path, os.O_CREAT | os.O_WRONLY, 0o600)
+        os.close(descriptor)
+        if os.name != "nt":
+            os.chmod(self.path, 0o600)
+        with closing(self._connect()) as database:
+            with database:
+                # Serialize schema inspection and migration across workers.
+                database.execute("BEGIN IMMEDIATE")
+                database.execute(
+                    "CREATE TABLE IF NOT EXISTS used_signatures ("
+                    "digest BLOB PRIMARY KEY, seen_at REAL NOT NULL"
+                    ", expires_at REAL"
+                    ") WITHOUT ROWID"
+                )
+                columns = {
+                    row[1] for row in database.execute(
+                        "PRAGMA table_info(used_signatures)"
+                    )
+                }
+                if "expires_at" not in columns:
+                    database.execute(
+                        "ALTER TABLE used_signatures "
+                        "ADD COLUMN expires_at REAL"
+                    )
+                # A pre-fix row may have represented a future-dated
+                # signature. Retain it for the maximum validity window.
+                database.execute(
+                    "UPDATE used_signatures SET expires_at = seen_at + ? "
+                    "WHERE expires_at IS NULL",
+                    (2 * self.expiry_seconds,),
+                )
+                database.execute(
+                    "CREATE INDEX IF NOT EXISTS used_signatures_expiry "
+                    "ON used_signatures(expires_at)"
+                )
 
     def _connect(self):
         database = sqlite3.connect(self.path, timeout=SQLITE_BUSY_TIMEOUT_SECONDS)
@@ -110,19 +117,66 @@ class SignatureReplayStore:
         expires_at = self._expires_at(data, seen_at)
         digest = signature_digest(signature)
         try:
-            with closing(self._connect()) as database:
-                with database:
-                    database.execute(
-                        "DELETE FROM used_signatures WHERE expires_at < ?",
-                        (seen_at,),
-                    )
-                    inserted = database.execute(
-                        "INSERT OR IGNORE INTO used_signatures "
-                        "(digest, seen_at, expires_at) VALUES (?, ?, ?)",
-                        (digest, seen_at, expires_at),
-                    ).rowcount
-            return inserted == 0
-        except (OSError, sqlite3.Error) as exc:
+            return self._claim(digest, seen_at, expires_at)
+        except sqlite3.DatabaseError as exc:
+            # The ledger this process opened at startup can be deleted or
+            # replaced underneath it -- a deploy that rsyncs `.co/` without
+            # protecting `replay.sqlite3` is enough, and the file it leaves
+            # behind has no schema (#1401). Nothing is wrong with this
+            # process, so a rebuild here is the difference between one
+            # recovered request and every signed call failing until somebody
+            # notices. Rebuild once and retry; a second failure is a live
+            # fault rather than a swapped file, and still fails closed.
+            if not self._is_missing_ledger(exc):
+                raise ReplayProtectionError(
+                    f"replay protection storage is unavailable: {self.path}"
+                ) from exc
+            try:
+                self._prepare_schema()
+                claimed = self._claim(digest, seen_at, expires_at)
+            except (OSError, sqlite3.Error) as retry_exc:
+                raise ReplayProtectionError(
+                    "replay protection storage is unavailable after rebuild: "
+                    f"{self.path}"
+                ) from retry_exc
+            logger.warning(
+                "Replay ledger at %s was missing its schema (%s) and has been "
+                "rebuilt. It was most likely deleted or replaced by a deploy; "
+                "exclude it from any sync that owns %s. Signatures recorded "
+                "before the rebuild are forgotten, so a captured signature can "
+                "be replayed until it expires (%ss).",
+                self.path, exc, self.path.parent, self.expiry_seconds,
+            )
+            return claimed
+        except OSError as exc:
             raise ReplayProtectionError(
                 f"replay protection storage is unavailable: {self.path}"
             ) from exc
+
+    @staticmethod
+    def _is_missing_ledger(exc: sqlite3.DatabaseError) -> bool:
+        """Tell a vanished ledger from a lock, a disk fault or real damage.
+
+        Only the missing-table case is safe to rebuild: it means the file at
+        this path is a fresh empty database. Corruption, `database is locked`
+        and I/O errors must keep failing closed, because rebuilding would
+        discard a ledger that is still the authority on what has been used.
+        """
+        return isinstance(exc, sqlite3.OperationalError) and (
+            "no such table" in str(exc).lower()
+        )
+
+    def _claim(self, digest: bytes, seen_at: float, expires_at: float) -> bool:
+        """Record one digest, returning whether it was already present."""
+        with closing(self._connect()) as database:
+            with database:
+                database.execute(
+                    "DELETE FROM used_signatures WHERE expires_at < ?",
+                    (seen_at,),
+                )
+                inserted = database.execute(
+                    "INSERT OR IGNORE INTO used_signatures "
+                    "(digest, seen_at, expires_at) VALUES (?, ?, ?)",
+                    (digest, seen_at, expires_at),
+                ).rowcount
+        return inserted == 0

--- a/docs/blog/2026-09-03-the-agent-that-passed-every-health-check.md
+++ b/docs/blog/2026-09-03-the-agent-that-passed-every-health-check.md
@@ -1,0 +1,103 @@
+# The Agent That Passed Every Health Check
+
+*2026-09-03*
+
+For two hours and forty-five minutes a production agent answered `/health` with
+HTTP 200, held its relay connection open, reported `active` to systemd, and
+finished its scheduled crawl on time. It also refused every single signed call:
+213 consecutive `misconfigured: replay protection unavailable` errors.
+
+Nothing that watches a service noticed. Everything that watches a service was
+looking at the half that still worked.
+
+## Two halves, one process
+
+A hosted agent has two ways in. Scheduled jobs run locally and write straight to
+the database — no signatures involved. Remote commands arrive over the relay and
+must prove they are one-use, which means consulting `.co/replay.sqlite3`.
+
+Those halves fail independently, and only one of them is instrumented. The crawl
+kept landing rows, so the dashboards stayed green and the data stayed fresh. The
+liveness probe never touches replay protection, so it stayed 200. From outside,
+the agent looked healthy while being unable to accept a single instruction.
+
+That is the part worth carrying forward. A health endpoint that cannot fail with
+the subsystem it is supposed to describe is not a health endpoint; it is a
+process-is-running check wearing a better name.
+
+## The file outlived its validation
+
+`SignatureReplayStore` checks its ledger in `__init__`. That check ran once, at
+`02:38:35`, against a perfectly good file.
+
+At `03:11:43` a deploy synced `.co/` with `rsync --delete` and no protection for
+the ledger. It deleted the file and left an empty one at the same path. The
+deploy then aborted before its `systemctl restart` — so the process kept running,
+holding a path that now pointed at a different, schemaless database.
+
+Every claim after that raised `no such table: used_signatures`, which the store
+correctly translated into a fail-closed `ReplayProtectionError`. Correctly, and
+forever, because the only code that could have repaired the ledger had finished
+running an hour earlier.
+
+Validating at construction assumes the thing you validated is the thing you will
+use. For a long-lived process holding a path into a directory that deployment
+tooling also writes to, that assumption has a shelf life.
+
+## The empty file was a red herring
+
+The obvious diagnosis is that a zero-byte SQLite file is corrupt and the framework
+choked on it. That diagnosis is wrong, and it survived long enough to produce a
+first draft of the fix aimed entirely at the wrong place.
+
+`CREATE TABLE IF NOT EXISTS` succeeds against an empty file. Construct a store
+over zero bytes and it simply builds the schema:
+
+```python
+p.write_bytes(b"")
+store = SignatureReplayStore(p)          # succeeds, file becomes 12288 bytes
+store.already_used({"signature": "x"})   # False — works fine
+```
+
+An empty ledger on disk at startup is harmless. What is not harmless is an empty
+ledger appearing *after* startup. The bug was never about the file's contents; it
+was about when the file changed relative to the one check that looked at it.
+
+Reproducing the failure rather than reasoning about it is what surfaced this. The
+symptom — an empty file and a fail-closed error — was consistent with a story that
+was not true.
+
+## Recover where the fault is found
+
+The fix moves recovery to `already_used`, where the missing schema is actually
+discovered: rebuild once, retry the claim, and if that fails too, keep failing
+closed.
+
+The predicate is deliberately narrow. Only `no such table` triggers a rebuild,
+because that alone means the file is a fresh empty database with nothing to lose.
+`database is locked` must not, or a busy peer's ledger gets discarded on
+contention. Genuine corruption must not either, because a damaged ledger is still
+the authority on which signatures have been spent. Both keep failing closed, and a
+test asserts that a claim made before a lock still catches its replay afterwards.
+
+Rebuilding forgets what was recorded, so a captured signature could be replayed
+until it expires. That window is bounded by `SIGNATURE_EXPIRY_SECONDS` — five
+minutes — and it only opens in a situation where the ledger has already been
+destroyed by something outside the process. Five bounded minutes of degraded
+replay protection beats an agent that answers nothing at all and says it is fine.
+
+## The deployment lesson is the older one
+
+`co deploy` never had this bug. Its first rsync filter is `P .co/**`, with a
+comment explaining that it protects "anything a future version writes there"
+without requiring anyone to enumerate it.
+
+The deploy that caused this was a hand-rolled fallback that listed excludes by
+name instead — and the list did not mention `replay.sqlite3`, because the person
+writing it had no reason to know that file existed. Upstream's own history says
+the same thing twice: the enumerate-what-to-keep approach lost `.co/skills/` in
+its first version and `.co/dashboard.html` in its second.
+
+An exclude list protects what someone remembered. A protect rule covers what
+nobody has thought of yet, including the files a future release will add. When
+those two disagree, the list is the one that will be wrong.

--- a/tests/unit/test_cross_worker_replay.py
+++ b/tests/unit/test_cross_worker_replay.py
@@ -406,3 +406,84 @@ def test_non_finite_timestamps_are_rejected_before_replay_claim(
     assert payload is None
     assert error == "unauthorized: timestamp must be finite"
     assert claimed == []
+
+
+def test_a_ledger_deleted_under_a_running_host_is_rebuilt(tmp_path):
+    """A deploy can replace `.co/replay.sqlite3` while the host is running.
+
+    The store was opened at startup, so init-time checks are long past. Before
+    #1401 every later claim raised `no such table: used_signatures`, and the
+    agent refused every signed call until someone restarted it by hand.
+    """
+    path = tmp_path / "replay.sqlite3"
+    store = SignatureReplayStore(path)
+    assert store.already_used({"signature": "before-deploy"}) is False
+
+    os.remove(path)
+    path.write_bytes(b"")
+
+    assert store.already_used({"signature": "after-deploy"}) is False
+    assert store.already_used({"signature": "after-deploy"}) is True
+
+
+def test_a_rebuilt_ledger_still_claims_atomically(tmp_path):
+    path = tmp_path / "replay.sqlite3"
+    store = SignatureReplayStore(path)
+    os.remove(path)
+
+    store.already_used({"signature": "captured"})
+
+    with sqlite3.connect(path) as database:
+        indexes = {
+            row[1] for row in database.execute(
+                "PRAGMA index_list(used_signatures)"
+            )
+        }
+        columns = {
+            row[1] for row in database.execute(
+                "PRAGMA table_info(used_signatures)"
+            )
+        }
+    # The rebuild must produce the full schema, not just enough to insert:
+    # a ledger without its expiry index or column stops pruning and grows.
+    assert "used_signatures_expiry" in indexes
+    assert {"digest", "seen_at", "expires_at"} <= columns
+
+
+def test_a_locked_ledger_is_never_rebuilt(tmp_path):
+    """Rebuilding on lock contention would discard a live worker's ledger."""
+    path = tmp_path / "replay.sqlite3"
+    store = SignatureReplayStore(path)
+    store.already_used({"signature": "claimed-by-a-peer"})
+
+    with sqlite3.connect(path) as blocker:
+        blocker.execute("BEGIN EXCLUSIVE")
+        with pytest.raises(ReplayProtectionError, match="storage is unavailable"):
+            store.already_used({"signature": "captured"})
+
+    # The prior claim survived, so a replay is still caught after the lock.
+    assert store.already_used({"signature": "claimed-by-a-peer"}) is True
+
+
+def test_a_corrupt_ledger_keeps_failing_closed(tmp_path):
+    """Corruption is not a vanished file; its history is still authoritative."""
+    path = tmp_path / "replay.sqlite3"
+    store = SignatureReplayStore(path)
+    path.write_bytes(b"SQLite format 3\x00" + b"\xde\xad\xbe\xef" * 64)
+
+    with pytest.raises(ReplayProtectionError):
+        store.already_used({"signature": "captured"})
+
+
+def test_rebuild_is_not_retried_forever(tmp_path, monkeypatch):
+    path = tmp_path / "replay.sqlite3"
+    store = SignatureReplayStore(path)
+    os.remove(path)
+
+    def still_broken():
+        raise sqlite3.OperationalError("no such table: used_signatures")
+
+    monkeypatch.setattr(store, "_prepare_schema", lambda: None)
+    monkeypatch.setattr(store, "_claim", lambda *args: still_broken())
+    with pytest.raises(ReplayProtectionError, match="unavailable after rebuild"):
+        store.already_used({"signature": "captured"})


### PR DESCRIPTION
Backport of the `SignatureReplayStore` self-heal (#1403, originally written in #1404) to the 1.7 stable line. Required by the forward-port tracker #1407 before 1.8.1 can ship a preview.

## Why 1.7 needs it

1.7 hosts keep the SQLite ledger for every socket — 1.7 has no sealed channel and no in-memory store, so `.co/replay.sqlite3` is the authority on every signed call. The schema is created once at startup, so a deploy that replaces or deletes that file leaves an empty database and every later claim raises `no such table: used_signatures`. The host then refuses every authenticated request while reporting itself healthy. That is exactly what took the Melbourne rental host offline for 2h44m on 2026-09-03.

`main` fixes this differently: #1406 gives `host()` an in-memory ledger, which 1.7 cannot have (its sealed-channel parts do not exist there). The self-heal is the part that applies to both, and it is what this backports.

## What it does

`already_used` distinguishes a vanished ledger from a real fault. Only `sqlite3.OperationalError` containing `no such table` is treated as recoverable: the schema is rebuilt once, the claim is retried once, and a warning names the file, the likely cause, and the consequence (signatures recorded before the rebuild are forgotten, so a captured signature can be replayed until it expires). Corruption, `database is locked` and I/O errors still fail closed, because rebuilding on those would discard a ledger that is still authoritative.

Schema creation moves into `_prepare_schema()` and the claim into `_claim()` so both the startup path and the retry use the same code.

## Verification

- `tests/unit/test_cross_worker_replay.py`: **25 passed** on this branch.
- Fail-first check on the unpatched 1.7 tree: the new test raises `sqlite3.OperationalError: no such table: used_signatures` and then `ReplayProtectionError: replay protection storage is unavailable`, which is the outage this fixes.

Cherry-picked from `fix/replay-ledger-rebuild-1401` (`a48a2717`, `03af84fd`); the only conflict was the `logger` line placement.

Closes the 1.7 half of #1407.

**Proposed target version:** 1.7.4 / next patch
**Estimated release window:** immediately after this merges, before the 1.8.1a1 preview
**Forward-port tracking issue (stable patches only):** #1407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmCtowqB3DqGVPpTb1VU3S
