### PR TITLE
email: read and filter every mailbox an account can reach, and pick a default

### DIFF
--- a/connectonion/cli/commands/email_commands.py
+++ b/connectonion/cli/commands/email_commands.py
@@ -84,13 +84,15 @@ def handle_email_send(
         raise typer.Exit(1)
 
 
-def handle_email_inbox(last: int = 10, unread: bool = False, offset: int = 0):
-    """List recent emails received at the agent's address."""
+def handle_email_inbox(
+    last: int = 10, unread: bool = False, offset: int = 0, address: str = None
+):
+    """List recent emails received at any address this account can read."""
     if not _require_auth():
         return
 
     from ...useful_tools.get_emails import get_emails
-    emails = get_emails(last=last, offset=offset)
+    emails = get_emails(last=last, offset=offset, address=address)
     page_is_full = len(emails) == last
     if unread:
         # The /received endpoint ignores the unread param, so filter here to keep the flag honest.
@@ -98,32 +100,53 @@ def handle_email_inbox(last: int = 10, unread: bool = False, offset: int = 0):
 
     if not emails:
         scope = "unread " if unread else ""
-        console.print(f"\n[cyan]Inbox:[/cyan] no {scope}emails\n")
+        where = f" at {address}" if address else ""
+        console.print(f"\n[cyan]Inbox:[/cyan] no {scope}emails{where}\n")
         return
+
+    # The To column earns its width only when the page actually spans more than
+    # one mailbox. On a single-address account it would be the same string on
+    # every row, which is noise; the moment a second address appears, knowing
+    # which one a message landed at is the whole point.
+    recipients = {e.get("to", "") for e in emails if e.get("to")}
+    show_to = len(recipients) > 1
 
     table = Table(title="📬 Inbox", show_header=True, header_style="bold cyan")
     table.add_column("#", justify="right")
     table.add_column("From")
+    if show_to:
+        # Fold, never ellipsize: a half-printed address is the one thing this
+        # column exists to disambiguate, and "aaron@mail.op…" and
+        # "aaron.xie@mail.op…" are the same string once Rich truncates them.
+        table.add_column("To", overflow="fold")
     table.add_column("Subject")
     table.add_column("Received")
 
     for email in emails:
         unread_mark = "" if email.get("read") else "[bold green]●[/bold green] "
-        table.add_row(
-            str(email.get("id", "")),
-            str(email.get("from", "")),
+        row = [str(email.get("id", "")), str(email.get("from", ""))]
+        if show_to:
+            row.append(str(email.get("to", "")))
+        row += [
             f"{unread_mark}{email.get('subject', '')}",
             str(email.get("timestamp", ""))[:19],
-        )
+        ]
+        table.add_row(*row)
 
     console.print()
     console.print(table)
     console.print("\n[dim]Read one with:[/dim] [bold]co email read <#>[/bold]")
+    if show_to:
+        console.print(
+            "[dim]One mailbox only:[/dim] "
+            "[bold]co email inbox --address <address>[/bold]"
+        )
     if page_is_full:
         next_offset = offset + last
+        address_flag = f" --address {address}" if address else ""
         console.print(
             "[dim]Next page:[/dim] "
-            f"[bold]co email inbox --last {last} --offset {next_offset}[/bold]"
+            f"[bold]co email inbox --last {last} --offset {next_offset}{address_flag}[/bold]"
         )
     console.print()
 
@@ -250,6 +273,32 @@ def handle_email_read(email_id: str, mark_read: bool = False):
         console.print("[dim]Marked read.[/dim]")
     else:
         console.print("[dim]Unread state unchanged. Use --mark-read to change it.[/dim]")
+
+
+def handle_email_default(address: str):
+    """Choose which owned address this account sends from by default.
+
+    The default lives on the account, not in a local file, so it is the same
+    from every machine and every agent using this key. A per-project override
+    is still `--from` on the individual send — one place to look when a message
+    goes out as the wrong address, instead of two that can disagree.
+    """
+    token = load_api_key()
+    if not token:
+        _print_no_auth()
+        raise typer.Exit(1)
+
+    r = requests.post(
+        f"{backend_url()}/api/v1/email/addresses/default",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"address": address},
+        timeout=10,
+    )
+    if not r.ok:
+        console.print(f"\n[red]✗ {_err(r)}[/red]\n")
+        raise typer.Exit(1)
+
+    console.print(f"\n[green]✓[/green] {address} is now the default sender\n")
 
 
 def handle_email_addresses():

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -840,10 +840,16 @@ def email_inbox(
         help="Skip this many newer emails",
     ),
     unread: bool = typer.Option(False, "--unread", "-u", help="Only unread emails"),
