### PR TITLE
[1.9.1] feat(listen): add WhatsApp Cloud API mailbox adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,11 +178,12 @@ connectonion/
 │   │       ├── tools.py            # Verification tools
 │   │       ├── trust_agent.py      # TrustAgent class
 │   │       └── policies/           # Trust level policy markdown
-│   ├── listen/                     # Chat platforms as mailbox directories (co feishu / co telegram listen, receive, send, reply)
+│   ├── listen/                     # Chat platforms as mailbox directories (co feishu / co telegram / co discord / co whatsapp)
 │   │   ├── mailbox.py              # ~/.co/<provider>/: inbox.jsonl log, new/ queue, cur/, outbox.jsonl
 │   │   ├── feishu.py               # Feishu/Lark long connection → files; REST reply
 │   │   ├── telegram.py             # Telegram getUpdates long poll → files; sendMessage reply
-│   │   └── discord.py              # Discord Gateway → files; REST reply
+│   │   ├── discord.py              # Discord Gateway → files; REST reply
+│   │   └── whatsapp.py             # O API webhook inbox → files; Meta REST reply
 │   ├── tui/                        # Terminal UI components
 │   ├── logger.py                   # Unified logging facade (terminal + file + YAML sessions)
 │   ├── console.py                  # Low-level terminal output with Rich

