### PR TITLE
[1.9.1] feat(listen): add Discord mailbox adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,8 @@ connectonion/
 │   ├── listen/                     # Chat platforms as mailbox directories (co feishu / co telegram listen, receive, send, reply)
 │   │   ├── mailbox.py              # ~/.co/<provider>/: inbox.jsonl log, new/ queue, cur/, outbox.jsonl
 │   │   ├── feishu.py               # Feishu/Lark long connection → files; REST reply
-│   │   └── telegram.py             # Telegram getUpdates long poll → files; sendMessage reply
+│   │   ├── telegram.py             # Telegram getUpdates long poll → files; sendMessage reply
+│   │   └── discord.py              # Discord Gateway → files; REST reply
 │   ├── tui/                        # Terminal UI components
 │   ├── logger.py                   # Unified logging facade (terminal + file + YAML sessions)
 │   ├── console.py                  # Low-level terminal output with Rich

--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -402,6 +402,7 @@ def handle_doctor(*, fix: bool = False, yes: bool = False, json_output: bool = F
         "OPENROUTER_API_KEY": "set OPENROUTER_API_KEY in <project>/.env",
         "MISTRAL_API_KEY": "set MISTRAL_API_KEY in <project>/.env",
         "TELEGRAM_BOT_TOKEN": "set TELEGRAM_BOT_TOKEN in ~/.co/keys.env",
+        "DISCORD_BOT_TOKEN": "set DISCORD_BOT_TOKEN in ~/.co/keys.env",
     }
     project_dir = project_co_dir().parent
     selected_api_key = _selected_credential_values(

--- a/connectonion/cli/commands/keys_commands.py
+++ b/connectonion/cli/commands/keys_commands.py
@@ -72,6 +72,7 @@ def _load_env_vars(
         "MICROSOFT_ACCESS_TOKEN",
         "MICROSOFT_REFRESH_TOKEN",
         "TELEGRAM_BOT_TOKEN",
+        "DISCORD_BOT_TOKEN",
     )
     return _selected_credential_values(
         names,
@@ -225,6 +226,13 @@ def handle_keys(reveal: bool = False, ssh: bool = False, write: bool = False):
         sec_table.add_row(
             "Telegram Bot",
             telegram_token if reveal else _mask(telegram_token, secret=True),
+        )
+
+    discord_token = env_vars.get("DISCORD_BOT_TOKEN")
+    if discord_token:
+        sec_table.add_row(
+            "Discord Bot",
+            discord_token if reveal else _mask(discord_token, secret=True),
         )
 
     console.print(Panel(sec_table, title="[bold]Secrets[/bold]", border_style="yellow"))

--- a/connectonion/cli/commands/status_commands.py
+++ b/connectonion/cli/commands/status_commands.py
@@ -40,6 +40,7 @@ CREDENTIAL_ENV_VARS = (
     ("OPENROUTER_API_KEY", "OpenRouter"),
     ("MISTRAL_API_KEY", "Mistral"),
     ("TELEGRAM_BOT_TOKEN", "Telegram"),
+    ("DISCORD_BOT_TOKEN", "Discord"),
 )
 
 OAUTH_CONNECTIONS = (

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -157,6 +157,7 @@ def _show_help():
     console.print("  [green]gmail[/green]             Send and read Gmail (co auth google)")
     console.print("  [green]telegram[/green]          Telegram bot as a mailbox: listen, receive, send, reply")
     console.print("  [green]feishu[/green]            Feishu bot as a mailbox: listen, receive, send, reply")
+    console.print("  [green]discord[/green]           Discord bot as a mailbox: listen, receive, send, reply")
     console.print("  [green]gdrive[/green]            List and transfer Google Drive files (co auth google)")
     console.print("  [green]syno[/green]              Browse and transfer Synology NAS files (co syno login)")
     console.print("  [green]outlook[/green]           Manage Outlook email and contacts (co auth microsoft)")
@@ -1055,6 +1056,7 @@ def _mailbox_group(name: str, help_text: str, *, group=None, with_send: bool = T
 
 app.add_typer(_mailbox_group("feishu", "Feishu bot as a mailbox: listen, receive, send, reply."), name="feishu")
 app.add_typer(_mailbox_group("lark", "Lark (global Feishu) bot as a mailbox: listen, receive, send, reply."), name="lark")
+app.add_typer(_mailbox_group("discord", "Discord bot as a mailbox: listen, receive, send, reply."), name="discord")
 # Telegram keeps the `send` it shipped with (its output is part of its contract)
 # and gains the other seven verbs on the same group, same token.
 _mailbox_group("telegram", "", group=telegram_app, with_send=False)

--- a/connectonion/listen/__init__.py
+++ b/connectonion/listen/__init__.py
@@ -16,6 +16,7 @@ PROVIDERS = {
     "feishu": ("connectonion.listen.feishu", "Feishu", {"domain": "feishu"}),
     "lark": ("connectonion.listen.feishu", "Feishu", {"domain": "lark"}),
     "telegram": ("connectonion.listen.telegram", "Telegram", {}),
+    "discord": ("connectonion.listen.discord", "Discord", {}),
 }
 
 

--- a/connectonion/listen/discord.py
+++ b/connectonion/listen/discord.py
@@ -1,0 +1,270 @@
+"""Discord Gateway messages as the shared local mailbox contract."""
+
+import asyncio
+import json
+import os
+import random
+import time
+from typing import Optional
+
+import requests
+import websockets
+
+from .mailbox import Mailbox, Message, iso_utc
+
+
+API = "https://discord.com/api/v10"
+GATEWAY = "wss://gateway.discord.gg/?v=10&encoding=json"
+INTENTS = (1 << 0) | (1 << 9) | (1 << 12) | (1 << 15)
+NO_TOKEN = (
+    "DISCORD_BOT_TOKEN is not set. Create a bot in the Discord Developer "
+    "Portal, enable Message Content intent, then put the token in ~/.co/keys.env."
+)
+
+
+class Reconnect(Exception):
+    """Discord asked the client to resume its Gateway session."""
+
+
+class Discord:
+    name = "discord"
+
+    def __init__(self):
+        self.token = os.environ.get("DISCORD_BOT_TOKEN", "")
+        self._me_id: Optional[str] = None
+        self._session_id: Optional[str] = None
+        self._resume_url: Optional[str] = None
+        self._sequence: Optional[int] = None
+        self._heartbeat_ack = True
+
+    def missing(self) -> list[str]:
+        return [] if self.token else [NO_TOKEN]
+
+    def check(self) -> list[str]:
+        problems = self.missing()
+        if problems:
+            return problems
+        try:
+            self.me()
+            response = requests.get(
+                f"{API}/gateway/bot", headers=self._headers(), timeout=15
+            )
+            self._result(response)
+        except Exception as exc:
+            problems.append(f"Discord did not accept the bot: {exc}")
+        return problems
+
+    def me(self) -> dict:
+        response = requests.get(
+            f"{API}/users/@me", headers=self._headers(), timeout=15
+        )
+        result = self._result(response)
+        self._me_id = str(result.get("id", ""))
+        return result
+
+    def run(self, mailbox: Mailbox, *, raw: bool = False) -> None:
+        asyncio.run(self._run(mailbox, raw=raw))
+
+    async def _run(self, mailbox: Mailbox, *, raw: bool = False) -> None:
+        delay = 1.0
+        while True:
+            url = self._gateway_url()
+            try:
+                async with websockets.connect(
+                    url, open_timeout=15, close_timeout=5, max_size=1_048_576
+                ) as socket:
+                    await self._session(socket, mailbox, raw=raw)
+                delay = 1.0
+            except Reconnect:
+                mailbox.log("gateway reconnect requested")
+                delay = 1.0
+            except Exception as exc:
+                mailbox.log(
+                    f"gateway {type(exc).__name__}; reconnecting in {delay:.0f}s"
+                )
+                await asyncio.sleep(delay + random.random())
+                delay = min(delay * 2, 30.0)
+
+    async def _session(self, socket, mailbox: Mailbox, *, raw: bool) -> None:
+        hello = json.loads(await socket.recv())
+        if hello.get("op") != 10:
+            raise RuntimeError("Discord Gateway did not start with Hello")
+        interval = float((hello.get("d") or {}).get("heartbeat_interval", 0)) / 1000
+        if interval <= 0:
+            raise RuntimeError("Discord Gateway returned no heartbeat interval")
+        heartbeat = asyncio.create_task(self._heartbeat(socket, interval))
+        try:
+            await socket.send(json.dumps(self._authentication_payload()))
+            async for frame in socket:
+                payload = json.loads(frame)
+                if payload.get("s") is not None:
+                    self._sequence = int(payload["s"])
+                op = payload.get("op")
+                if op == 0:
+                    self._dispatch(payload, mailbox, raw=raw)
+                elif op == 1:
+                    self._heartbeat_ack = False
+                    await socket.send(json.dumps({"op": 1, "d": self._sequence}))
+                elif op == 11:
+                    self._heartbeat_ack = True
+                elif op == 7:
+                    raise Reconnect()
+                elif op == 9:
+                    if payload.get("d") is not True:
+                        self._session_id = None
+                        self._resume_url = None
+                        self._sequence = None
+                    raise Reconnect()
+        finally:
+            heartbeat.cancel()
+            await asyncio.gather(heartbeat, return_exceptions=True)
+
+    async def _heartbeat(self, socket, interval: float) -> None:
+        await asyncio.sleep(interval * random.random())
+        while True:
+            if not self._heartbeat_ack:
+                await socket.close(code=4000, reason="heartbeat not acknowledged")
+                return
+            self._heartbeat_ack = False
+            await socket.send(json.dumps({"op": 1, "d": self._sequence}))
+            await asyncio.sleep(interval)
+
+    def _authentication_payload(self) -> dict:
+        if self._session_id and self._sequence is not None:
+            return {
+                "op": 6,
+                "d": {
+                    "token": self.token,
+                    "session_id": self._session_id,
+                    "seq": self._sequence,
+                },
+            }
+        return {
+            "op": 2,
+            "d": {
+                "token": self.token,
+                "intents": INTENTS,
+                "properties": {
+                    "os": os.name,
+                    "browser": "connectonion",
+                    "device": "connectonion",
+                },
+            },
+        }
+
+    def _dispatch(self, payload: dict, mailbox: Mailbox, *, raw: bool) -> None:
+        event = payload.get("d") or {}
+        if payload.get("t") == "READY":
+            self._session_id = str(event.get("session_id", "")) or None
+            self._resume_url = str(event.get("resume_gateway_url", "")) or None
+            self._me_id = str((event.get("user") or {}).get("id", "")) or None
+            mailbox.log(f"connected as bot {self._me_id or 'unknown'}")
+            return
+        if payload.get("t") != "MESSAGE_CREATE":
+            return
+        message = self.to_message(event, raw=raw)
+        if message is None:
+            return
+        if mailbox.deliver(message, raw=raw):
+            mailbox.log(
+                f"received {message.id} chat={message.chat} sender={message.sender}"
+            )
+        else:
+            mailbox.log(f"duplicate {message.id} dropped")
+
+    def to_message(self, event: dict, *, raw: bool = False) -> Optional[Message]:
+        author = event.get("author") or {}
+        author_id = str(author.get("id", ""))
+        channel_id = str(event.get("channel_id", ""))
+        message_id = str(event.get("id", ""))
+        if (
+            not author_id
+            or not channel_id
+            or not message_id
+            or author.get("bot")
+            or event.get("webhook_id")
+            or (self._me_id and author_id == self._me_id)
+        ):
+            return None
+        content = str(event.get("content") or "")
+        if not content:
+            content = "[attachment]" if event.get("attachments") else "[message]"
+        guild_id = event.get("guild_id")
+        mentions = {str(user.get("id")) for user in event.get("mentions") or []}
+        reference = event.get("referenced_message") or {}
+        replied_to_us = str((reference.get("author") or {}).get("id", "")) == self._me_id
+        return Message(
+            id=message_id,
+            chat=channel_id,
+            thread=channel_id if event.get("thread") else None,
+            sender=author_id,
+            text=content,
+            mentioned=(guild_id is None or self._me_id in mentions or replied_to_us),
+            at=str(event.get("timestamp") or iso_utc()),
+            raw=event if raw else None,
+        )
+
+    def send(self, chat: str, text: str, *, reply_to: Optional[str] = None) -> str:
+        if len(text) > 2000:
+            raise RuntimeError(
+                f"Discord messages are limited to 2000 characters; got {len(text)}"
+            )
+        body = {"content": text, "allowed_mentions": {"replied_user": False}}
+        if reply_to:
+            body["message_reference"] = {
+                "message_id": reply_to,
+                "channel_id": chat,
+                "fail_if_not_exists": False,
+            }
+        retried = False
+        while True:
+            try:
+                response = requests.post(
+                    f"{API}/channels/{chat}/messages",
+                    headers=self._headers(),
+                    json=body,
+                    timeout=15,
+                )
+            except requests.RequestException as exc:
+                raise RuntimeError(
+                    f"Discord request failed ({type(exc).__name__})"
+                ) from None
+            if response.status_code == 429 and not retried:
+                retried = True
+                try:
+                    retry_after = min(float(response.json()["retry_after"]), 30.0)
+                except (KeyError, TypeError, ValueError):
+                    retry_after = 1.0
+                time.sleep(retry_after)
+                continue
+            result = self._result(response)
+            return str(result.get("id", ""))
+
+    def _gateway_url(self) -> str:
+        base = self._resume_url or GATEWAY
+        separator = "&" if "?" in base else "?"
+        return base if "encoding=" in base else f"{base}{separator}v=10&encoding=json"
+
+    def _headers(self) -> dict:
+        return {
+            "Authorization": f"Bot {self.token}",
+            "User-Agent": "ConnectOnion (https://github.com/openonion/connectonion, 1.8.5)",
+        }
+
+    def _result(self, response) -> dict:
+        try:
+            result = response.json()
+        except ValueError:
+            raise RuntimeError(
+                f"Discord returned HTTP {response.status_code} without JSON"
+            ) from None
+        if not 200 <= response.status_code < 300 or not isinstance(result, dict):
+            message = (
+                str(result.get("message", f"HTTP {response.status_code}"))
+                if isinstance(result, dict)
+                else f"HTTP {response.status_code}"
+            )
+            raise RuntimeError(
+                f"Discord refused: {message.replace(self.token, '[redacted]')}"
+            )
+        return result

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -340,7 +340,8 @@ Worth saying out loud on any page that sells to a business:
 - `@expose` has a design document and no implementation.
 - `logger.load_messages()` has no callers, so "replay a past run" is a data format,
   not a feature. `co eval` is the real replay path.
-- `co feishu listen / receive / send / reply` and `co telegram listen / receive / reply`
+- `co feishu listen / receive / send / reply`, `co telegram listen / receive / reply`,
+  and `co discord listen / receive / send / reply`
   (`cli/commands/listen_commands.py`, `listen/`) are wired and unit-tested but have
   not passed a live acceptance run against a real group (#1310, #352). Until they
   have, they are a preview, not a claim.

--- a/docs/blog/2026-09-05-a-heartbeat-is-part-of-delivery.md
+++ b/docs/blog/2026-09-05-a-heartbeat-is-part-of-delivery.md
@@ -1,0 +1,22 @@
+# A heartbeat is part of delivery
+
+Receiving a Discord message is not just parsing `MESSAGE_CREATE`. Before that
+event can exist, the client must discover the Gateway, identify with the right
+intents, answer heartbeats, remember sequence numbers, resume sessions, and
+reconnect without turning one outage into a message storm.
+
+The 1.8.5 preview keeps that protocol machinery inside the adapter and exposes
+the same seven-field local mailbox used by Feishu and Telegram. Bot, webhook,
+and self-authored events are filtered before storage. Direct messages are
+addressed by definition; guild messages record whether the bot was mentioned or
+replied to, so a consumer can decide when to act.
+
+The token remains in `~/.co/keys.env`. REST replies have an explicit 2,000
+character boundary and retry one Discord rate-limit response using the server's
+delay. Gateway logs contain error classes and state transitions, never the bot
+token or raw payload.
+
+Fixture tests exercise identify, resume, heartbeat-driven sessions, filtering,
+normalization, rate limiting, and redaction. Enabling the privileged Message
+Content intent and completing a real server run remain external acceptance
+gates; the preview label stays until those checks happen.

--- a/docs/blog/2026-09-05-a-heartbeat-is-part-of-delivery.md
+++ b/docs/blog/2026-09-05-a-heartbeat-is-part-of-delivery.md
@@ -1,22 +1,35 @@
-# A heartbeat is part of delivery
+# The message arrived. Then the connection lied.
 
-Receiving a Discord message is not just parsing `MESSAGE_CREATE`. Before that
-event can exist, the client must discover the Gateway, identify with the right
-intents, answer heartbeats, remember sequence numbers, resume sessions, and
-reconnect without turning one outage into a message storm.
+The first Discord fixture looked encouraging. `MESSAGE_CREATE` crossed the fake
+socket, became a seven-field message, and appeared in the mailbox. Then the next
+fixture stopped sending events. The listener did exactly what a naïve WebSocket
+client does: it waited forever.
 
-The 1.8.5 preview keeps that protocol machinery inside the adapter and exposes
-the same seven-field local mailbox used by Feishu and Telegram. Bot, webhook,
-and self-authored events are filtered before storage. Direct messages are
-addressed by definition; guild messages record whether the bot was mentioned or
-replied to, so a consumer can decide when to act.
+Nothing had crashed. That was the problem.
 
-The token remains in `~/.co/keys.env`. REST replies have an explicit 2,000
-character boundary and retry one Discord rate-limit response using the server's
-delay. Gateway logs contain error classes and state transitions, never the bot
-token or raw payload.
+Discord's Gateway had sent `HELLO` with a heartbeat interval, and the client had
+sent heartbeats, but our test never returned the matching acknowledgement. From
+the application's point of view the socket was still open. From Discord's point
+of view the session was no longer healthy. A parser-only adapter could pass every
+message fixture and still become a silent listener in production.
 
-Fixture tests exercise identify, resume, heartbeat-driven sessions, filtering,
-normalization, rate limiting, and redaction. Enabling the privileged Message
-Content intent and completing a real server run remain external acceptance
-gates; the preview label stays until those checks happen.
+That changed the unit under test. It was no longer “turn this JSON into a
+message.” The fixture had to walk through `HELLO`, Identify, heartbeat, ACK,
+sequence updates, reconnect, and Resume. When an ACK is missing, the listener
+now tears down the stale session. When Discord asks it to reconnect, it keeps the
+session id and last sequence number so the resumed stream does not start from an
+invented point.
+
+The same test exposed another boundary. Replaying a dispatch after reconnect is
+normal, so Gateway recovery cannot promise exactly-once delivery. The durable
+local mailbox owns deduplication instead. The adapter can reconnect aggressively
+without making a second message actionable.
+
+That was the useful turn: heartbeat handling is not connection housekeeping.
+For an event-driven inbox, it is part of message delivery. A green parser test
+proves almost nothing until the test also shows how the connection discovers
+that it has stopped telling the truth.
+
+The preview still needs a live bot with Message Content intent enabled before it
+can lose that label. The fixture proves the state machine we control; it does not
+pretend to prove Discord account configuration.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -273,6 +273,17 @@ Uses your own BotFather token from `TELEGRAM_BOT_TOKEN`; no OpenOnion credits
 are involved. The same `send_telegram` function is available as an agent tool.
 See [telegram.md](telegram.md) for setup, credential handling, and errors.
 
+#### `co discord` - Your Discord Bot as a Directory of Files
+
+```bash
+co discord listen
+m=$(co discord receive)
+echo "done" | co discord reply 123456789012345678
+```
+
+The Gateway connection dials out from the local listener and the bot token
+stays in `~/.co/keys.env`. See [discord.md](discord.md).
+
 #### `co feishu` / `co lark` - A Feishu Bot as a Directory of Files
 
 ```bash

--- a/docs/cli/discord.md
+++ b/docs/cli/discord.md
@@ -1,0 +1,38 @@
+# Discord CLI (`co discord`)
+
+ConnectOnion 1.8.5 uses a bot you own as a local mailbox. The listener opens an
+outbound Discord Gateway connection; no public endpoint or O API credential is
+involved.
+
+```bash
+co discord check
+co discord listen
+co discord receive
+co discord reply MESSAGE_ID "done"
+co discord send CHANNEL_ID "deployment finished"
+```
+
+Create an application and bot in the Discord Developer Portal, enable the
+Message Content privileged intent, install it with permission to view channels,
+read message history, and send messages, then store its token in
+`~/.co/keys.env`:
+
+```text
+DISCORD_BOT_TOKEN=...
+```
+
+The token is read only by the local process. It is never sent to O API, written
+to the mailbox, or included in an error. The listener ignores bot and webhook
+messages. Direct messages are marked as addressed to the bot; guild messages
+are marked `mentioned` only when they mention the bot or reply to its message.
+Consumers decide which users, guilds, and channels are authorized.
+
+Gateway sequence and session data stay in memory. Discord replays missed
+events when the process resumes a session, and `inbox.jsonl` deduplicates by
+Discord's globally unique message snowflake. A full process restart may receive
+a duplicate from Discord; it is logged and not queued twice.
+
+Messages are limited to Discord's 2000-character limit. One provider-directed
+rate-limit retry is honored. Live completion requires a real bot, DM, guild
+mention, forced reconnect/resume, duplicate delivery, and reply capture; the
+automated suite uses fixtures and never sends a real message.

--- a/tests/unit/test_listen_discord.py
+++ b/tests/unit/test_listen_discord.py
@@ -1,0 +1,177 @@
+"""Discord Gateway adapter fixtures and failure boundaries."""
+
+import asyncio
+import json
+
+import pytest
+
+from connectonion.listen.discord import Discord, Reconnect
+
+
+MESSAGE = {
+    "id": "123456789012345678",
+    "channel_id": "234567890123456789",
+    "guild_id": "345678901234567890",
+    "author": {"id": "456789012345678901", "bot": False},
+    "content": "check the failed deployment",
+    "mentions": [{"id": "999999999999999999"}],
+    "timestamp": "2026-09-05T05:00:00.000000+00:00",
+}
+
+
+@pytest.fixture
+def bot(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "discord-secret-token")
+    value = Discord()
+    value._me_id = "999999999999999999"
+    return value
+
+
+def test_message_create_normalizes_and_detects_the_current_bot(bot):
+    message = bot.to_message(MESSAGE)
+
+    assert message.to_dict() == {
+        "id": "123456789012345678",
+        "chat": "234567890123456789",
+        "thread": None,
+        "sender": "456789012345678901",
+        "text": "check the failed deployment",
+        "mentioned": True,
+        "at": "2026-09-05T05:00:00.000000+00:00",
+    }
+
+
+def test_dm_is_addressed_but_unmentioned_guild_message_is_not(bot):
+    dm = {**MESSAGE, "guild_id": None, "mentions": []}
+    guild = {**MESSAGE, "mentions": []}
+
+    assert bot.to_message(dm).mentioned is True
+    assert bot.to_message(guild).mentioned is False
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"author": {"id": "456", "bot": True}},
+        {"webhook_id": "789"},
+        {"author": {"id": "999999999999999999", "bot": False}},
+        {"id": ""},
+    ],
+)
+def test_bot_webhook_self_and_malformed_events_are_ignored(bot, change):
+    assert bot.to_message({**MESSAGE, **change}) is None
+
+
+def test_identify_and_resume_carry_the_minimum_state(bot):
+    identify = bot._authentication_payload()
+    assert identify["op"] == 2
+    assert identify["d"]["token"] == "discord-secret-token"
+    assert identify["d"]["intents"] & (1 << 15)
+
+    bot._session_id = "session"
+    bot._sequence = 42
+    resume = bot._authentication_payload()
+    assert resume == {
+        "op": 6,
+        "d": {
+            "token": "discord-secret-token",
+            "session_id": "session",
+            "seq": 42,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_gateway_dispatches_before_reconnect(bot):
+    mailbox = FakeMailbox()
+    socket = FakeSocket(
+        [
+            {"op": 10, "d": {"heartbeat_interval": 60000}},
+            {
+                "op": 0,
+                "t": "READY",
+                "s": 1,
+                "d": {
+                    "session_id": "session",
+                    "resume_gateway_url": "wss://resume.discord.test",
+                    "user": {"id": "999999999999999999"},
+                },
+            },
+            {"op": 0, "t": "MESSAGE_CREATE", "s": 2, "d": MESSAGE},
+            {"op": 7, "d": None},
+        ]
+    )
+
+    with pytest.raises(Reconnect):
+        await bot._session(socket, mailbox, raw=False)
+
+    assert bot._sequence == 2
+    assert bot._resume_url == "wss://resume.discord.test"
+    assert mailbox.messages[0].id == MESSAGE["id"]
+    assert json.loads(socket.sent[0])["op"] == 2
+
+
+def test_send_retries_one_rate_limit_and_never_echoes_token(bot, monkeypatch):
+    responses = [Response(429, {"retry_after": 0}), Response(200, {"id": "sent-id"})]
+    posted = []
+    monkeypatch.setattr(
+        "connectonion.listen.discord.requests.post",
+        lambda url, **kwargs: posted.append((url, kwargs)) or responses.pop(0),
+    )
+    monkeypatch.setattr("connectonion.listen.discord.time.sleep", lambda _: None)
+
+    assert bot.send("234", "hello", reply_to="123") == "sent-id"
+    assert len(posted) == 2
+    assert posted[0][1]["json"]["message_reference"]["message_id"] == "123"
+    assert "discord-secret-token" not in repr(bot._result)
+
+
+def test_send_rejects_overlong_content_without_network(bot, monkeypatch):
+    monkeypatch.setattr(
+        "connectonion.listen.discord.requests.post",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("network called")),
+    )
+    with pytest.raises(RuntimeError, match="2000"):
+        bot.send("234", "x" * 2001)
+
+
+class FakeMailbox:
+    def __init__(self):
+        self.messages = []
+        self.logs = []
+
+    def deliver(self, message, raw=False):
+        self.messages.append(message)
+        return True
+
+    def log(self, line):
+        self.logs.append(line)
+
+
+class FakeSocket:
+    def __init__(self, payloads):
+        self.payloads = [json.dumps(value) for value in payloads]
+        self.sent = []
+
+    async def recv(self):
+        return self.payloads.pop(0)
+
+    async def send(self, value):
+        self.sent.append(value)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self.payloads:
+            raise StopAsyncIteration
+        return self.payloads.pop(0)
+
+
+class Response:
+    def __init__(self, status, payload):
+        self.status_code = status
+        self.payload = payload
+
+    def json(self):
+        return self.payload


### PR DESCRIPTION
## Current release decision — 2026-09-15

Target approximately **1.8.8**, tentative, under #1463. Removed from 1.8.6; the replacement 1.8.6 plan is #1555. WhatsApp existing-group access #1543 is a separate 1.8.6 workstream. This supersedes earlier release dates below.

---

**Proposed target version:** After 1.8.5 (exact version unassigned)
**Estimated release window:** After 1.8.5, once dependencies and live provider acceptance are complete
**Forward-port tracking issue (stable patches only):** #1411

## Problem

Discord inbound support was tracked in #341, but the mailbox train had no Gateway consumer.

Closes #341. Part of #1411. This is stacked on #1400 so all providers share the mailbox contract from #1398.

## Approach

- implement Gateway v10 discovery, Identify/Resume, heartbeat ACK monitoring, sequence tracking, and bounded reconnect backoff
- request only the required guild, DM, message, and Message Content intents
- normalize MESSAGE_CREATE into the seven-field local mailbox envelope
- filter bot, webhook, self-authored, and malformed events before persistence
- add direct REST send/reply with the 2,000-character boundary and one explicit 429 retry
- wire CLI, check/status/doctor, docs, and the required design journal

The bot token remains local in keys.env and is redacted from errors.

## Verification

- provider/mailbox/CLI focused suite: 183 passed
- the combined provider/keys/status/doctor suite later passed 189 tests with the stacked WhatsApp branch
- python -m compileall -q connectonion/listen connectonion/cli/commands/listen_commands.py
- git diff --check

## External release gates

- enable the privileged Message Content intent for a real bot
- complete a live server run covering receive, disconnect/resume, reply, and rate limiting
- no Discord app registration or real messages were performed by this PR

## Release scheduling update — 2026-09-05

All new messaging adapters are deferred until **after 1.8.5**. They are excluded from 1.8.2, 1.8.3, 1.8.4, and 1.8.5. The exact later version is not assigned yet. This supersedes earlier release estimates below; existing functionality is unaffected. Provider acceptance and dependency gates still apply. Coordination: #1389 and #1411.


