### PR TITLE
fix: fail browser navigation on proxy rejection and network error pages

### DIFF
--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -18,6 +18,7 @@ import contextvars
 import json
 import os
 import platform
+import re
 import sys
 import time
 import urllib.parse
@@ -53,6 +54,15 @@ class PaidSessionEndedError(RuntimeError):
     def __init__(self, reason: str):
         super().__init__(f"paid browser session ended: {reason}")
         self.reason = reason
+
+
+class BrowserNavigationError(RuntimeError):
+    """Navigation failed without committing a usable destination document."""
+
+    def __init__(self, code: str):
+        self.code = code
+        # URLs and driver call logs can contain proxy credentials or tokens.
+        super().__init__(code)
 
 
 _FOCUSED_ELEMENT_SCRIPT = """
@@ -834,10 +844,31 @@ class AsyncBrowserCore:
             if self.page is None:
                 await self.open_browser()
 
-            await self.page.goto(
-                _normalize_url(url), wait_until="domcontentloaded", timeout=30000
-            )
+            try:
+                response = await self.page.goto(
+                    _normalize_url(url), wait_until="domcontentloaded", timeout=30000
+                )
+            except Exception as exc:
+                match = re.search(r"net::(ERR_[A-Z0-9_]+)", str(exc))
+                if match:
+                    code = (
+                        "NAVIGATION_PROXY_AUTH_FAILED"
+                        if match[1] in {"ERR_INVALID_AUTH_CREDENTIALS", "ERR_PROXY_AUTH_REQUESTED"}
+                        else "NAVIGATION_NETWORK_ERROR"
+                    )
+                    raise BrowserNavigationError(code) from None
+                raise
+            if response is not None and response.status == 407:
+                raise BrowserNavigationError("NAVIGATION_PROXY_AUTH_FAILED")
             await self.page.wait_for_timeout(2000)
+            # Chrome may commit its internal error document without goto raising.
+            # An empty page or an ordinary HTTP 4xx response alone is not failure.
+            document_uri = await self.page.evaluate("() => document.documentURI")
+            if (
+                self.page.url.startswith("chrome-error://")
+                or isinstance(document_uri, str) and document_uri.startswith("chrome-error://")
+            ):
+                raise BrowserNavigationError("NAVIGATION_NETWORK_ERROR")
             self.current_url = self.page.url
             meta = self._tab_meta.setdefault(
                 key,

--- a/docs/blog/2026-09-05-navigation-was-not-success.md
+++ b/docs/blog/2026-09-05-navigation-was-not-success.md
@@ -1,0 +1,29 @@
+# Navigation Was Not Success
+
+The proxy rejected every request, but `co browser go_to` exited successfully.
+The page was empty. For an agent deciding whether to read the page or move on,
+the command had supplied the wrong answer at exactly the decision point.
+
+We had treated completion of `page.goto` as proof of navigation. A rejected
+proxy challenge can return an HTTP 407 response without raising a driver
+exception. Chrome can also commit its own network-error document. Neither
+result is the destination the caller asked for, yet our code saved context and
+printed “Navigated to” for both.
+
+The fix checks those outcomes before announcing success. Proxy authentication
+failure becomes `BrowserNavigationError: NAVIGATION_PROXY_AUTH_FAILED`;
+Chromium network errors become `NAVIGATION_NETWORK_ERROR`. The existing daemon
+exception boundary then produces a nonzero CLI exit. The messages deliberately
+omit driver call logs and URLs, which can contain credentials. A blank body or
+an ordinary HTTP 404 is still a legitimate page to inspect, not a reason to
+invent a transport failure.
+
+Three focused regressions failed before the change. With the fix, the async
+core and daemon suites passed 58 tests. On the GCP acceptance machine, a real
+headed browser navigated through a loopback proxy using the correct password
+and read the expected marker, exiting 0. A fresh isolated session with the
+wrong password was rejected by the proxy and exited 1 with the typed error.
+No public site or purchased credit was needed for that check.
+
+This closes a specific false-success path. It does not establish that every
+proxy deployment or the separate paid-panel flow has passed release acceptance.

--- a/docs/blog/2026-09-05-navigation-was-not-success.md
+++ b/docs/blog/2026-09-05-navigation-was-not-success.md
@@ -10,20 +10,22 @@ exception. Chrome can also commit its own network-error document. Neither
 result is the destination the caller asked for, yet our code saved context and
 printed “Navigated to” for both.
 
-The fix checks those outcomes before announcing success. Proxy authentication
-failure becomes `BrowserNavigationError: NAVIGATION_PROXY_AUTH_FAILED`;
-Chromium network errors become `NAVIGATION_NETWORK_ERROR`. The existing daemon
-exception boundary then produces a nonzero CLI exit. The messages deliberately
-omit driver call logs and URLs, which can contain credentials. A blank body or
-an ordinary HTTP 404 is still a legitimate page to inspect, not a reason to
-invent a transport failure.
+The empty page looked like a useful clue, but it was the wrong boundary to put
+into the fix. A site is allowed to return nothing. A 404 page can contain exactly
+the explanation an agent needs to read. Rejecting either would replace one
+misleading answer with another. We needed to ask whether the browser had reached
+a document from the destination, not whether that document looked useful.
 
-Three focused regressions failed before the change. With the fix, the async
-core and daemon suites passed 58 tests. On the GCP acceptance machine, a real
-headed browser navigated through a loopback proxy using the correct password
-and read the expected marker, exiting 0. A fresh isolated session with the
-wrong password was rejected by the proxy and exited 1 with the typed error.
-No public site or purchased credit was needed for that check.
+That distinction led us back to the response and Chrome's internal error page.
+We checked them before saving context or announcing success. On the GCP machine,
+the correct proxy password still let the browser read our test marker. With the
+wrong password, the command now exited 1. Then a tighter assertion failed: we had
+expected a proxy-authentication error, but Chrome had surfaced a network error
+instead of handing us the 407. The rejection was real; our expectation about how
+the driver would describe it was too narrow.
 
-This closes a specific false-success path. It does not establish that every
-proxy deployment or the separate paid-panel flow has passed release acceptance.
+The final check accepts either of those explicit failure paths, but never a
+successful exit for the rejected navigation. Ordinary empty and 404 pages remain
+readable. The focused suite passed 58 tests, and the real proxy check passed both
+password cases. The useful change is small: an agent can now stop at the failed
+navigation instead of trying to make sense of a page it never reached.

--- a/tests/e2e/cli/test_browser_proxy_navigation.py
+++ b/tests/e2e/cli/test_browser_proxy_navigation.py
@@ -1,0 +1,88 @@
+"""Opt-in real CLI regression: CO_BROWSER_PROXY_E2E=1 xvfb-run -a python <file>."""
+
+import base64
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import os
+from pathlib import Path
+import secrets
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+
+
+@unittest.skipUnless(os.getenv("CO_BROWSER_PROXY_E2E") == "1", "real browser opt-in required")
+class ProxyNavigationTests(unittest.TestCase):
+    def test_valid_proxy_and_rejected_credentials(self):
+        password = secrets.token_urlsafe(24)
+        expected = "Basic " + base64.b64encode(f"test:{password}".encode()).decode()
+        rejected = []
+        accepted = []
+
+        class Proxy(BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def do_GET(self):
+                if self.headers.get("Proxy-Authorization") != expected:
+                    rejected.append(True)
+                    self.send_response(407)
+                    self.send_header("Proxy-Authenticate", 'Basic realm="acceptance"')
+                    body = b""
+                else:
+                    accepted.append(True)
+                    self.send_response(200)
+                    body = b"<p>PROXY_AUTHENTICATED</p>"
+                self.send_header("Content-Type", "text/html")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Proxy)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        co = os.getenv("CO_BROWSER_TEST_CLI", str(Path(sys.executable).with_name("co")))
+        try:
+            for valid in (True, False):
+                with self.subTest(valid=valid), tempfile.TemporaryDirectory(prefix="co-proxy-") as directory:
+                    root = Path(directory)
+                    credential = password if valid else secrets.token_urlsafe(24)
+                    env = dict(os.environ, CO_WHO="proxy-navigation-test",
+                               CO_BROWSER_SOCK=str(root / "b.sock"),
+                               CO_BROWSER_PROFILE_DIR=str(root / "profile"),
+                               BROWSER_PROXY=f"http://test:{credential}@127.0.0.1:{server.server_port}")
+
+                    def run(*args):
+                        return subprocess.run([co, "browser", *args], env=env, cwd=root,
+                                              capture_output=True, text=True, timeout=90)
+
+                    before = len(accepted)
+                    rejected_before = len(rejected)
+                    try:
+                        result = run("go_to", "http://co-proxy-test.invalid/")
+                        self.assertFalse(credential in result.stdout + result.stderr,
+                                         "credential appeared in CLI output")
+                        if valid:
+                            self.assertEqual(result.returncode, 0)
+                            self.assertIn("Navigated to", result.stdout)
+                            self.assertIn("PROXY_AUTHENTICATED", run("get_text").stdout)
+                            self.assertGreater(len(accepted), before)
+                        else:
+                            self.assertNotEqual(result.returncode, 0)
+                            self.assertIn("BrowserNavigationError", result.stdout + result.stderr)
+                            self.assertIn("NAVIGATION_", result.stdout + result.stderr)
+                            self.assertNotIn("Navigated to", result.stdout)
+                            self.assertEqual(len(accepted), before)
+                            self.assertGreater(len(rejected), rejected_before)
+                        print(f"PASS proxy valid={valid}, cli_exit={result.returncode}", flush=True)
+                    finally:
+                        self.assertEqual(run("close").returncode, 0)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/cli/test_browser_proxy_navigation.py
+++ b/tests/e2e/cli/test_browser_proxy_navigation.py
@@ -78,7 +78,10 @@ class ProxyNavigationTests(unittest.TestCase):
                         else:
                             self.assertNotEqual(result.returncode, 0)
                             self.assertIn("BrowserNavigationError", result.stdout + result.stderr)
-                            self.assertIn("NAVIGATION_PROXY_AUTH_FAILED", result.stdout + result.stderr)
+                            # Chromium can surface a rejected challenge as a
+                            # network error instead of returning its HTTP 407.
+                            self.assertRegex(result.stdout + result.stderr,
+                                             r"BrowserNavigationError: NAVIGATION_(PROXY_AUTH_FAILED|NETWORK_ERROR)")
                             self.assertNotIn("Navigated to", result.stdout)
                             self.assertEqual(len(accepted), before)
                             self.assertGreater(len(rejected), rejected_before)

--- a/tests/e2e/cli/test_browser_proxy_navigation.py
+++ b/tests/e2e/cli/test_browser_proxy_navigation.py
@@ -24,6 +24,13 @@ class ProxyNavigationTests(unittest.TestCase):
             def log_message(self, *args):
                 pass
 
+            def handle(self):
+                try:
+                    super().handle()
+                except (BrokenPipeError, ConnectionResetError):
+                    # Chromium cancels background requests when the test closes.
+                    pass
+
             def do_GET(self):
                 if self.headers.get("Proxy-Authorization") != expected:
                     rejected.append(True)
@@ -71,7 +78,7 @@ class ProxyNavigationTests(unittest.TestCase):
                         else:
                             self.assertNotEqual(result.returncode, 0)
                             self.assertIn("BrowserNavigationError", result.stdout + result.stderr)
-                            self.assertIn("NAVIGATION_", result.stdout + result.stderr)
+                            self.assertIn("NAVIGATION_PROXY_AUTH_FAILED", result.stdout + result.stderr)
                             self.assertNotIn("Navigated to", result.stdout)
                             self.assertEqual(len(accepted), before)
                             self.assertGreater(len(rejected), rejected_before)

--- a/tests/unit/test_async_browser_core.py
+++ b/tests/unit/test_async_browser_core.py
@@ -282,6 +282,50 @@ def test_async_core_has_no_sync_patchright_dependency():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["407", "chrome-error", "net-error"])
+async def test_navigation_rejects_proxy_and_browser_error_pages(monkeypatch, tmp_path, failure):
+    install_fake_runtime(monkeypatch, tmp_path)
+    browser = async_mod.AsyncBrowserCore(headless=True)
+    await browser.open_browser()
+
+    async def goto(url, **kwargs):
+        browser.page.url = url
+        if failure == "net-error":
+            raise RuntimeError("net::ERR_PROXY_CONNECTION_FAILED at https://secret:password@example.com")
+        return SimpleNamespace(status=407 if failure == "407" else 200)
+
+    monkeypatch.setattr(browser.page, "goto", goto)
+    if failure == "chrome-error":
+        browser.page.evaluate_result = "chrome-error://chromewebdata/"
+    try:
+        with pytest.raises(RuntimeError, match="NAVIGATION_") as caught:
+            await browser.go_to("https://example.com", purpose="test", who="tester")
+        assert "password" not in str(caught.value)
+        assert browser.current_url != "https://example.com"
+    finally:
+        await browser.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [200, 204, 404])
+async def test_navigation_preserves_real_http_pages(monkeypatch, tmp_path, status):
+    install_fake_runtime(monkeypatch, tmp_path)
+    browser = async_mod.AsyncBrowserCore(headless=True)
+    await browser.open_browser()
+
+    async def goto(url, **kwargs):
+        browser.page.url = url
+        return SimpleNamespace(status=status)
+
+    monkeypatch.setattr(browser.page, "goto", goto)
+    browser.page.evaluate_result = "https://example.com"
+    try:
+        assert "Navigated to" in await browser.go_to("https://example.com", purpose="test", who="tester")
+    finally:
+        await browser.close()
+
+
+@pytest.mark.asyncio
 async def test_open_reuses_one_async_context_and_seeds_before_navigation(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
## Problem
GCP acceptance found wrong proxy credentials could reject every request while co browser go_to exited 0 and reported navigation success.

## Fix
Raise BrowserNavigationError before announcing success for HTTP407, chrome-error internal documents and driver net::ERR failures. The existing daemon error boundary yields a nonzero CLI exit. Error messages omit driver call logs and URLs which can contain credentials. Preserve legitimate empty and HTTP404 pages.

## Release planning
- **Proposed target version:** 1.8.1
- **Estimated release window:** next candidate after release acceptance
- **Forward-port tracking issue (stable patches only):** #1428 (targets main directly, no duplicate port required)

## Verification
- Regression first failed in three cases before implementation.
- Async core and daemon suites: 58 passed.
- GCP real headed Chromium: correct loopback proxy credentials exit0 plus expected page marker; wrong credentials exit1 with BrowserNavigationError: NAVIGATION_NETWORK_ERROR. Proxy observations verify rejected requests and no accepted request during the negative case.
- Opt-in test is tests/e2e/cli/test_browser_proxy_navigation.py; it uses a local proxy, no external site and no paid credit.
- Final explicit failure-code regression on GCP passed both cases in 9.123 seconds, exit0 for the test runner.

## Release impact
This fixes a verified 1.8.1 blocker but does not authorize publication. CI/main inclusion and other release gates, including the separately requested paid-panel proof, remain required. No unrelated work is merged.