+    address: str = typer.Option(
+        None,
+        "--address",
+        "-a",
+        help="Only mail delivered to this address (default: every address you can read)",
+    ),
 ):
-    """List recent received emails."""
+    """List recent received emails, across every address this account can read."""
     from .commands.email_commands import handle_email_inbox
-    handle_email_inbox(last=last, offset=offset, unread=unread)
+    handle_email_inbox(last=last, offset=offset, unread=unread, address=address)
 
 
 @email_app.command("read")
@@ -884,6 +890,15 @@ def email_addresses():
     """List every email address this account owns, marking the default sender."""
     from .commands.email_commands import handle_email_addresses
     handle_email_addresses()
+
+
+@email_app.command("default")
+def email_default(
+    address: str = typer.Argument(..., help="One of your own addresses, e.g. aaron@mail.openonion.ai"),
+):
+    """Choose which of your addresses is the default sender."""
+    from .commands.email_commands import handle_email_default
+    handle_email_default(address)
 
 
 @email_app.command("name")

--- a/connectonion/useful_tools/get_emails.py
+++ b/connectonion/useful_tools/get_emails.py
@@ -20,18 +20,26 @@ MIN_RECEIVED_EMAILS = 1
 MAX_RECEIVED_EMAILS = 1000
 
 
-def get_emails(last: int = 10, unread: bool = False, offset: int = 0) -> List[Dict]:
-    """Get emails sent to the agent's address.
+def get_emails(
+    last: int = 10, unread: bool = False, offset: int = 0, address: str = None
+) -> List[Dict]:
+    """Get emails sent to any address this account can read.
+
+    An account can hold several addresses, and can be granted read access to
+    another account's. They arrive as one merged list, so every message carries
+    `to` — which mailbox it landed in. Pass `address` to narrow to one.
 
     Args:
         last: Number of emails to retrieve (default: 10, range: 1..1000)
         unread: Only get unread emails (default: False)
         offset: Number of newer emails to skip (default: 0)
+        address: Only mail delivered to this address (default: all readable)
 
     Returns:
         List of email dictionaries containing:
             - id: Unique message ID
             - from: Sender's email address
+            - to: The address that received it
             - subject: Email subject
             - message: Email body content
             - timestamp: ISO format timestamp
@@ -65,6 +73,8 @@ def get_emails(last: int = 10, unread: bool = False, offset: int = 0) -> List[Di
         "offset": offset,
         "unread_only": unread
     }
