### PR TITLE
fix: avoid false missing-browser status in async daemon

### DIFF
--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -653,7 +653,9 @@ class BrowserDaemon:
         binary = engine.get("executable")
         if not binary:
             try:
-                binary = installed_browser_path()
+                # The fallback starts Patchright's synchronous driver. Running it
+                # on this event loop raises and falsely reports Chromium missing.
+                binary = await asyncio.to_thread(installed_browser_path)
             except Exception:
                 binary = None  # status is what you run when things are broken
         lines.append(f"Browser binary: ✓ {binary}" if binary else

--- a/docs/blog/2026-09-05-the-browser-that-status-could-not-see.md
+++ b/docs/blog/2026-09-05-the-browser-that-status-could-not-see.md
@@ -1,0 +1,30 @@
+# The Browser That Status Could Not See
+
+The Linux acceptance browser opened our test page, typed into its input, and
+clicked the button. Then `co browser status` told us no browser was installed.
+Following its advice would have downloaded the browser again. Nothing about the
+successful page operations suggested that another download could help.
+
+The installation probe asked Patchright for Chromium's executable path. That
+was sensible: guessing a cache directory would break when the driver's version
+or platform layout changed. But the probe used Patchright's synchronous API,
+and status now ran inside the daemon's asyncio event loop. The driver refused
+that combination. Our diagnostic caught the exception and translated it into
+“none installed.” We had turned a failed measurement into a claim about the
+machine.
+
+The older tests supplied either a path or no path. Both cases passed because
+neither cared where the probe ran. A new test made the probe reject an active
+event loop, reproducing the false missing-browser message. Moving the fallback
+probe to a worker thread made that test pass without changing which browser
+launches or how paid sessions are selected.
+
+On the same Linux acceptance machine, the repaired status printed the installed
+Chromium executable while the real page still passed navigation, reading,
+typing, script execution, clicking, and screenshot checks. The focused status,
+probe-cache, and async-daemon suite passed 23 tests. Those are diagnostic and
+free-browser results, not evidence that the paid panel flow has passed.
+
+Next time a diagnostic catches an exception to remain usable, its tests need
+to cover the context in which the measurement runs—not just the values we
+hope it will return.

--- a/tests/unit/test_browser_status_says_if_a_browser_exists.py
+++ b/tests/unit/test_browser_status_says_if_a_browser_exists.py
@@ -27,6 +27,8 @@ wrong one for the page commands — which is why the client keys on the daemon's
 own launch failure instead.
 """
 
+import asyncio
+
 import pytest
 
 from connectonion.cli.browser_agent import daemon as daemon_module
@@ -101,6 +103,19 @@ class TestAnInstalledBrowserIsNamed:
         monkeypatch.setattr(daemon_module, "installed_browser_path", lambda: self.PATH)
 
         assert "none installed" not in status_text()
+
+    def test_sync_driver_probe_runs_outside_the_daemon_event_loop(self, status_text, monkeypatch):
+        def sync_probe():
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                return self.PATH
+            raise RuntimeError("Patchright Sync API cannot run inside the asyncio loop")
+
+        monkeypatch.setattr(daemon_module, "installed_browser_path", sync_probe)
+        text = status_text()
+        assert self.PATH in text
+        assert "none installed" not in text
 
 
 class TestStatusStillAnswersWhenThingsAreBroken:


### PR DESCRIPTION
## Problem
The async daemon ran the synchronous Patchright installation probe on its event loop. The resulting exception falsely reported Chromium missing while real navigation worked.

## Fix
Run the fallback probe using asyncio.to_thread, retaining paid executable selection and missing-browser handling. Include regression coverage and an engineering journal.

## Release planning
- **Proposed target version:** 1.8.1
- **Estimated release window:** current 1.8.1 release candidate
- **Forward-port tracking issue (stable patches only):** #1427 (already targets main; no duplicate port)

## Verification
- Regression reproduced failure before implementation.
- Status, probe-cache and async daemon tests: 23 passed.
- Linux real headed Chromium: navigation, reading, input, script, click, screenshot and close passed; status reports the actual installed executable.
- Code/platform CI passed; refresh release metadata against this current body.

## Corrected acceptance scope
The product has CLI engine selection, not a paid UI panel. User confirmed that no panel gate applies. Existing real free-close to Onion to core-actions to close to free CLI acceptance is the switching evidence. This PR does not change defaults or authorize another paid session.