--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -403,6 +403,9 @@ def handle_doctor(*, fix: bool = False, yes: bool = False, json_output: bool = F
         "MISTRAL_API_KEY": "set MISTRAL_API_KEY in <project>/.env",
         "TELEGRAM_BOT_TOKEN": "set TELEGRAM_BOT_TOKEN in ~/.co/keys.env",
         "DISCORD_BOT_TOKEN": "set DISCORD_BOT_TOKEN in ~/.co/keys.env",
+        "WHATSAPP_ACCESS_TOKEN": "set WHATSAPP_ACCESS_TOKEN in ~/.co/keys.env",
+        "WHATSAPP_APP_SECRET": "set WHATSAPP_APP_SECRET in ~/.co/keys.env",
+        "WHATSAPP_VERIFY_TOKEN": "set WHATSAPP_VERIFY_TOKEN in ~/.co/keys.env",
     }
     project_dir = project_co_dir().parent
     selected_api_key = _selected_credential_values(

--- a/connectonion/cli/commands/keys_commands.py
+++ b/connectonion/cli/commands/keys_commands.py
@@ -73,6 +73,9 @@ def _load_env_vars(
         "MICROSOFT_REFRESH_TOKEN",
         "TELEGRAM_BOT_TOKEN",
         "DISCORD_BOT_TOKEN",
+        "WHATSAPP_ACCESS_TOKEN",
+        "WHATSAPP_APP_SECRET",
+        "WHATSAPP_VERIFY_TOKEN",
     )
     return _selected_credential_values(
         names,
@@ -234,6 +237,18 @@ def handle_keys(reveal: bool = False, ssh: bool = False, write: bool = False):
             "Discord Bot",
             discord_token if reveal else _mask(discord_token, secret=True),
         )
+
+    for name, label in (
+        ("WHATSAPP_ACCESS_TOKEN", "WhatsApp Access"),
+        ("WHATSAPP_APP_SECRET", "WhatsApp App"),
+        ("WHATSAPP_VERIFY_TOKEN", "WhatsApp Verify"),
+    ):
+        value = env_vars.get(name)
+        if value:
+            sec_table.add_row(
+                label,
+                value if reveal else _mask(value, secret=True),
+            )
 
     console.print(Panel(sec_table, title="[bold]Secrets[/bold]", border_style="yellow"))
 

--- a/connectonion/cli/commands/listen_commands.py
+++ b/connectonion/cli/commands/listen_commands.py
@@ -18,7 +18,8 @@ from typing import List, Optional
 
 from rich.console import Console
 
-from ...listen import Mailbox, provider
+from ...backend import backend_url
+from ...listen import Mailbox, ProviderPolicyError, provider
 
 console = Console()
 errors = Console(stderr=True)
@@ -127,6 +128,10 @@ def handle_send(name: str, chat: str, text: Optional[str] = None, reply_to: Opti
     body = _text_from(text)
     try:
         sent = p.send(chat, body, reply_to=reply_to)
+    except ProviderPolicyError as exc:
+        mailbox.record_sent(chat=chat, text=body, reply_to=reply_to, error=str(exc))
+        errors.print(str(exc), style="red")
+        sys.exit(EXIT_CONFIG)
     except Exception as exc:
         mailbox.record_sent(chat=chat, text=body, reply_to=reply_to, error=str(exc))
         errors.print(str(exc), style="red")
@@ -149,6 +154,10 @@ def handle_reply(name: str, message_id: str, text: Optional[str] = None, again: 
     body = _text_from(text)
     try:
         sent = p.send(original.chat, body, reply_to=message_id)
+    except ProviderPolicyError as exc:
+        mailbox.record_sent(chat=original.chat, text=body, reply_to=message_id, error=str(exc))
+        errors.print(str(exc), style="red")
+        sys.exit(EXIT_CONFIG)
     except Exception as exc:
         mailbox.record_sent(chat=original.chat, text=body, reply_to=message_id, error=str(exc))
         errors.print(str(exc), style="red")
@@ -170,6 +179,28 @@ def handle_check(name: str) -> None:
     pid = mailbox.listener_pid()
     listener = f"listener pid {pid}" if pid else "no listener running (receive starts one)"
     console.print(f"[green]✓[/green] {name} reachable · {listener} · {len(mailbox.unread())} unread · {mailbox.root}")
+
+
+def handle_bind(name: str) -> None:
+    """Register provider webhook routing without placing secrets on argv."""
+    p = provider(name)
+    problems = p.bind_missing()
+    if problems:
+        for problem in problems:
+            errors.print(problem, style="red")
+        sys.exit(EXIT_CONFIG)
+    try:
+        result = p.bind()
+    except Exception as exc:
+        errors.print(str(exc), style="red")
+        sys.exit(1)
+    binding_id = result["id"]
+    print(binding_id)
+    errors.print(
+        f"set WHATSAPP_BINDING_ID={binding_id}; configure Meta's callback as "
+        f"{backend_url()}/api/v1/messaging/webhooks/whatsapp/{binding_id}",
+        style="dim",
+    )
 
 
 def handle_ls(name: str) -> None:

--- a/connectonion/cli/commands/status_commands.py
+++ b/connectonion/cli/commands/status_commands.py
@@ -41,6 +41,9 @@ CREDENTIAL_ENV_VARS = (
     ("MISTRAL_API_KEY", "Mistral"),
     ("TELEGRAM_BOT_TOKEN", "Telegram"),
     ("DISCORD_BOT_TOKEN", "Discord"),
+    ("WHATSAPP_ACCESS_TOKEN", "WhatsApp"),
+    ("WHATSAPP_APP_SECRET", "WhatsApp webhook"),
+    ("WHATSAPP_VERIFY_TOKEN", "WhatsApp verify"),
 )
 
 OAUTH_CONNECTIONS = (

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -158,6 +158,7 @@ def _show_help():
     console.print("  [green]telegram[/green]          Telegram bot as a mailbox: listen, receive, send, reply")
     console.print("  [green]feishu[/green]            Feishu bot as a mailbox: listen, receive, send, reply")
     console.print("  [green]discord[/green]           Discord bot as a mailbox: listen, receive, send, reply")
+    console.print("  [green]whatsapp[/green]          WhatsApp Cloud API as a mailbox: bind, listen, receive, send, reply")
     console.print("  [green]gdrive[/green]            List and transfer Google Drive files (co auth google)")
     console.print("  [green]syno[/green]              Browse and transfer Synology NAS files (co syno login)")
     console.print("  [green]outlook[/green]           Manage Outlook email and contacts (co auth microsoft)")
@@ -973,7 +974,7 @@ def telegram_send(
     handle_telegram_send(chat, message)
 
 
-# Mailbox providers: feishu, lark. One directory per provider under ~/.co/,
+# Mailbox providers. One directory per provider under ~/.co/,
 # the same eight verbs on each. The tool knows nothing about agents; anything
 # that can read a file consumes it (DD-063).
 def _mailbox_group(name: str, help_text: str, *, group=None, with_send: bool = True) -> typer.Typer:
@@ -1057,6 +1058,15 @@ def _mailbox_group(name: str, help_text: str, *, group=None, with_send: bool = T
 app.add_typer(_mailbox_group("feishu", "Feishu bot as a mailbox: listen, receive, send, reply."), name="feishu")
 app.add_typer(_mailbox_group("lark", "Lark (global Feishu) bot as a mailbox: listen, receive, send, reply."), name="lark")
 app.add_typer(_mailbox_group("discord", "Discord bot as a mailbox: listen, receive, send, reply."), name="discord")
+whatsapp_app = _mailbox_group("whatsapp", "WhatsApp Cloud API as a mailbox: listen, receive, send, reply.")
+app.add_typer(whatsapp_app, name="whatsapp")
+
+
+@whatsapp_app.command("bind")
+def whatsapp_bind():
+    """Register WABA webhook routing from environment variables."""
+    from .commands.listen_commands import handle_bind
+    handle_bind("whatsapp")
 # Telegram keeps the `send` it shipped with (its output is part of its contract)
 # and gains the other seven verbs on the same group, same token.
 _mailbox_group("telegram", "", group=telegram_app, with_send=False)

--- a/connectonion/listen/__init__.py
+++ b/connectonion/listen/__init__.py
@@ -10,6 +10,10 @@ LLM-Note:
 
 from .mailbox import Mailbox, Message
 
+
+class ProviderPolicyError(RuntimeError):
+    """A provider policy makes this send invalid without new user action."""
+
 # name → (module, class, constructor kwargs). Lark is Feishu with a different
 # domain and its own credentials, not a second implementation.
 PROVIDERS = {
@@ -17,6 +21,7 @@ PROVIDERS = {
     "lark": ("connectonion.listen.feishu", "Feishu", {"domain": "lark"}),
     "telegram": ("connectonion.listen.telegram", "Telegram", {}),
     "discord": ("connectonion.listen.discord", "Discord", {}),
+    "whatsapp": ("connectonion.listen.whatsapp", "WhatsApp", {}),
 }
 
 
@@ -32,4 +37,4 @@ def provider(name: str):
     return getattr(module, class_name)(**kwargs)
 
 
-__all__ = ["Mailbox", "Message", "provider", "PROVIDERS"]
+__all__ = ["Mailbox", "Message", "ProviderPolicyError", "provider", "PROVIDERS"]

--- a/connectonion/listen/whatsapp.py
+++ b/connectonion/listen/whatsapp.py
@@ -1,0 +1,255 @@
+"""WhatsApp Cloud API through O API ingress and direct Meta delivery."""
+
+import os
+import re
+import time
+from typing import Optional
+
+import requests
+
+from ..backend import backend_url
+from ..credentials import require_ambient_api_key
+from . import ProviderPolicyError
+from .mailbox import Mailbox, Message, iso_utc
+
+
+GRAPH = "https://graph.facebook.com"
+_VERSION = re.compile(r"^v[0-9]+\.[0-9]+$")
+SERVICE_WINDOW_ERROR = 131047
+
+
+class WhatsApp:
+    name = "whatsapp"
+
+    def __init__(self):
+        self.access_token = os.environ.get("WHATSAPP_ACCESS_TOKEN", "")
+        self.phone_number_id = os.environ.get("WHATSAPP_PHONE_NUMBER_ID", "")
+        self.binding_id = os.environ.get("WHATSAPP_BINDING_ID", "")
+        self.graph_version = os.environ.get("WHATSAPP_GRAPH_VERSION", "")
+
+    def missing(self) -> list[str]:
+        problems = []
+        if not os.environ.get("OPENONION_API_KEY"):
+            problems.append("OPENONION_API_KEY is not set. Run 'co auth'.")
+        if not self.binding_id:
+            problems.append(
+                "WHATSAPP_BINDING_ID is not set. Run 'co whatsapp bind' after "
+                "creating the Meta app."
+            )
+        if not self.access_token:
+            problems.append(
+                "WHATSAPP_ACCESS_TOKEN is not set. Store the user-owned Cloud "
+                "API token in ~/.co/keys.env."
+            )
+        if not self.phone_number_id:
+            problems.append("WHATSAPP_PHONE_NUMBER_ID is not set.")
+        if not _VERSION.fullmatch(self.graph_version):
+            problems.append(
+                "WHATSAPP_GRAPH_VERSION must be an explicit Meta version such "
+                "as v23.0; pin a supported version rather than relying on latest."
+            )
+        return problems
+
+    def bind_missing(self) -> list[str]:
+        required = {
+            "WHATSAPP_WABA_ID": os.environ.get("WHATSAPP_WABA_ID"),
+            "WHATSAPP_PHONE_NUMBER_ID": self.phone_number_id,
+            "WHATSAPP_APP_SECRET": os.environ.get("WHATSAPP_APP_SECRET"),
+            "WHATSAPP_VERIFY_TOKEN": os.environ.get("WHATSAPP_VERIFY_TOKEN"),
+            "OPENONION_API_KEY": os.environ.get("OPENONION_API_KEY"),
+        }
+        return [f"{name} is not set" for name, value in required.items() if not value]
+
+    def bind(self) -> dict:
+        token = require_ambient_api_key()
+        response = requests.put(
+            f"{backend_url()}/api/v1/messaging/bindings/whatsapp",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "waba_id": os.environ["WHATSAPP_WABA_ID"],
+                "phone_number_id": self.phone_number_id,
+                "app_secret": os.environ["WHATSAPP_APP_SECRET"],
+                "verify_token": os.environ["WHATSAPP_VERIFY_TOKEN"],
+            },
+            timeout=15,
+        )
+        return self._o_api_result(response)
+
+    def check(self) -> list[str]:
+        problems = self.missing()
+        if problems:
+            return problems
+        try:
+            token = require_ambient_api_key()
+            response = requests.get(
+                f"{backend_url()}/api/v1/messaging/bindings",
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=15,
+            )
+            bindings = self._o_api_result(response).get("bindings") or []
+            if not any(str(row.get("id")) == self.binding_id for row in bindings):
+                problems.append(
+                    "WHATSAPP_BINDING_ID is not owned by this OpenOnion account"
+                )
+            graph = requests.get(
+                f"{GRAPH}/{self.graph_version}/{self.phone_number_id}",
+                params={"fields": "id"},
+                headers={"Authorization": f"Bearer {self.access_token}"},
+                timeout=15,
+            )
+            self._meta_result(graph)
+        except Exception as exc:
+            problems.append(f"WhatsApp check failed: {exc}")
+        return problems
+
+    def run(self, mailbox: Mailbox, *, raw: bool = False) -> None:
+        delay = 1.0
+        while True:
+            try:
+                delivered = self._poll_once(mailbox)
+                delay = 1.0
+                if not delivered:
+                    time.sleep(2.0)
+            except Exception as exc:
+                mailbox.log(
+                    f"O API poll {type(exc).__name__}; retrying in {delay:.0f}s"
+                )
+                time.sleep(delay)
+                delay = min(delay * 2, 30.0)
+
+    def _poll_once(self, mailbox: Mailbox) -> int:
+        page = self._o_api(
+            "post",
+            "/api/v1/messaging/inbox/whatsapp/claim",
+            json={"limit": 20, "lease_seconds": 60},
+        )
+        events = page.get("events") or []
+        for event in events:
+            try:
+                message = self.to_message(event)
+                accepted = mailbox.deliver(message)
+            except Exception as exc:
+                self._nack(event, type(exc).__name__)
+                mailbox.log(
+                    f"delivery {event.get('delivery_id', 'unknown')} could not be stored"
+                )
+                continue
+            self._ack(event)
+            status = "received" if accepted else "duplicate"
+            mailbox.log(f"{status} {message.id} chat={message.chat} sender={message.sender}")
+        return len(events)
+
+    @staticmethod
+    def to_message(event: dict) -> Message:
+        required = ("id", "chat", "sender", "text", "delivery_id", "lease_token")
+        if any(not event.get(name) for name in required):
+            raise ValueError("O API returned an incomplete messaging event")
+        return Message(
+            id=str(event["id"]),
+            chat=str(event["chat"]),
+            thread=event.get("thread"),
+            sender=str(event["sender"]),
+            text=str(event["text"]),
+            mentioned=bool(event.get("mentioned", True)),
+            at=str(event.get("at") or iso_utc()),
+        )
+
+    def _ack(self, event: dict) -> None:
+        self._o_api(
+            "post",
+            f"/api/v1/messaging/inbox/{event['delivery_id']}/ack",
+            json={"lease_token": event["lease_token"]},
+        )
+
+    def _nack(self, event: dict, error: str) -> None:
+        self._o_api(
+            "post",
+            f"/api/v1/messaging/inbox/{event['delivery_id']}/nack",
+            json={
+                "lease_token": event["lease_token"],
+                "error": error,
+                "retry_after_seconds": 30,
+            },
+        )
+
+    def send(self, chat: str, text: str, *, reply_to: Optional[str] = None) -> str:
+        body = {
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": chat,
+            "type": "text",
+            "text": {"preview_url": False, "body": text},
+        }
+        if reply_to:
+            body["context"] = {"message_id": reply_to}
+        response = requests.post(
+            f"{GRAPH}/{self.graph_version}/{self.phone_number_id}/messages",
+            headers={"Authorization": f"Bearer {self.access_token}"},
+            json=body,
+            timeout=15,
+        )
+        result = self._meta_result(response)
+        messages = result.get("messages") or []
+        if not messages or not messages[0].get("id"):
+            raise RuntimeError("WhatsApp returned no message id")
+        return str(messages[0]["id"])
+
+    def _o_api(self, method: str, path: str, **kwargs) -> dict:
+        token = require_ambient_api_key()
+        response = getattr(requests, method)(
+            f"{backend_url()}{path}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=15,
+            **kwargs,
+        )
+        return self._o_api_result(response)
+
+    def _o_api_result(self, response) -> dict:
+        try:
+            result = response.json()
+        except ValueError:
+            raise RuntimeError(
+                f"O API returned HTTP {response.status_code} without JSON"
+            ) from None
+        if not 200 <= response.status_code < 300 or not isinstance(result, dict):
+            detail = result.get("detail") if isinstance(result, dict) else None
+            raise RuntimeError(
+                self._redact(f"O API refused: {detail or response.status_code}")
+            )
+        return result
+
+    def _meta_result(self, response) -> dict:
+        try:
+            result = response.json()
+        except ValueError:
+            raise RuntimeError(
+                f"WhatsApp returned HTTP {response.status_code} without JSON"
+            ) from None
+        error = result.get("error") if isinstance(result, dict) else None
+        if not 200 <= response.status_code < 300 or not isinstance(result, dict):
+            code = error.get("code") if isinstance(error, dict) else None
+            message = error.get("message") if isinstance(error, dict) else None
+            safe = self._redact(
+                f"WhatsApp refused ({code or response.status_code}): "
+                f"{message or 'request failed'}"
+            )
+            if code == SERVICE_WINDOW_ERROR:
+                raise ProviderPolicyError(
+                    safe
+                    + "; the 24-hour customer-service window is closed and a "
+                    "pre-approved template is required"
+                )
+            raise RuntimeError(safe)
+        return result
+
+    def _redact(self, value: str) -> str:
+        secrets = (
+            self.access_token,
+            os.environ.get("OPENONION_API_KEY", ""),
+            os.environ.get("WHATSAPP_APP_SECRET", ""),
+            os.environ.get("WHATSAPP_VERIFY_TOKEN", ""),
+        )
+        for secret in secrets:
+            if secret:
+                value = value.replace(secret, "[redacted]")
+        return value[:1000]

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -341,7 +341,8 @@ Worth saying out loud on any page that sells to a business:
 - `logger.load_messages()` has no callers, so "replay a past run" is a data format,
   not a feature. `co eval` is the real replay path.
 - `co feishu listen / receive / send / reply`, `co telegram listen / receive / reply`,
-  and `co discord listen / receive / send / reply`
+  `co discord listen / receive / send / reply`, and
+  `co whatsapp bind / listen / receive / send / reply`
   (`cli/commands/listen_commands.py`, `listen/`) are wired and unit-tested but have
   not passed a live acceptance run against a real group (#1310, #352). Until they
   have, they are a preview, not a claim.

--- a/docs/blog/2026-09-05-the-webhook-is-not-the-mailbox.md
+++ b/docs/blog/2026-09-05-the-webhook-is-not-the-mailbox.md
@@ -1,21 +1,38 @@
-# The webhook is not the mailbox
+# The request returned 200. The inbox was empty.
 
-A WhatsApp webhook says that Meta attempted delivery. It does not say the local
-agent stored the message. Treating those as the same event creates the worst kind
-of reliability bug: a successful HTTP response followed by an empty inbox.
+The first WhatsApp path had a comforting shape: verify Meta's signature, parse a
+message, hand it toward the client, and return success. Then we wrote the failure
+fixture. It let the webhook finish and made the local mailbox raise `OSError`, as
+if its disk were full.
 
-The 1.8.5 preview splits the boundary. O API verifies the raw-body signature,
-deduplicates the provider event, and holds a normalized delivery under a lease.
-The local listener claims it, writes the ordinary seven-field mailbox record, and
-only then acknowledges the remote delivery. A disk error produces a negative
-acknowledgement and a retry instead of a quiet loss.
+The HTTP request had already succeeded. Meta would not retry. The inbox was
+empty. Every component could log “success” while the user's message no longer
+existed anywhere we controlled.
 
-Outbound traffic takes the opposite route. The user's WhatsApp access token stays
-local and the CLI calls Meta directly. O API needs only the webhook app secret and
-verify token, encrypted at rest, because those are what let it authenticate public
-pushes. The division is intentionally asymmetric: every credential exists in the
-smallest trust boundary that can do its job.
+The fixture forced us to name two events that the first design had collapsed.
+Meta delivering a webhook is one event. The local agent durably storing a
+seven-field mailbox record is another. There can be minutes, a network failure,
+or a dead laptop between them.
 
-Fixtures cover signatures, ownership, deduplication, leases, retries, and the
-24-hour service-window error. A real WABA subscription is still a release gate,
-not something a unit test can honestly claim to have proved.
+So the webhook stopped trying to be the mailbox. O API now verifies the raw-body
+signature and WABA mapping, deduplicates the provider message id, and stores the
+normalized event. A local listener claims that event under a lease. In the test,
+the call order is visible: claim, local write, ACK. When the fake disk fails, the
+last call is NACK instead. If the process disappears entirely, the lease expires
+and makes the event claimable again.
+
+That repair created a credential question. Moving all WhatsApp traffic through O
+API would have solved routing neatly, but it would also have put the user's Cloud
+API access token in a service that does not need it. The final boundary is
+asymmetric on purpose: O API holds only the encrypted webhook app secret and a
+hash of the verify token; outbound replies go directly from the user's machine to
+Meta.
+
+The lesson from the empty-inbox fixture was simple: an accepted webhook is a
+receipt, not delivery. Delivery finishes only when the durable consumer says it
+does. That is why the ACK sits after the filesystem write, even though moving it
+one line earlier would make the happy path look cleaner.
+
+A real WABA subscription is still required before the preview label can be
+removed. The fixture proves what happens at a failed local write; it cannot prove
+Meta app review or account permissions.

--- a/docs/blog/2026-09-05-the-webhook-is-not-the-mailbox.md
+++ b/docs/blog/2026-09-05-the-webhook-is-not-the-mailbox.md
@@ -1,0 +1,21 @@
+# The webhook is not the mailbox
+
+A WhatsApp webhook says that Meta attempted delivery. It does not say the local
+agent stored the message. Treating those as the same event creates the worst kind
+of reliability bug: a successful HTTP response followed by an empty inbox.
+
+The 1.8.5 preview splits the boundary. O API verifies the raw-body signature,
+deduplicates the provider event, and holds a normalized delivery under a lease.
+The local listener claims it, writes the ordinary seven-field mailbox record, and
+only then acknowledges the remote delivery. A disk error produces a negative
+acknowledgement and a retry instead of a quiet loss.
+
+Outbound traffic takes the opposite route. The user's WhatsApp access token stays
+local and the CLI calls Meta directly. O API needs only the webhook app secret and
+verify token, encrypted at rest, because those are what let it authenticate public
+pushes. The division is intentionally asymmetric: every credential exists in the
+smallest trust boundary that can do its job.
+
+Fixtures cover signatures, ownership, deduplication, leases, retries, and the
+24-hour service-window error. A real WABA subscription is still a release gate,
+not something a unit test can honestly claim to have proved.

--- a/docs/cli/whatsapp.md
+++ b/docs/cli/whatsapp.md
@@ -1,0 +1,39 @@
+# WhatsApp mailbox (preview)
+
+`co whatsapp` uses Meta's WhatsApp Cloud API for outbound messages and the O API
+as a durable webhook inbox. The access token stays on the operator's machine. The
+app secret and verify token are sent once to the authenticated O API binding
+endpoint and encrypted at rest.
+
+Set these values in `~/.co/keys.env` (never pass them on the command line):
+
+```dotenv
+OPENONION_API_KEY=...
+WHATSAPP_WABA_ID=...
+WHATSAPP_PHONE_NUMBER_ID=...
+WHATSAPP_APP_SECRET=...
+WHATSAPP_VERIFY_TOKEN=...
+WHATSAPP_ACCESS_TOKEN=...
+WHATSAPP_GRAPH_VERSION=v23.0
+```
+
+Register the webhook routing, then save the returned binding id:
+
+```bash
+co whatsapp bind
+# add WHATSAPP_BINDING_ID=<printed-id> to ~/.co/keys.env
+co whatsapp check
+co whatsapp listen
+```
+
+Meta must be configured with the callback URL printed by `bind`, the same verify
+token, and the `messages` webhook field. The Graph API version is deliberately
+explicit so Meta version changes cannot silently alter delivery.
+
+Inbound events are claimed with a lease and ACKed only after the seven-field
+message has been durably stored in the local mailbox. A failed local write is
+NACKed for retry. Duplicate provider message ids are harmless. Replies are text
+only; outside Meta's 24-hour customer-service window the CLI exits with a clear
+template-required policy error. Live Meta acceptance remains an external release
+gate because fixtures cannot validate app review, WABA subscription, or account
+permissions.

--- a/tests/unit/test_listen_whatsapp.py
+++ b/tests/unit/test_listen_whatsapp.py
@@ -1,0 +1,149 @@
+"""WhatsApp O API ingress and Meta delivery boundaries."""
+
+import pytest
+
+from connectonion.listen import ProviderPolicyError
+from connectonion.listen.whatsapp import WhatsApp
+
+
+EVENT = {
+    "delivery_id": "a28b5479-67dc-4f03-a7a2-c3b7af73b8b2",
+    "lease_token": "403ddf37-09b1-4cf7-81fa-bbfa1545effe",
+    "id": "wamid.HBgLMTE",
+    "chat": "61400000000",
+    "thread": None,
+    "sender": "61400000000",
+    "text": "hello from WhatsApp",
+    "mentioned": True,
+    "at": "2026-09-05T05:00:00Z",
+}
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    values = {
+        "OPENONION_API_KEY": "oo-secret",
+        "WHATSAPP_ACCESS_TOKEN": "meta-secret",
+        "WHATSAPP_PHONE_NUMBER_ID": "100200300",
+        "WHATSAPP_BINDING_ID": "binding-id",
+        "WHATSAPP_GRAPH_VERSION": "v23.0",
+        "WHATSAPP_WABA_ID": "waba-id",
+        "WHATSAPP_APP_SECRET": "app-secret",
+        "WHATSAPP_VERIFY_TOKEN": "verify-secret",
+    }
+    for name, value in values.items():
+        monkeypatch.setenv(name, value)
+    return WhatsApp()
+
+
+def test_event_normalizes_to_the_shared_seven_fields(adapter):
+    assert adapter.to_message(EVENT).to_dict() == {
+        "id": "wamid.HBgLMTE",
+        "chat": "61400000000",
+        "thread": None,
+        "sender": "61400000000",
+        "text": "hello from WhatsApp",
+        "mentioned": True,
+        "at": "2026-09-05T05:00:00Z",
+    }
+
+
+def test_claim_is_written_locally_before_ack(adapter, monkeypatch):
+    actions = []
+
+    def api(method, path, **kwargs):
+        actions.append(path)
+        return {"events": [EVENT]} if path.endswith("/claim") else {"state": "acked"}
+
+    monkeypatch.setattr(adapter, "_o_api", api)
+    mailbox = FakeMailbox(actions)
+
+    assert adapter._poll_once(mailbox) == 1
+    assert actions == [
+        "/api/v1/messaging/inbox/whatsapp/claim",
+        "deliver",
+        f"/api/v1/messaging/inbox/{EVENT['delivery_id']}/ack",
+    ]
+
+
+def test_failed_local_write_nacks_instead_of_acking(adapter, monkeypatch):
+    paths = []
+
+    def api(method, path, **kwargs):
+        paths.append((path, kwargs.get("json")))
+        return {"events": [EVENT]} if path.endswith("/claim") else {"state": "pending"}
+
+    monkeypatch.setattr(adapter, "_o_api", api)
+    adapter._poll_once(FakeMailbox([], failure=OSError("disk full")))
+
+    assert paths[-1][0].endswith("/nack")
+    assert paths[-1][1]["error"] == "OSError"
+    assert not any(path.endswith("/ack") for path, _ in paths)
+
+
+def test_send_uses_pinned_graph_version_and_context(adapter, monkeypatch):
+    posted = []
+    monkeypatch.setattr(
+        "connectonion.listen.whatsapp.requests.post",
+        lambda url, **kwargs: posted.append((url, kwargs))
+        or Response(200, {"messages": [{"id": "wamid.sent"}]}),
+    )
+
+    assert adapter.send("61400000000", "hello", reply_to="wamid.original") == "wamid.sent"
+    assert posted[0][0] == "https://graph.facebook.com/v23.0/100200300/messages"
+    assert posted[0][1]["json"]["context"] == {"message_id": "wamid.original"}
+    assert "meta-secret" not in posted[0][0]
+
+
+def test_closed_service_window_is_an_explicit_redacted_policy_error(adapter):
+    response = Response(
+        400,
+        {"error": {"code": 131047, "message": "meta-secret outside window"}},
+    )
+
+    with pytest.raises(ProviderPolicyError, match="pre-approved template") as error:
+        adapter._meta_result(response)
+    assert "meta-secret" not in str(error.value)
+    assert "[redacted]" in str(error.value)
+
+
+def test_bind_sends_secrets_only_in_authenticated_request_body(adapter, monkeypatch):
+    requests = []
+    monkeypatch.setattr(
+        "connectonion.listen.whatsapp.require_ambient_api_key",
+        lambda: "oo-secret",
+    )
+    monkeypatch.setattr(
+        "connectonion.listen.whatsapp.requests.put",
+        lambda url, **kwargs: requests.append((url, kwargs))
+        or Response(200, {"id": "binding-id"}),
+    )
+
+    assert adapter.bind() == {"id": "binding-id"}
+    assert requests[0][1]["json"]["app_secret"] == "app-secret"
+    assert requests[0][1]["headers"] == {"Authorization": "Bearer oo-secret"}
+
+
+class FakeMailbox:
+    def __init__(self, actions, failure=None):
+        self.actions = actions
+        self.failure = failure
+        self.logs = []
+
+    def deliver(self, message):
+        self.actions.append("deliver")
+        if self.failure:
+            raise self.failure
+        return True
+
+    def log(self, line):
+        self.logs.append(line)
+
+
+class Response:
+    def __init__(self, status, payload):
+        self.status_code = status
+        self.payload = payload
+
+    def json(self):
+        return self.payload


### PR DESCRIPTION
## Current release decision — 2026-09-15

Target approximately **1.8.8**, tentative, under #1463. Removed from 1.8.6; the replacement 1.8.6 plan is #1555. WhatsApp existing-group access #1543 is a separate 1.8.6 workstream. This supersedes earlier release dates below.

---

**Proposed target version:** After 1.8.5 (exact version unassigned)
**Estimated release window:** After 1.8.5, once dependencies and live provider acceptance are complete
**Forward-port tracking issue (stable patches only):** #1411

## Problem

WhatsApp/O API support in #349 needs a client adapter that preserves local credential ownership while making webhook delivery durable.

Closes #349. Part of #1411. Depends on openonion/oo-api#227 and is stacked on #1433.

## Approach

- add co whatsapp bind without putting app secret or verify token on argv
- poll the authenticated O API inbox using claim leases
- ACK only after the ordinary seven-field message is stored locally; NACK failed local writes
- send and reply directly through an explicitly pinned Meta Graph API version
- turn Meta error 131047 into a clear template-required policy error
- keep the access token local and redact access/app/verify secrets from keys, status, doctor, and provider errors
- add CLI docs, preview caveats, design journal, and fixture tests

## Verification

- python -m pytest tests/unit/test_listen_whatsapp.py tests/unit/test_listen_discord.py tests/unit/test_listen_telegram.py tests/unit/test_listen_feishu.py tests/unit/test_listen_mailbox.py tests/unit/test_listen_commands.py tests/e2e/cli/test_cli_help.py tests/e2e/cli/test_cli_keys.py tests/e2e/cli/test_cli_status.py tests/e2e/cli/test_cli_doctor.py tests/unit/test_doctor_credentials_are_redacted.py -q
  - 189 passed
- python -m compileall -q connectonion/listen connectonion/cli/commands/listen_commands.py
- git diff --check

## External release gates

- merge and deploy openonion/oo-api#227 with MESSAGING_CREDENTIAL_KEY and its migration
- register/configure a real Meta app and WABA webhook subscription
- exercise challenge, signed inbound delivery, duplicate delivery, local ACK/NACK, direct reply, and the 24-hour window
- no external app registration, credentials, real messages, or deployment were performed by this PR

## Release scheduling update — 2026-09-05

All new messaging adapters are deferred until **after 1.8.5**. They are excluded from 1.8.2, 1.8.3, 1.8.4, and 1.8.5. The exact later version is not assigned yet. This supersedes earlier release estimates below; existing functionality is unaffected. Provider acceptance and dependency gates still apply. Coordination: #1389 and #1411.