+    if address:
+        params["address"] = address
 
     response = requests.get(
         endpoint,
@@ -82,6 +92,15 @@ def get_emails(last: int = 10, unread: bool = False, offset: int = 0) -> List[Di
             "This backend does not support received email pagination yet; "
             "upgrade the backend before using offset"
         )
+    # An older backend ignores an unknown query parameter and answers with the
+    # whole mailbox. Silently showing every address when one was asked for is
+    # the failure this filter exists to prevent, so refuse rather than degrade.
+    if address and data.get("address_filter_applied") != address:
+        raise RuntimeError(
+            f"This backend does not support filtering received email by address "
+            f"yet, so it returned every address instead of {address}; upgrade the "
+            f"backend before relying on --address"
+        )
     emails = data.get("emails", [])
 
     # Ensure consistent format
@@ -90,6 +109,7 @@ def get_emails(last: int = 10, unread: bool = False, offset: int = 0) -> List[Di
         formatted_emails.append({
             "id": email.get("id", ""),
             "from": email.get("from_email", email.get("from", "")),
+            "to": email.get("to_email", email.get("to", "")),
             "subject": email.get("subject", ""),
             "message": email.get("text") or email.get("html") or email.get("text_body") or email.get("html_body", ""),
             "timestamp": email.get("received_at", ""),

--- a/docs/blog/2026-09-05-the-inbox-that-answered-nobody.md
+++ b/docs/blog/2026-09-05-the-inbox-that-answered-nobody.md
@@ -1,0 +1,89 @@
+# The inbox that answered nobody
+
+A job application went out on Tuesday with the wrong email address on it. That
+part is an ordinary mistake. What made it worth writing down is what happened
+next: **nothing**.
+
+OpenAI's recruiting system replied within the hour. The mail was accepted,
+routed, and stored in `email_received` exactly as designed. No bounce, because
+nothing bounced — the address resolved, the message was delivered, the row is
+still there. It simply belonged to a second account of the same person's, and
+`co email inbox` on the machine that sent the application showed an empty
+result where the answer was.
+
+The only symptom was silence, and silence is what you expect while you wait.
+
+## The mail was never lost
+
+The address was `aaron@mail.openonion.ai`. The account doing the work owns
+`aaron.xie@mail.openonion.ai` — a rename from a month earlier that a document
+had not caught up with. Two accounts, one person, one of them not the one
+holding the mailbox.
+
+The obvious fix was already in the product. `co email share --can read` grants
+another account read access to one of your addresses, and #1137 shipped both
+the command and the `email_grants` table with a `can_read` column.
+
+We ran it. The row was written. The output said so. Nothing changed.
+
+```
+email_grants row       ✓ can_send=t  can_read=t  revoked_at=NULL
+co email inbox         ✗ the mail is still not there
+```
+
+## can_read had never been read
+
+`account_inbox_addresses()` builds the filter both read paths share. Its
+docstring lists four things that can route mail to one account — the derived
+`0x…` address, the tier's alias, a purchased custom name, and the rows in
+`email_addresses` — and it was scrupulous about all four, because an earlier
+bug had lost 173 messages by omitting one of them.
+
+It never consulted `email_grants`. Grants were checked on the **send** path
+only, through `may_use_email_address()`. So `--can read` wrote a durable,
+correct-looking row into a table nothing queried, and reported success.
+
+A column that exists, a flag that writes, a command that returns zero, and no
+effect anywhere. From the outside this is indistinguishable from a working
+feature — which is the whole problem with it.
+
+## What we changed
+
+`account_inbox_addresses()` gained a fifth source: addresses granted with
+`can_read` and not revoked. Two more things came along with it, because the
+same investigation kept running into them:
+
+- **Every received message now carries `to`.** An account reading two mailboxes
+  used to get one merged list with no way to tell which address anything
+  arrived at — ambiguous precisely when it matters.
+- **`GET /received?address=` narrows to one mailbox.** The filter *intersects*
+  with the readable set and can never widen it, so asking for an address you
+  cannot read returns an empty page rather than an error. An error would tell a
+  prober which addresses exist.
+
+The default sender became settable too (`POST /addresses/default`), restricted
+to owned addresses. A granted address can be revoked by its owner at any
+moment, and a default that vanishes underneath you is worse than no default.
+
+`delete_address_mail()` stayed gated on `owns_email_address()`, not on the read
+set, so `can_read` cannot escalate into deleting somebody else's mail.
+
+## The client fails closed
+
+`get_emails(address=...)` refuses a backend that ignored the parameter instead
+of quietly returning everything. An older deployment answers an unknown query
+string by handing back the whole mailbox, and "I asked for one address and got
+all of them" is the exact failure the filter exists to prevent. The `offset`
+parameter already had this guard; the new one copies it.
+
+## What it cost to find
+
+Five tests, each checked against the unpatched code first to prove they were
+capable of failing. But the measurement that actually mattered came from
+outside the test suite: sending a real message to the address and watching it
+not arrive, then finding it sitting in the database.
+
+The lesson we keep relearning is not "write more tests." It is that a write
+returning success proves a write returned success. `INSERT 0 1` was true, and
+the feature did nothing. The only check with any force was opening the inbox
+afterwards and seeing the message that had been invisible for a day.

--- a/tests/cli/test_email_failures_exit_nonzero.py
+++ b/tests/cli/test_email_failures_exit_nonzero.py
@@ -106,7 +106,7 @@ def test_inbox_forwards_the_page_size_and_offset():
         )
 
     assert result.exit_code == 0
-    get_emails.assert_called_once_with(last=1000, offset=2000)
+    get_emails.assert_called_once_with(last=1000, offset=2000, address=None)
 
 
 def test_a_successful_send_does_not_raise():

--- a/tests/cli/test_email_multi_address.py
+++ b/tests/cli/test_email_multi_address.py
@@ -1,0 +1,134 @@
+"""One account, several mailboxes: say which one, and pick a default.
+
+An account can own more than one address and can be granted read access to
+another account's. Until now the inbox merged them into one list that never said
+which address a message arrived at, and there was no way to ask for just one.
+
+That ambiguity is not cosmetic. On 2026-09-05 a job application went out
+carrying the wrong one of two addresses; the employer's reply was delivered and
+stored correctly and simply could not be told apart from — or found among — the
+other mailbox's mail. Successful delivery produces no bounce, so nothing
+anywhere reported a problem.
+
+The default sender had the same shape of gap: `is_default` existed in the
+database, `co email addresses` displayed it, and no command could change it.
+"""
+
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+import typer
+from rich.console import Console
+
+from connectonion.cli.commands import email_commands
+import connectonion.useful_tools.get_emails  # noqa: F401 — the real module, past the package re-exports
+
+# `from connectonion.useful_tools import get_emails` binds the FUNCTION the
+# package re-exports, not the module, and patching an attribute on it fails
+# with a confusing AttributeError. Same trick as test_email_addresses.py.
+get_emails_module = sys.modules["connectonion.useful_tools.get_emails"]
+
+
+def _resp(ok=True, json_data=None, status=200):
+    r = Mock()
+    r.ok = ok
+    r.status_code = status
+    r.json.return_value = json_data
+    r.headers = {"content-type": "application/json"}
+    r.text = ""
+    r.raise_for_status = Mock()
+    return r
+
+
+TWO_MAILBOXES = [
+    {"id": 486, "from": "xietianle@outlook.com", "to": "aaron@mail.openonion.ai",
+     "subject": "deliverability check", "message": "", "timestamp": "2026-09-04T22:53:56", "read": False},
+    {"id": 484, "from": "events@example.com", "to": "aaron.xie@mail.openonion.ai",
+     "subject": "popular events", "message": "", "timestamp": "2026-09-04T08:29:40", "read": True},
+]
+
+ONE_MAILBOX = [TWO_MAILBOXES[0]]
+
+
+def test_inbox_names_the_mailbox_when_the_page_spans_two(capsys):
+    # A wide console so the assertion is about content, not terminal geometry:
+    # at 80 columns Rich folds an address across lines and no substring check
+    # can tell folding from truncation.
+    wide = Console(width=200)
+    with patch.object(email_commands, "_require_auth", return_value=True), \
+         patch.object(email_commands, "console", wide), \
+         patch.object(get_emails_module, "get_emails", return_value=TWO_MAILBOXES):
+        email_commands.handle_email_inbox()
+    out = capsys.readouterr().out
+    assert "aaron@mail.openonion.ai" in out
+    assert "aaron.xie@mail.openonion.ai" in out
+    assert "--address" in out, "the way to narrow it must be discoverable here"
+
+
+def test_inbox_omits_the_to_column_for_a_single_mailbox(capsys):
+    """Same string on every row is noise, so it must not be spent on a column."""
+    with patch.object(email_commands, "_require_auth", return_value=True), \
+         patch.object(get_emails_module, "get_emails", return_value=ONE_MAILBOX):
+        email_commands.handle_email_inbox()
+    out = capsys.readouterr().out
+    assert "--address" not in out
+
+
+def test_inbox_passes_the_address_filter_through(capsys):
+    captured = {}
+
+    def _fake(last=10, offset=0, address=None, **kw):
+        captured["address"] = address
+        return ONE_MAILBOX
+
+    with patch.object(email_commands, "_require_auth", return_value=True), \
+         patch.object(get_emails_module, "get_emails", _fake):
+        email_commands.handle_email_inbox(address="aaron@mail.openonion.ai")
+    assert captured["address"] == "aaron@mail.openonion.ai"
+
+
+def test_empty_filtered_inbox_says_which_mailbox_was_empty(capsys):
+    with patch.object(email_commands, "_require_auth", return_value=True), \
+         patch.object(get_emails_module, "get_emails", return_value=[]):
+        email_commands.handle_email_inbox(address="aaron@mail.openonion.ai")
+    assert "aaron@mail.openonion.ai" in capsys.readouterr().out
+
+
+def test_get_emails_refuses_a_backend_that_ignored_the_filter():
+    """An old backend answers with every address; degrading silently is the bug."""
+    unfiltered = {"emails": [], "offset": 0, "address_filter_applied": None}
+    with patch.object(get_emails_module, "require_ambient_api_key", return_value="tok"), \
+         patch.object(get_emails_module.requests, "get", return_value=_resp(json_data=unfiltered)):
+        with pytest.raises(RuntimeError, match="does not support filtering received email by address"):
+            get_emails_module.get_emails(address="aaron@mail.openonion.ai")
+
+
+def test_get_emails_sends_the_address_param_and_returns_to():
+    body = {
+        "emails": [{"id": 1, "from": "a@b.c", "to": "aaron@mail.openonion.ai",
+                    "subject": "s", "text": "t", "received_at": "x", "is_read": False}],
+        "offset": 0,
+        "address_filter_applied": "aaron@mail.openonion.ai",
+    }
+    with patch.object(get_emails_module, "require_ambient_api_key", return_value="tok"), \
+         patch.object(get_emails_module.requests, "get", return_value=_resp(json_data=body)) as get:
+        emails = get_emails_module.get_emails(address="aaron@mail.openonion.ai")
+    assert get.call_args.kwargs["params"]["address"] == "aaron@mail.openonion.ai"
+    assert emails[0]["to"] == "aaron@mail.openonion.ai"
+
+
+def test_default_sender_can_be_changed(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "post", return_value=_resp(json_data={"success": True})) as post:
+        email_commands.handle_email_default("aaron@mail.openonion.ai")
+    assert post.call_args.kwargs["json"] == {"address": "aaron@mail.openonion.ai"}
+    assert "default sender" in capsys.readouterr().out
+
+
+def test_default_sender_failure_exits_nonzero(capsys):
+    refusal = _resp(ok=False, status=403, json_data={"detail": "not one of this account's own addresses"})
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "post", return_value=refusal):
+        with pytest.raises(typer.Exit):
+            email_commands.handle_email_default("someone.else@mail.openonion.ai")


### PR DESCRIPTION
Client half of openonion/oo-api#224 (merged and deployed 2026-09-05).

## What was broken

An account can own several addresses and be granted read access to another account's, but the CLI could not tell them apart or ask for one:

- `co email inbox` merged every readable address into one list and **never said which address a message arrived at**
- there was no way to narrow to a single mailbox
- `is_default` existed in the database and was displayed by `co email addresses`; nothing could change it

## What this adds

- `co email inbox --address <addr>` (`-a`)
- a **To** column that appears only when the page actually spans more than one mailbox — on a single-address account it would be the same string on every row, which is noise. It folds rather than ellipsizes, because a truncated address is the one thing the column exists to disambiguate.
- `co email default <address>`
- `get_emails(..., address=)` returns `to` on every message

## Failing closed

`get_emails()` refuses a backend that ignored the `address` parameter rather than silently returning every address — the same guard `offset` already had. An old backend answering with the whole mailbox when one was requested is the exact failure the filter exists to prevent.

## Why this matters

From a real incident on 2026-09-05: a job application went out carrying the wrong one of two addresses. The employer's reply was delivered and stored correctly, and could not be found — successfully delivered mail generates no bounce, so nothing anywhere reported a problem. The mail was simply in a list that did not say which mailbox anything belonged to.

## Tests

`tests/cli/test_email_multi_address.py` — 8 tests, each verified to fail against the unpatched code first.

One existing test updated: it pins the exact call signature of `get_emails`, which now takes `address`.

`tests/cli` 50 passed · `tests/unit` 7332 passed (1 pre-existing failure in `test_the_version_agrees_with_itself.py`, unrelated — docs-site advertises 1.6.12; verified it fails identically with these changes stashed).

## Labels and target release (required)

- **Suggested labels:** feature
- **Proposed target version:** 1.8.0
- **Estimated release window:** next 1.8 alpha
- **Milestone:** [maintainer assigns the confirmed release milestone]
- **Why this release:** This continues #1137, which landed in 1.8.0a1 — the grants table and `co email share` shipped there with a `can_read` column nothing ever read. The 1.7 line is feature-frozen and takes stabilisation fixes only, so new feature work belongs on 1.8/main, which is where this branch is cut from. Rollback risk is low: `--address` and `co email default` are additive, and `get_emails()` fails closed against a backend without the server half rather than silently returning every mailbox.
- **Forward-port tracking issue (stable patches only):** N/A — not a stable patch.

## How this was written

- [x] AI-assisted — I reviewed every line and can explain why each change is there

**Which model?** Claude Opus 5, via Claude Code.

The server half (openonion/oo-api#224) and this client half were written in one session that started from a real incident: a job application went out with the wrong one of two addresses, and the reply was invisible because the merged inbox never said which mailbox a message arrived at. Every new test was run against the unpatched code first to prove it could fail. The one thing worth a reviewer's attention is `account_inbox_addresses()` on the server — adding a fifth address source widens what two read paths return, and the guard that keeps it safe is that `delete_address_mail()` is gated on ownership rather than on that set.
