### PR TITLE
feat(cli): stage Gmail drafts and improve Gmail/Drive recovery

### DIFF
--- a/connectonion/cli/commands/gdrive_commands.py
+++ b/connectonion/cli/commands/gdrive_commands.py
@@ -5,7 +5,7 @@ LLM-Note:
   Data flow: _gdrive() loads GOOGLE_* from .env / ~/.co/keys.env and checks the drive scope → GDrive() instance | list/search: list_files()/search_files() → numbered Rich table (tab-separated with full ids when piped) → saves {#: file_id} to ~/.co/gdrive_last_list.json | get/rm: resolve short numbers via that cache → download()/delete()
   State/Effects: writes ~/.co/gdrive_last_list.json (last listing's # → file id map; "numbers mean your last listing") | downloads write local files | put uploads to Drive | rm trashes (recoverable) rather than deleting
   Integration: exposes handle_gdrive_list(), handle_gdrive_search(), handle_gdrive_get(), handle_gdrive_put(), handle_gdrive_rm() for cli/main.py | presentation mirrors gmail_commands.py / outlook_commands.py | Drive logic lives in useful_tools/gdrive.py | requires prior 'co auth google'
-  Errors: guarded failures print a hint and exit 1 (typer.Exit) — missing auth/drive scope, unresolvable file #, missing upload path | Drive API errors propagate from the GDrive tool
+  Errors: guarded failures print a next command and exit 1 (typer.Exit); google_errors sanitizes provider/transport failures | empty list/search clears old numbers; piped rows append their row number as column five
 """
 
 import json
@@ -15,6 +15,7 @@ from pathlib import Path
 import typer
 from rich.console import Console
 from rich.table import Table
+from .google_errors import google_errors
 
 console = Console()
 
@@ -91,11 +92,11 @@ def _print_listing(files: list, title: str):
         # Scripts and agents get full file ids, never a truncated column.
         # Plain print, not console.print: Rich expands \t into spaces, which
         # silently turns tab-separated output into something cut -f can't read.
-        for item in files:
-            print(f"{item['name']}\t{item['type']}\t{item['size']}\t{item['id']}")
+        for i, item in enumerate(files, 1):
+            print(f"{item['name']}\t{item['type']}\t{item['size']}\t{item['id']}\t{i}")
         # Same next-step tip as the terminal table: piped callers are exactly
         # the AI audience the tip exists for.
-        print("Download one with: co gdrive get <#>")
+        print("Download one with: co gdrive get <# from column 5>")
         return
 
     table = Table(title=title, show_header=True, header_style="bold cyan")
@@ -113,23 +114,31 @@ def _print_listing(files: list, title: str):
     console.print("\n[dim]Download one with:[/dim] [bold]co gdrive get <#>[/bold]\n")
 
 
+@google_errors("co gdrive list")
 def handle_gdrive_list(last: int = 20):
     """List recently modified Drive files as a numbered table."""
     drive = _gdrive()
     files = drive.list_files(last=last)
     if not files:
+        LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        LIST_CACHE.write_text("{}", encoding="utf-8")
         console.print("\n[cyan]Google Drive:[/cyan] no files\n")
+        print("Search by name: co gdrive search <name prefix>")
         return
     _print_listing(files, f"📁 Drive — {os.getenv('GOOGLE_EMAIL', '')}")
 
 
+@google_errors("co gdrive list")
 def handle_gdrive_search(query: str, last: int = 20):
     """Search Drive by file name, numbered like the listing."""
     drive = _gdrive()
     files = drive.search_files(query, last=last)
     if not files:
+        LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        LIST_CACHE.write_text("{}", encoding="utf-8")
         console.print(f"\n[cyan]Drive search:[/cyan] no files matching [bold]{query}[/bold]")
         console.print("[dim]Drive matches word prefixes, not any substring.[/dim]\n")
+        print("Show recent files: co gdrive list")
         return
     _print_listing(files, f"🔎 Drive — {query}")
 
@@ -147,22 +156,26 @@ def _resolve_file_id(file_id: str) -> str:
     return file_id
 
 
+@google_errors("co gdrive list")
 def handle_gdrive_get(file_id: str, dest: str = "."):
     """Download a Drive file. Accepts the listing # or a full file id."""
     drive = _gdrive()
     resolved = _resolve_file_id(file_id)
     if not resolved:
-        console.print(f"\n[yellow]No file #{file_id} in your last listing — run co gdrive, then co gdrive get <#>.[/yellow]\n")
+        console.print(f"\nNo file #{file_id} in your last listing.", markup=False)
+        print("Refresh the listing: co gdrive list")
         raise typer.Exit(1)
 
     console.print(drive.download(resolved, dest=dest).replace("Downloaded to", "\n[green]✓ Downloaded[/green]"))
-    console.print()
+    print("Show more files: co gdrive list")
 
 
+@google_errors("co gdrive list")
 def handle_gdrive_put(path: str, name: str = None):
     """Upload a local file to Drive."""
     if not Path(path).expanduser().is_file():
         console.print(f"\n❌ [bold red]File not found:[/bold red] {path}\n")
+        print("Retry with: co gdrive put <path to an existing file>")
         raise typer.Exit(1)
 
     drive = _gdrive()
@@ -170,16 +183,19 @@ def handle_gdrive_put(path: str, name: str = None):
     console.print(f"\n[green]✓ Uploaded[/green] [bold]{uploaded['name']}[/bold]")
     if uploaded["link"]:
         console.print(f"  {uploaded['link']}")
-    console.print()
+    print("Check uploaded files: co gdrive list")
 
 
+@google_errors("co gdrive list")
 def handle_gdrive_rm(file_id: str):
     """Move a Drive file to the trash. Accepts the listing # or a full file id."""
     drive = _gdrive()
     resolved = _resolve_file_id(file_id)
     if not resolved:
-        console.print(f"\n[yellow]No file #{file_id} in your last listing — run co gdrive, then co gdrive rm <#>.[/yellow]\n")
+        console.print(f"\nNo file #{file_id} in your last listing.", markup=False)
+        print("Refresh the listing: co gdrive list")
         raise typer.Exit(1)
 
     drive.delete(resolved)
     console.print("\n[green]✓ Moved to trash[/green] — restore it from drive.google.com if that was wrong\n")
+    print("Show remaining files: co gdrive list")

--- a/connectonion/cli/commands/gmail_commands.py
+++ b/connectonion/cli/commands/gmail_commands.py
@@ -5,7 +5,7 @@ LLM-Note:
   Data flow: _gmail() loads GOOGLE_* from .env / ~/.co/keys.env → Gmail() instance | inbox/search: list_inbox()/list_search() → numbered Rich table (plain ID-bearing text when piped) → saves {#: message_id} to ~/.co/gmail_last_inbox.json | draft list → ~/.co/gmail_last_drafts.json | draft edits parse and replace Gmail's raw MIME message | Drive attachment reads reuse GDrive without writing local files
   State/Effects: writes Gmail inbox/draft numbering caches under ~/.co | draft commands create/update Gmail drafts, but only draft send can deliver and it always asks for confirmation | read changes mailbox state only with --mark-read | Gmail refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
   Integration: exposes inbox/read/reply/send/sent/search plus draft list/create/attach/remove/replace/preview/send handlers for cli/main.py | presentation mirrors outlook_commands.py | Gmail/Drive API logic lives in useful_tools | requires prior 'co auth google'
-  Errors: every guarded draft failure prints a provider-safe hint and exits 1 (typer.Exit) so scripts can detect it — missing auth/scopes, unresolvable email/draft/file #, missing or oversized attachments | older direct Gmail commands retain their existing API-error behavior
+  Errors: guarded failures exit 1 with a next command; provider and transport errors are sanitized by google_errors | send/reply connection failures point to sent-mail inspection because delivery may have completed
 """
 
 import json
@@ -17,6 +17,7 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+from .google_errors import google_errors
 
 console = Console()
 
@@ -106,13 +107,17 @@ def _print_listing(gmail, emails: list, title: str):
     console.print("\n[dim]Read one with:[/dim] [bold]co gmail read <#>[/bold]\n")
 
 
+@google_errors("co gmail inbox")
 def handle_gmail_inbox(last: int = 10, unread: bool = False):
     """List recent Gmail inbox emails as a numbered table, and remember the numbering for 'read'."""
     gmail = _gmail()
     emails = gmail.list_inbox(last=last, unread=unread)
     if not emails:
+        INBOX_CACHE.parent.mkdir(exist_ok=True)
+        INBOX_CACHE.write_text("{}", encoding="utf-8")
         scope = "unread " if unread else ""
         console.print(f"\n[cyan]Gmail inbox:[/cyan] no {scope}emails\n")
+        print("Search mail: co gmail search <query>")
         return
     _print_listing(gmail, emails, f"📬 Gmail — {os.getenv('GOOGLE_EMAIL', '')}")
 
@@ -126,7 +131,7 @@ def _resolve_email_id(gmail, email_id: str) -> str:
     if not (email_id.isascii() and email_id.isdigit() and len(email_id) < 5):
         return email_id  # full Gmail message id
 
-    if cached or int(email_id) < 1:
+    if INBOX_CACHE.exists() or int(email_id) < 1:
         # The user is pointing at their last listing and that number wasn't in
         # it — fetching a fresh (differently numbered) list would silently open
         # the wrong email.
@@ -138,12 +143,14 @@ def _resolve_email_id(gmail, email_id: str) -> str:
     return emails[int(email_id) - 1]["id"]
 
 
+@google_errors("co gmail inbox")
 def handle_gmail_read(email_id: str, mark_read: bool = False):
     """Show one Gmail message; mark it read only with explicit opt-in."""
     gmail = _gmail()
     resolved = _resolve_email_id(gmail, email_id)
     if not resolved:
-        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co gmail, then co gmail read <#>.[/yellow]\n")
+        console.print(f"\nNo email #{email_id} in your last listing.", markup=False)
+        print("Refresh the listing: co gmail inbox")
         raise typer.Exit(1)
 
     body = gmail.get_email_body(resolved)
@@ -164,10 +171,12 @@ def handle_gmail_read(email_id: str, mark_read: bool = False):
         gmail.mark_read(resolved)
         marked = "Marked read. "
     elif mark_read:
-        marked = "Not marked read: run co auth google to grant gmail.modify. "
-    console.print(f"\n[dim]{marked}Reply with:[/dim] [bold]co gmail reply <#> <message>[/bold]\n")
+        print("Not marked read: gmail.modify permission missing.\nNext: co auth google")
+        return
+    print(f"\n{marked}Reply with: co gmail reply {resolved} <message>")
 
 
+@google_errors("co gmail sent")
 def handle_gmail_reply(email_id: str, message: str):
     """Reply to an email from the last listing (threaded). A message of '-' reads stdin."""
     if message == "-":
@@ -176,11 +185,13 @@ def handle_gmail_reply(email_id: str, message: str):
     gmail = _gmail()
     resolved = _resolve_email_id(gmail, email_id)
     if not resolved:
-        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co gmail, then co gmail reply <#> <message>.[/yellow]\n")
+        console.print(f"\nNo email #{email_id} in your last listing.", markup=False)
+        print("Refresh the listing: co gmail inbox")
         raise typer.Exit(1)
 
     gmail.reply(resolved, message)
     console.print(f"\n[green]✓ Replied[/green] to email {email_id}\n")
+    print("Check sent mail: co gmail sent")
 
 
 def _check_attachments(attachments: list):
@@ -198,12 +209,15 @@ def _check_attachments(attachments: list):
     for given, path in zip(attachments, paths):
         if not path.is_file():
             console.print(f"\n❌ [bold red]Attachment not found:[/bold red] {given}\n")
+            print("Check attachment syntax: co gmail send --help")
             raise typer.Exit(1)
     if sum(p.stat().st_size for p in paths) > GMAIL_ATTACHMENT_LIMIT:
         console.print("\n❌ [bold red]Attachments exceed Gmail's 25MB send limit.[/bold red]\n")
+        print("Prepare a Drive link instead: co gmail draft create <to> <subject> <message>")
         raise typer.Exit(1)
 
 
+@google_errors("co gmail sent")
 def handle_gmail_send(to: str, subject: str, message: str, cc: str = None,
                       bcc: str = None, attachments: list = None):
     """Send an email from the connected Gmail account. A message of '-' reads the body from stdin."""
@@ -218,23 +232,28 @@ def handle_gmail_send(to: str, subject: str, message: str, cc: str = None,
 
     console.print(f"\n[green]✓ Sent[/green] to [cyan]{to}[/cyan]")
     console.print(f"  From: {os.getenv('GOOGLE_EMAIL', '')}")
-    console.print()
+    print("Check sent mail: co gmail sent")
 
 
+@google_errors("co gmail sent")
 def handle_gmail_sent(last: int = 10):
     """List recently sent Gmail emails."""
     gmail = _gmail()
     console.print(f"\n📤 [bold cyan]Gmail sent[/bold cyan] [dim]({os.getenv('GOOGLE_EMAIL', '')})[/dim]\n")
     console.print(gmail.get_sent_emails(max_results=last), markup=False, highlight=False)
-    console.print()
+    print("Find sent messages to read: co gmail search in:sent")
 
 
+@google_errors("co gmail inbox")
 def handle_gmail_search(query: str, last: int = 10):
     """Search Gmail and list matches with the same numbering contract as the inbox."""
     gmail = _gmail()
     emails = gmail.list_search(query, max_results=last)
     if not emails:
+        INBOX_CACHE.parent.mkdir(exist_ok=True)
+        INBOX_CACHE.write_text("{}", encoding="utf-8")
         console.print(f"\n[cyan]Search:[/cyan] no emails matching [bold]{query}[/bold]\n")
+        print("Show recent mail: co gmail inbox")
         return
     _print_listing(gmail, emails, f"🔎 Gmail — {query}")
 
@@ -343,6 +362,7 @@ def _draft_id_or_exit(draft_id: str) -> str:
     return resolved
 
 
+@google_errors("co gmail draft list")
 def handle_gmail_draft_list(last: int = 20):
     gmail = _gmail()
     drafts = _draft_call(lambda: gmail.list_drafts(last=last), "co gmail draft list")
@@ -355,6 +375,7 @@ def handle_gmail_draft_list(last: int = 20):
     _print_draft_list(drafts)
 
 
+@google_errors("co gmail draft list")
 def handle_gmail_draft_create(to: str, subject: str, message: str, cc: str = None,
                               bcc: str = None):
     if message == "-":
@@ -368,6 +389,7 @@ def handle_gmail_draft_create(to: str, subject: str, message: str, cc: str = Non
     console.print(f"Attach a local file: [bold]co gmail draft attach {draft['id']} <path>[/bold]\n")
 
 
+@google_errors("co gmail draft list")
 def handle_gmail_draft_attach(draft_id: str, source: str, drive: bool = False,
                               link: bool = False):
     if link and not drive:
@@ -421,6 +443,7 @@ def handle_gmail_draft_attach(draft_id: str, source: str, drive: bool = False,
     console.print(f"Preview it: [bold]co gmail draft preview {updated['id']}[/bold]\n")
 
 
+@google_errors("co gmail draft list")
 def handle_gmail_draft_remove(draft_id: str, attachment: int):
     gmail = _gmail(require_draft_write=True)
     resolved = _draft_id_or_exit(draft_id)
@@ -432,6 +455,7 @@ def handle_gmail_draft_remove(draft_id: str, attachment: int):
     console.print(f"Preview it: [bold]co gmail draft preview {updated['id']}[/bold]\n")
 
 
+@google_errors("co gmail draft list")
 def handle_gmail_draft_replace(draft_id: str, attachment: int, source: str,
                                drive: bool = False):
     gmail = _gmail(require_draft_write=True)
@@ -464,6 +488,7 @@ def handle_gmail_draft_replace(draft_id: str, attachment: int, source: str,
     console.print(f"Preview it: [bold]co gmail draft preview {updated['id']}[/bold]\n")
 
 
+@google_errors("co gmail draft list")
 def handle_gmail_draft_preview(draft_id: str):
     gmail = _gmail()
     resolved = _draft_id_or_exit(draft_id)
@@ -471,6 +496,7 @@ def handle_gmail_draft_preview(draft_id: str):
     _print_draft_preview(draft)
 
 
+@google_errors("co gmail sent")
 def handle_gmail_draft_send(draft_id: str):
     gmail = _gmail(require_draft_write=True)
     resolved = _draft_id_or_exit(draft_id)

--- a/connectonion/cli/commands/gmail_commands.py
+++ b/connectonion/cli/commands/gmail_commands.py
@@ -2,10 +2,10 @@
 Purpose: CLI surface for the user's Gmail mailbox — send, list (inbox/sent), read, reply, and search from the terminal
 LLM-Note:
   Dependencies: imports from [os, sys, json, pathlib, typer, dotenv, rich.console, rich.panel, rich.table, ...useful_tools.gmail.Gmail] | imported by [cli/main.py via handle_gmail_*()] | hits the Gmail API through the Gmail tool
-  Data flow: _gmail() loads GOOGLE_* from .env / ~/.co/keys.env → Gmail() instance | inbox/search: list_inbox()/list_search() → numbered Rich table (plain ID-bearing text when piped) → saves {#: message_id} to ~/.co/gmail_last_inbox.json | read/reply: resolve short numbers via that cache → get_email_body()/reply() | send: '-' body reads stdin
-  State/Effects: writes ~/.co/gmail_last_inbox.json (last listing's # → message id map; "numbers mean your last listing" — only inbox and search write it) | read changes mailbox state only with --mark-read | Gmail refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
-  Integration: exposes handle_gmail_send(), handle_gmail_inbox(), handle_gmail_read(), handle_gmail_reply(), handle_gmail_sent(), handle_gmail_search() for cli/main.py | presentation mirrors outlook_commands.py (table shape, ● unread mark, ✉️ panel, '✓ Sent' wording) | Gmail API logic lives in useful_tools/gmail.py | requires prior 'co auth google'
-  Errors: every guarded failure prints a hint and exits 1 (typer.Exit) so scripts can detect it — missing auth/scopes, unresolvable email # | Gmail API errors propagate from the Gmail tool
+  Data flow: _gmail() loads GOOGLE_* from .env / ~/.co/keys.env → Gmail() instance | inbox/search: list_inbox()/list_search() → numbered Rich table (plain ID-bearing text when piped) → saves {#: message_id} to ~/.co/gmail_last_inbox.json | draft list → ~/.co/gmail_last_drafts.json | draft edits parse and replace Gmail's raw MIME message | Drive attachment reads reuse GDrive without writing local files
+  State/Effects: writes Gmail inbox/draft numbering caches under ~/.co | draft commands create/update Gmail drafts, but only draft send can deliver and it always asks for confirmation | read changes mailbox state only with --mark-read | Gmail refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
+  Integration: exposes inbox/read/reply/send/sent/search plus draft list/create/attach/remove/replace/preview/send handlers for cli/main.py | presentation mirrors outlook_commands.py | Gmail/Drive API logic lives in useful_tools | requires prior 'co auth google'
+  Errors: every guarded draft failure prints a provider-safe hint and exits 1 (typer.Exit) so scripts can detect it — missing auth/scopes, unresolvable email/draft/file #, missing or oversized attachments | older direct Gmail commands retain their existing API-error behavior
 """
 
 import json
@@ -21,9 +21,10 @@ from rich.table import Table
 console = Console()
 
 INBOX_CACHE = Path.home() / ".co" / "gmail_last_inbox.json"
+DRAFT_CACHE = Path.home() / ".co" / "gmail_last_drafts.json"
 
 
-def _gmail():
+def _gmail(require_draft_write: bool = False):
     """Load GOOGLE_* credentials from .env files and return a Gmail instance. Exits 1 with a hint if not connected."""
     from dotenv import load_dotenv
     from ...project import project_root
@@ -45,6 +46,14 @@ def _gmail():
         console.print("\n❌ [bold red]Gmail permission missing[/bold red]")
         console.print("\n[cyan]Reconnect Google to grant it:[/cyan]")
         console.print("  [bold]co auth google[/bold]     Re-authorize with Gmail access\n")
+        raise typer.Exit(1)
+
+    if require_draft_write and not any(
+        scope in scopes for scope in ("gmail.modify", "gmail.compose", "mail.google.com")
+    ):
+        console.print("\n❌ [bold red]Gmail draft permission missing[/bold red]")
+        console.print("\n[cyan]Reconnect Google to grant it:[/cyan]")
+        console.print("  [bold]co auth google[/bold]     Re-authorize with Gmail draft access\n")
         raise typer.Exit(1)
 
     from ...useful_tools.gmail import Gmail
@@ -228,3 +237,247 @@ def handle_gmail_search(query: str, last: int = 10):
         console.print(f"\n[cyan]Search:[/cyan] no emails matching [bold]{query}[/bold]\n")
         return
     _print_listing(gmail, emails, f"🔎 Gmail — {query}")
+
+
+# === Draft attachment workflow ===
+
+def _resolve_draft_id(draft_id: str) -> str:
+    """Turn a draft-list number into an immutable Gmail draft id."""
+    cached = json.loads(DRAFT_CACHE.read_text(encoding="utf-8")) if DRAFT_CACHE.exists() else {}
+    if draft_id in cached:
+        return cached[draft_id]
+    if draft_id.isascii() and draft_id.isdigit() and len(draft_id) < 5:
+        return ""
+    return draft_id
+
+
+def _draft_call(action, retry_command: str):
+    """Run one draft API operation and turn provider failures into fix-it output."""
+    from googleapiclient.errors import HttpError
+
+    try:
+        return action()
+    except HttpError as exc:
+        status = getattr(exc.resp, "status", None)
+        if status in (401, 403):
+            cause = "Google rejected the Gmail/Drive permission."
+            retry_command = "co auth google"
+        elif status == 404:
+            cause = "Gmail draft or Drive file was not found."
+            retry_command = "co gmail draft list"
+        else:
+            suffix = f" (HTTP {status})" if status else ""
+            cause = f"Google could not complete the draft request{suffix}."
+        console.print(f"\n❌ {cause}", markup=False, highlight=False)
+        console.print(f"Retry with: {retry_command}\n", markup=False, highlight=False)
+        raise typer.Exit(1) from None
+    except (FileNotFoundError, PermissionError, ValueError) as exc:
+        # These messages are generated locally by the bounded attachment and
+        # OAuth checks. Provider response bodies (which can carry secrets) are
+        # never printed.
+        console.print(f"\n❌ {exc}", markup=False, highlight=False)
+        console.print(f"Retry with: {retry_command}\n", markup=False, highlight=False)
+        raise typer.Exit(1) from None
+
+
+def _print_draft_list(drafts: list) -> None:
+    DRAFT_CACHE.parent.mkdir(exist_ok=True)
+    DRAFT_CACHE.write_text(
+        json.dumps({str(i): draft["id"] for i, draft in enumerate(drafts, 1)}),
+        encoding="utf-8",
+    )
+    if not console.is_terminal:
+        for i, draft in enumerate(drafts, 1):
+            print(
+                f"{i}.\t{draft['to']}\t{draft['subject']}\t"
+                f"{draft['attachments']}\t{draft['id']}"
+            )
+        print("Preview one with: co gmail draft preview <# from this listing>")
+        return
+
+    table = Table(title=f"📝 Gmail drafts — {os.getenv('GOOGLE_EMAIL', '')}")
+    table.add_column("#", justify="right")
+    table.add_column("To", max_width=30, no_wrap=True)
+    table.add_column("Subject", overflow="ellipsis", no_wrap=True)
+    table.add_column("Files", justify="right")
+    for i, draft in enumerate(drafts, 1):
+        table.add_row(str(i), draft["to"] or "-", draft["subject"] or "(no subject)",
+                      str(draft["attachments"]))
+    console.print()
+    console.print(table)
+    console.print("\nPreview one with: [bold]co gmail draft preview <# from this listing>[/bold]\n")
+
+
+def _print_draft_preview(draft: dict, tip: bool = True) -> None:
+    console.print()
+    console.print(f"Draft: {draft['id']}", markup=False, highlight=False)
+    console.print(f"To: {draft['to'] or '-'}", markup=False, highlight=False)
+    if draft.get("cc"):
+        console.print(f"Cc: {draft['cc']}", markup=False, highlight=False)
+    if draft.get("bcc"):
+        console.print(f"Bcc: {draft['bcc']}", markup=False, highlight=False)
+    console.print(f"Subject: {draft['subject'] or '(no subject)'}", markup=False, highlight=False)
+    console.print("\n--- Body ---", markup=False)
+    console.print(draft["body"] or "(empty body)", markup=False, highlight=False)
+    console.print("\n--- Attachments ---", markup=False)
+    if draft["attachments"]:
+        for i, item in enumerate(draft["attachments"], 1):
+            console.print(
+                f"{i}. {item['name']} ({item['type']}, {item['size']} bytes)",
+                markup=False,
+                highlight=False,
+            )
+        console.print(f"Total: {draft['attachment_size']} bytes", markup=False)
+    else:
+        console.print("(none)", markup=False)
+    if tip:
+        console.print(f"\nSend with confirmation: [bold]co gmail draft send {draft['id']}[/bold]\n")
+
+
+def _draft_id_or_exit(draft_id: str) -> str:
+    resolved = _resolve_draft_id(draft_id)
+    if not resolved:
+        console.print(f"\n❌ [bold red]No draft #{draft_id} in your last listing.[/bold red]")
+        console.print("List drafts: [bold]co gmail draft list[/bold]\n")
+        raise typer.Exit(1)
+    return resolved
+
+
+def handle_gmail_draft_list(last: int = 20):
+    gmail = _gmail()
+    drafts = _draft_call(lambda: gmail.list_drafts(last=last), "co gmail draft list")
+    if not drafts:
+        console.print("\nGmail drafts: none")
+        console.print("Create one with: [bold]co gmail draft create <to> <subject> <message>[/bold]\n")
+        return
+    _print_draft_list(drafts)
+
+
+def handle_gmail_draft_create(to: str, subject: str, message: str, cc: str = None,
+                              bcc: str = None):
+    if message == "-":
+        message = sys.stdin.read()
+    gmail = _gmail(require_draft_write=True)
+    draft = _draft_call(
+        lambda: gmail.create_draft(to, subject, message, cc=cc, bcc=bcc),
+        "co gmail draft create <to> <subject> <message>",
+    )
+    console.print(f"\n[green]✓ Draft created[/green] {draft['id']}")
+    console.print(f"Attach a local file: [bold]co gmail draft attach {draft['id']} <path>[/bold]\n")
+
+
+def handle_gmail_draft_attach(draft_id: str, source: str, drive: bool = False,
+                              link: bool = False):
+    if link and not drive:
+        console.print("\n❌ [bold red]--link requires --drive.[/bold red]")
+        console.print(
+            f"Retry with: [bold]co gmail draft attach {draft_id} <Drive file # or id> --drive --link[/bold]\n"
+        )
+        raise typer.Exit(1)
+
+    gmail = _gmail(require_draft_write=True)
+    resolved = _draft_id_or_exit(draft_id)
+    if drive:
+        from .gdrive_commands import _gdrive, _resolve_file_id
+        from ...useful_tools.gmail import GMAIL_ATTACHMENT_LIMIT
+
+        file_id = _resolve_file_id(source)
+        if not file_id:
+            console.print(f"\n❌ [bold red]No Drive file #{source} in your last listing.[/bold red]")
+            console.print("List Drive files: [bold]co gdrive[/bold]\n")
+            raise typer.Exit(1)
+        drive_client = _gdrive()
+        if link:
+            item = _draft_call(lambda: drive_client._get_file(file_id), "co gdrive")
+            if not item["link"]:
+                console.print("\n❌ [bold red]Drive returned no web link for this file.[/bold red]")
+                console.print(f"Attach its bytes: [bold]co gmail draft attach {draft_id} {source} --drive[/bold]\n")
+                raise typer.Exit(1)
+            updated = _draft_call(
+                lambda: gmail.add_draft_link(resolved, item["name"], item["link"]),
+                f"co gmail draft attach {draft_id} {source} --drive --link",
+            )
+        else:
+            item = _draft_call(
+                lambda: drive_client._read_file(file_id, max_bytes=GMAIL_ATTACHMENT_LIMIT),
+                f"co gmail draft attach {draft_id} {source} --drive",
+            )
+            updated = _draft_call(
+                lambda: gmail._add_draft_attachment(
+                    resolved, item["name"], item["type"], item["data"]
+                ),
+                f"co gmail draft attach {draft_id} {source} --drive",
+            )
+    else:
+        updated = _draft_call(
+            lambda: gmail.add_draft_attachment(resolved, source),
+            f"co gmail draft attach {draft_id} <path that exists>",
+        )
+
+    action = "Drive link added" if link else "Attachment staged"
+    console.print(f"\n[green]✓ {action}[/green]")
+    console.print(f"Preview it: [bold]co gmail draft preview {updated['id']}[/bold]\n")
+
+
+def handle_gmail_draft_remove(draft_id: str, attachment: int):
+    gmail = _gmail(require_draft_write=True)
+    resolved = _draft_id_or_exit(draft_id)
+    updated = _draft_call(
+        lambda: gmail.remove_draft_attachment(resolved, attachment),
+        f"co gmail draft preview {resolved}",
+    )
+    console.print(f"\n[green]✓ Attachment removed[/green]")
+    console.print(f"Preview it: [bold]co gmail draft preview {updated['id']}[/bold]\n")
+
+
+def handle_gmail_draft_replace(draft_id: str, attachment: int, source: str,
+                               drive: bool = False):
+    gmail = _gmail(require_draft_write=True)
+    resolved = _draft_id_or_exit(draft_id)
+    if drive:
+        from .gdrive_commands import _gdrive, _resolve_file_id
+        from ...useful_tools.gmail import GMAIL_ATTACHMENT_LIMIT
+
+        file_id = _resolve_file_id(source)
+        if not file_id:
+            console.print(f"\n❌ [bold red]No Drive file #{source} in your last listing.[/bold red]")
+            console.print("List Drive files: [bold]co gdrive[/bold]\n")
+            raise typer.Exit(1)
+        item = _draft_call(
+            lambda: _gdrive()._read_file(file_id, max_bytes=GMAIL_ATTACHMENT_LIMIT),
+            f"co gmail draft replace {draft_id} {attachment} {source} --drive",
+        )
+        updated = _draft_call(
+            lambda: gmail._replace_draft_attachment(
+                resolved, attachment, item["name"], item["type"], item["data"]
+            ),
+            f"co gmail draft preview {resolved}",
+        )
+    else:
+        updated = _draft_call(
+            lambda: gmail.replace_draft_attachment(resolved, attachment, source),
+            f"co gmail draft replace {draft_id} {attachment} <path that exists>",
+        )
+    console.print("\n[green]✓ Attachment replaced[/green]")
+    console.print(f"Preview it: [bold]co gmail draft preview {updated['id']}[/bold]\n")
+
+
+def handle_gmail_draft_preview(draft_id: str):
+    gmail = _gmail()
+    resolved = _draft_id_or_exit(draft_id)
+    draft = _draft_call(lambda: gmail.get_draft(resolved), "co gmail draft list")
+    _print_draft_preview(draft)
+
+
+def handle_gmail_draft_send(draft_id: str):
+    gmail = _gmail(require_draft_write=True)
+    resolved = _draft_id_or_exit(draft_id)
+    draft = _draft_call(lambda: gmail.get_draft(resolved), "co gmail draft list")
+    _print_draft_preview(draft, tip=False)
+    if not typer.confirm("\nSend this Gmail draft now?", default=False):
+        console.print("\n[yellow]Not sent; the Gmail draft was kept.[/yellow]")
+        console.print(f"Preview again: [bold]co gmail draft preview {resolved}[/bold]\n")
+        raise typer.Exit(1)
+    sent = _draft_call(lambda: gmail._send_draft(resolved), f"co gmail draft send {resolved}")
+    console.print(f"\n[green]✓ Sent[/green] Gmail message {sent.get('id', '')}")
+    console.print("List sent mail: [bold]co gmail sent[/bold]\n")

--- a/connectonion/cli/commands/gmail_commands.py
+++ b/connectonion/cli/commands/gmail_commands.py
@@ -347,6 +347,8 @@ def handle_gmail_draft_list(last: int = 20):
     gmail = _gmail()
     drafts = _draft_call(lambda: gmail.list_drafts(last=last), "co gmail draft list")
     if not drafts:
+        DRAFT_CACHE.parent.mkdir(exist_ok=True)
+        DRAFT_CACHE.write_text("{}", encoding="utf-8")
         console.print("\nGmail drafts: none")
         console.print("Create one with: [bold]co gmail draft create <to> <subject> <message>[/bold]\n")
         return
@@ -474,7 +476,11 @@ def handle_gmail_draft_send(draft_id: str):
     resolved = _draft_id_or_exit(draft_id)
     draft = _draft_call(lambda: gmail.get_draft(resolved), "co gmail draft list")
     _print_draft_preview(draft, tip=False)
-    if not typer.confirm("\nSend this Gmail draft now?", default=False):
+    try:
+        confirmed = typer.confirm("\nSend this Gmail draft now?", default=False)
+    except (typer.Abort, KeyboardInterrupt, EOFError):
+        confirmed = False
+    if not confirmed:
         console.print("\n[yellow]Not sent; the Gmail draft was kept.[/yellow]")
         console.print(f"Preview again: [bold]co gmail draft preview {resolved}[/bold]\n")
         raise typer.Exit(1)

--- a/connectonion/cli/commands/google_errors.py
+++ b/connectonion/cli/commands/google_errors.py
@@ -1,0 +1,44 @@
+"""Provider-safe recovery for the Gmail and Drive command surfaces."""
+
+from functools import wraps
+import json
+
+import typer
+from rich.console import Console
+
+
+def google_errors(next_command: str):
+    """Keep provider bodies out of errors and name one concrete recovery step.
+
+    Write commands use an inspection command: a lost response does not prove
+    that the provider rejected the write, so blindly retrying can duplicate it.
+    """
+    def decorate(handler):
+        @wraps(handler)
+        def guarded(*args, **kwargs):
+            from googleapiclient.errors import HttpError
+            from google.auth.exceptions import GoogleAuthError
+            from httplib2 import HttpLib2Error
+            from requests import RequestException
+
+            recovery = next_command
+            try:
+                return handler(*args, **kwargs)
+            except json.JSONDecodeError:
+                cause = "Saved listing numbers are unreadable; refresh the listing."
+            except HttpError as exc:
+                status = getattr(exc.resp, "status", None)
+                cause = f"Google request failed (HTTP {status}). Inspect state before retrying a write."
+                if status in (401, 403):
+                    recovery = "co auth google"
+            except GoogleAuthError:
+                cause = "Google authorization failed."
+                recovery = "co auth google"
+            except (RequestException, HttpLib2Error, OSError):
+                cause = "Local I/O or Google connection failed. A write may have completed; inspect state before retrying."
+            except ValueError:
+                cause = "Invalid input or unsupported file. Check the command arguments."
+            Console().print(f"Error: {cause}\nNext: {recovery}", markup=False, highlight=False)
+            raise typer.Exit(1)
+        return guarded
+    return decorate

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -1067,6 +1067,89 @@ def gmail_search(
     """Search your mail with Gmail query syntax."""
     from .commands.gmail_commands import handle_gmail_search
     handle_gmail_search(query, last=last)
+
+
+# Drafts are a nested, explicit workflow: editing never sends, and the send
+# command always previews and confirms. Keeping these under `co gmail draft`
+# makes the safe path discoverable without changing the immediate-send command.
+gmail_draft_app = _typer_app(help="Create, inspect, and edit Gmail drafts; sending always asks for confirmation.")
+gmail_app.add_typer(gmail_draft_app, name="draft")
+
+
+@gmail_draft_app.command("list")
+def gmail_draft_list(
+    last: int = typer.Option(20, "--last", "-n", min=1, max=500, help="How many drafts to show"),
+):
+    """List Gmail drafts, numbered for later draft commands."""
+    from .commands.gmail_commands import handle_gmail_draft_list
+    handle_gmail_draft_list(last=last)
+
+
+@gmail_draft_app.command("create")
+def gmail_draft_create(
+    to: str = typer.Argument(..., help="Recipient address (comma-separated for several)"),
+    subject: str = typer.Argument(..., help="Email subject"),
+    message: str = typer.Argument(..., help="Email body, or '-' to read stdin"),
+    cc: str = typer.Option(None, "--cc", help="CC recipients (comma-separated)"),
+    bcc: str = typer.Option(None, "--bcc", help="BCC recipients (comma-separated)"),
+):
+    """Create an unsent Gmail draft."""
+    from .commands.gmail_commands import handle_gmail_draft_create
+    handle_gmail_draft_create(to, subject, message, cc=cc, bcc=bcc)
+
+
+@gmail_draft_app.command("attach")
+def gmail_draft_attach(
+    draft_id: str = typer.Argument(..., help="Draft # from the last draft list, or a full draft id"),
+    source: str = typer.Argument(..., help="Local path, or Drive file #/id with --drive"),
+    drive: bool = typer.Option(False, "--drive", help="Read the source from the last Drive listing or a Drive id"),
+    link: bool = typer.Option(False, "--link", help="With --drive, append its web link instead of attaching bytes"),
+):
+    """Stage a local/Drive file, or append a Drive link, without sending."""
+    from .commands.gmail_commands import handle_gmail_draft_attach
+    handle_gmail_draft_attach(draft_id, source, drive=drive, link=link)
+
+
+@gmail_draft_app.command("remove")
+def gmail_draft_remove(
+    draft_id: str = typer.Argument(..., help="Draft # from the last draft list, or a full draft id"),
+    attachment: int = typer.Argument(..., min=1, help="Attachment # from draft preview"),
+):
+    """Remove one staged attachment; the draft remains unsent."""
+    from .commands.gmail_commands import handle_gmail_draft_remove
+    handle_gmail_draft_remove(draft_id, attachment)
+
+
+@gmail_draft_app.command("replace")
+def gmail_draft_replace(
+    draft_id: str = typer.Argument(..., help="Draft # from the last draft list, or a full draft id"),
+    attachment: int = typer.Argument(..., min=1, help="Attachment # from draft preview"),
+    source: str = typer.Argument(..., help="Local path, or Drive file #/id with --drive"),
+    drive: bool = typer.Option(False, "--drive", help="Read the replacement from Drive"),
+):
+    """Atomically replace one staged attachment without sending."""
+    from .commands.gmail_commands import handle_gmail_draft_replace
+    handle_gmail_draft_replace(draft_id, attachment, source, drive=drive)
+
+
+@gmail_draft_app.command("preview")
+def gmail_draft_preview(
+    draft_id: str = typer.Argument(..., help="Draft # from the last draft list, or a full draft id"),
+):
+    """Print recipients, body, and the final attachment manifest."""
+    from .commands.gmail_commands import handle_gmail_draft_preview
+    handle_gmail_draft_preview(draft_id)
+
+
+@gmail_draft_app.command("send")
+def gmail_draft_send(
+    draft_id: str = typer.Argument(..., help="Draft # from the last draft list, or a full draft id"),
+):
+    """Preview a draft and send it only after interactive confirmation."""
+    from .commands.gmail_commands import handle_gmail_draft_send
+    handle_gmail_draft_send(draft_id)
+
+
 # Google Drive command group. `co gdrive` (no args) lists recent files.
 # Uses the GOOGLE_* OAuth tokens saved to .env by `co auth google`.
 gdrive_app = _typer_app(help="List, search, download, and upload Google Drive files. Bare 'co gdrive' lists recent files.")

--- a/connectonion/useful_skills/co-mail-and-drive/SKILL.md
+++ b/connectonion/useful_skills/co-mail-and-drive/SKILL.md
@@ -142,6 +142,7 @@ co outlook contact search yifei
 
 ```bash
 co gdrive                          # bare command = 20 most recently modified
+co gdrive list                     # explicit form of the same listing
 co gdrive search report -n 50
 co gdrive get 3 --to ~/Downloads   # download row 3
 co gdrive put report.pdf --name "Q3 report.pdf"
@@ -157,7 +158,8 @@ numbering of the listing you just printed, cached in `~/.co/gmail_last_inbox.jso
 `~/.co/gdrive_last_list.json`. List again and the numbers move. Two consequences:
 
 - Never carry a number across two listings — re-list, then act.
-- Only `inbox`, `search` (and `outlook scheduled`) write the cache. `sent` does
+- Gmail `inbox`/`search`, Gmail `draft list`, and Drive `list`/`search` each
+  refresh their own numbering, including clearing it on an empty result. `sent` does
   **not**: after `co gmail sent`, `read 1` still opens row 1 of the older inbox listing.
 - A number that isn't in the cache gets `No email #N in your last listing` and exit
   `1` rather than a silently wrong email. Re-list and retry.
@@ -168,7 +170,7 @@ print the untruncated form with full IDs instead:
 
 ```bash
 co gmail inbox -n 50 | grep "ID:"   # full message ids, numbered 1., 2., ...
-co gdrive list -n 100 | cut -f4     # name<TAB>type<TAB>size<TAB>id
+co gdrive list -n 100 | cut -f4     # name<TAB>type<TAB>size<TAB>id<TAB>row-number
 co outlook contact list | cut -f2   # name<TAB>email<TAB>id
 ```
 
@@ -234,6 +236,29 @@ from credits) and `co email upgrade plus|pro` raises the quota.
 | `0`, clean output | success — including legitimately empty listings | continue |
 | `1` | guarded failure: account not connected, scope missing, unknown listing or attachment number, declined/rejected send, unowned `--from` address, attachment missing/too large | run the literal next command (`co auth google`, re-list/preview, correct the path) |
 | `2` | usage error: unknown subcommand, missing or bad argument | fix the syntax; the error names the argument, `--help` lists the rest |
+
+For Gmail and Drive, these are the concrete recovery routes:
+
+| Result | Next command |
+|---|---|
+| Gmail listing succeeded | `co gmail read <# from this listing>` |
+| Drive listing succeeded | `co gdrive get <# from column 5 when piped>` |
+| Empty Gmail inbox | `co gmail search <query>` |
+| Empty Gmail search | `co gmail inbox` |
+| Empty Drive listing | `co gdrive search <name prefix>` |
+| Empty Drive search | `co gdrive list` |
+| Missing Google permission (exit 1) | `co auth google` |
+| Gmail read/list failure (exit 1) | `co gmail inbox` |
+| Gmail send/reply connection failure (exit 1, delivery uncertain) | `co gmail sent` |
+| Drive connection or local I/O failure (exit 1) | `co gdrive list` |
+| Missing upload path (exit 1) | `co gdrive put <path to an existing file>` |
+| Missing Gmail read argument (exit 2) | `co gmail read --help` |
+| Missing Drive get argument (exit 2) | `co gdrive get --help` |
+
+A connection failure does not prove a write failed: inspect the provider state
+before repeating a send, reply, upload, or draft creation. Provider error bodies
+are omitted from CLI error messages. Outlook and agent-mail recovery behavior
+is outside the Gmail/Drive audit.
 
 The printed messages carry the current recovery step — trust them over this table.
 

--- a/connectonion/useful_skills/co-mail-and-drive/SKILL.md
+++ b/connectonion/useful_skills/co-mail-and-drive/SKILL.md
@@ -46,9 +46,9 @@ co outlook sent -n 20
 Gmail search takes full Gmail query syntax (`from:`, `subject:`, `after:2026/07/01`,
 `is:unread`). Outlook search is plain text over subject and body.
 
-`co gmail read` marks the mail read only when the token carries the `gmail.modify`
-scope; with read-only + send scopes it prints the body and leaves it unread. It says
-which happened — repeat what it says, don't assume.
+`co gmail read` preserves unread state by default. `co gmail read 3 --mark-read`
+marks it read only when the token carries `gmail.modify`; otherwise it prints
+a reauthorization hint. Repeat what the output says, don't assume.
 
 ## Send and reply
 
@@ -71,6 +71,7 @@ always previews and asks for interactive confirmation:
 ```bash
 co gmail draft list
 co gmail draft create bob@example.com "Subject" "Body text"
+co gmail draft list           # create prints an ID; it does not assign row 1
 co gmail draft attach 1 report.pdf
 co gdrive list
 co gmail draft attach 1 3 --drive
@@ -83,13 +84,16 @@ co gmail draft send 1
 
 `draft create`, `attach`, `remove`, `replace`, and `preview` never send. `draft
 send` has no `--yes` or other confirmation bypass. A declined confirmation
-leaves the draft intact and exits `1`.
+leaves the draft intact and exits `1`. EOF or interruption at the confirmation
+prompt does the same and prints the preview command again.
 
 A Gmail draft number comes from the immediately preceding `co gmail draft
 list`, cached separately at `~/.co/gmail_last_drafts.json`. Attachment numbers
 come from the current `draft preview`. Drive file numbers still come from the
 immediately preceding `co gdrive` listing. Re-list before acting rather than
 carrying numbers across listings.
+An empty draft listing clears its old numbers. After creating a draft, use the
+ID printed by `create`, or list again before choosing a row number.
 
 `--drive` attaches bytes without making a local copy. Native Docs, Sheets,
 Slides, and Drawings are exported using the same formats as `co gdrive get`.

--- a/connectonion/useful_skills/co-mail-and-drive/SKILL.md
+++ b/connectonion/useful_skills/co-mail-and-drive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: co-mail-and-drive
-description: Read and send mail from the user's own Gmail or Outlook account, send from the agent's own address, manage their Outlook contacts, and list/search/download/upload their Google Drive files — with `co gmail`, `co outlook`, `co email`, and `co gdrive`. Use when the user asks about *their* inbox, an email they received or want to send, a contact, or a file in their Drive.
+description: Read and send mail from the user's own Gmail or Outlook account, safely stage Gmail draft attachments, send from the agent's own address, manage Outlook contacts, and work with Google Drive files — with `co gmail`, `co outlook`, `co email`, and `co gdrive`. Use when the user asks about their inbox, an email or draft they want to prepare, an attachment, a contact, or a file in Drive.
 ---
 
 # co gmail / co outlook / co email / co gdrive
@@ -52,6 +52,53 @@ which happened — repeat what it says, don't assume.
 
 ## Send and reply
 
+For Gmail attachments, or whenever a person should review the final message,
+use the provider-native draft workflow. Only the last command can send, and it
+always previews and asks for interactive confirmation:
+
+| Intent | Command |
+|---|---|
+| List and number drafts | `co gmail draft list` |
+| Create an unsent draft | `co gmail draft create <to> <subject> <message>` |
+| Stage a local file | `co gmail draft attach <draft> <path>` |
+| Stage a Drive file | `co gmail draft attach <draft> <file> --drive` |
+| Append a Drive URL | `co gmail draft attach <draft> <file> --drive --link` |
+| Remove a staged file | `co gmail draft remove <draft> <attachment#>` |
+| Replace a staged file | `co gmail draft replace <draft> <attachment#> <source> [--drive]` |
+| Inspect recipients, body, and manifest | `co gmail draft preview <draft>` |
+| Preview, confirm, and send | `co gmail draft send <draft>` |
+
+```bash
+co gmail draft list
+co gmail draft create bob@example.com "Subject" "Body text"
+co gmail draft attach 1 report.pdf
+co gdrive list
+co gmail draft attach 1 3 --drive
+co gmail draft attach 1 3 --drive --link
+co gmail draft remove 1 2
+co gmail draft replace 1 1 corrected.pdf
+co gmail draft preview 1
+co gmail draft send 1
+```
+
+`draft create`, `attach`, `remove`, `replace`, and `preview` never send. `draft
+send` has no `--yes` or other confirmation bypass. A declined confirmation
+leaves the draft intact and exits `1`.
+
+A Gmail draft number comes from the immediately preceding `co gmail draft
+list`, cached separately at `~/.co/gmail_last_drafts.json`. Attachment numbers
+come from the current `draft preview`. Drive file numbers still come from the
+immediately preceding `co gdrive` listing. Re-list before acting rather than
+carrying numbers across listings.
+
+`--drive` attaches bytes without making a local copy. Native Docs, Sheets,
+Slides, and Drawings are exported using the same formats as `co gdrive get`.
+`--drive --link` appends the web URL but does not grant the recipient access or
+change Drive sharing.
+
+Each success and guarded failure prints a literal next command. Read it even
+when output is piped; it is part of the CLI contract.
+
 ```bash
 co gmail send bob@example.com "Subject" "Body text"
 co gmail reply 3 "Sounds good, see you then."
@@ -75,9 +122,9 @@ co outlook cancel 1           # pull one back before it goes
 Outlook can also save an email's attachments: `co outlook download 3 --to ~/Downloads`.
 Gmail has no download command — there is no way to save a Gmail attachment from this CLI.
 
-**Never send on the user's behalf without showing them the exact text first.**
-Draft it, print it, wait for a yes. Sending is not undoable — scheduling is, until
-it goes out.
+**Never send on the user's behalf without showing them the exact text and final
+attachment manifest first.** Prefer `co gmail draft`; print its preview and wait
+for a yes. Sending is not undoable — scheduling is, until it goes out.
 
 ## Contacts (Outlook only)
 
@@ -99,10 +146,11 @@ co gdrive rm 3                     # move to trash (recoverable)
 
 ## The two gotchas that make you report something false
 
-**1. Numbers mean your last listing.** `read 3` / `get 3` resolve against the
+**1. Numbers mean your last listing.** `read 3` / `get 3` / `draft preview 3`
+resolve against the
 numbering of the listing you just printed, cached in `~/.co/gmail_last_inbox.json`,
-`~/.co/outlook_last_inbox.json`, `~/.co/gdrive_last_list.json`. List again and the
-numbers move. Two consequences:
+`~/.co/gmail_last_drafts.json`, `~/.co/outlook_last_inbox.json`, and
+`~/.co/gdrive_last_list.json`. List again and the numbers move. Two consequences:
 
 - Never carry a number across two listings — re-list, then act.
 - Only `inbox`, `search` (and `outlook scheduled`) write the cache. `sent` does
@@ -180,7 +228,7 @@ from credits) and `co email upgrade plus|pro` raises the quota.
 | exit | Meaning | What to do |
 |---|---|---|
 | `0`, clean output | success — including legitimately empty listings | continue |
-| `1` | guarded failure: account not connected, scope missing, unknown listing number, rejected send, unowned `--from` address, attachment missing/too large | the message names the fix (`co auth google`, `co email addresses`, re-list, correct the path) |
+| `1` | guarded failure: account not connected, scope missing, unknown listing or attachment number, declined/rejected send, unowned `--from` address, attachment missing/too large | run the literal next command (`co auth google`, re-list/preview, correct the path) |
 | `2` | usage error: unknown subcommand, missing or bad argument | fix the syntax; the error names the argument, `--help` lists the rest |
 
 The printed messages carry the current recovery step — trust them over this table.
@@ -190,6 +238,7 @@ When a command says the account is not connected:
 ```
 ❌ Google account not connected     → co auth google
 ❌ Gmail permission missing         → co auth google      (re-consent)
+❌ Gmail draft permission missing   → co auth google      (re-consent)
 ❌ Google Drive permission missing  → co auth google      (re-consent)
 ❌ Microsoft account not connected  → co auth microsoft
 ❌ Microsoft <scope> permission missing → co auth microsoft
@@ -205,6 +254,7 @@ it themselves**, do not try to drive that flow.
 
 - [ ] Right mailbox chosen (asked, if both were connected)
 - [ ] Exact text shown to the user before any send
+- [ ] Final Gmail attachment manifest shown before any draft send
 - [ ] Numbers used from the listing printed immediately before the action
 - [ ] IDs taken from piped output, never from a truncated table column
 - [ ] `--from` address taken from `co email addresses`, never guessed

--- a/connectonion/useful_tools/gdrive.py
+++ b/connectonion/useful_tools/gdrive.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [io, mimetypes, os, pathlib, googleapiclient.discovery, googleapiclient.http, google.oauth2.credentials] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth google' | tested by [tests/unit/test_gdrive.py]
   Data flow: Agent calls GDrive methods → _get_service() validates the ambient OpenOnion account and refreshes the access token via oo-api once per instance → Drive v3 API → returns file dicts or confirmations | list_files()/search_files() page through files().list() with 'trashed = false' | download() picks get_media() for binary files and export_media() for Google-native docs | upload() sends a MediaFileUpload
   State/Effects: reads GOOGLE_* env vars for OAuth tokens | makes HTTP calls to the Drive API | creates/overwrites local files on download and remote files on upload | token refresh rewrites ~/.co/keys.env
-  Integration: exposes GDrive class with list_files(), search_files(), download(), upload(), delete() | list_files()/search_files() return dicts for the CLI (cli/commands/gdrive_commands.py) | used as agent tool via Agent(tools=[GDrive()])
+  Integration: exposes GDrive class with list_files(), search_files(), download(), upload(), delete() | private metadata/byte helpers let the Gmail CLI stage a Drive file without writing it locally | used as agent tool via Agent(tools=[GDrive()])
   Performance: network I/O per API call | listings page at 100/request | downloads stream in chunks
   Errors: raises ValueError if OAuth not configured, if the Drive scope is missing, on unknown file ids, and on Google-native types with no export format | HttpError from the Drive API propagates
 
@@ -272,6 +272,56 @@ class GDrive:
             return self._get_meta(shortcut["targetId"])
         return item
 
+    def _get_file(self, file_id: str) -> dict:
+        """Get one Drive file's normalized metadata without downloading it."""
+        return self._file_dict(self._get_meta(file_id))
+
+    def _read_file(self, file_id: str, max_bytes: int | None = None) -> dict:
+        """Read a Drive file for another provider, exporting native docs.
+
+        This is the in-memory counterpart of download(). It never writes a
+        local file and can fail before or during download when `max_bytes` is
+        exceeded.
+        """
+        item = self._get_meta(file_id)
+        name, mime = item["name"], item["mimeType"]
+        if max_bytes is not None and item.get("size") and int(item["size"]) > max_bytes:
+            raise ValueError(f"Drive file exceeds the {max_bytes}-byte attachment limit.")
+
+        service = self._get_service()
+        if mime.startswith(NATIVE_PREFIX):
+            if mime not in EXPORT_FORMATS:
+                raise ValueError(
+                    f"'{name}' is a {mime.replace(NATIVE_PREFIX, '')} — Drive has "
+                    "no export format for it, so it cannot be downloaded or attached."
+                )
+            mime, suffix = EXPORT_FORMATS[mime]
+            request = service.files().export_media(fileId=item["id"], mimeType=mime)
+            name = f"{name}{suffix}"
+        else:
+            request = service.files().get_media(fileId=item["id"], supportsAllDrives=True)
+
+        buffer = io.BytesIO()
+        # The library default is a 100 MB chunk, which would defeat the
+        # attachment limit for sizeless Google-native exports. Keep memory
+        # bounded to at most roughly one small chunk beyond max_bytes.
+        chunk_size = min(1024 * 1024, max_bytes + 1) if max_bytes is not None else 1024 * 1024
+        downloader = MediaIoBaseDownload(buffer, request, chunksize=chunk_size)
+        done = False
+        while not done:
+            _, done = downloader.next_chunk()
+            if max_bytes is not None and buffer.tell() > max_bytes:
+                raise ValueError(f"Drive file exceeds the {max_bytes}-byte attachment limit.")
+
+        return {
+            "id": item["id"],
+            "name": name,
+            "type": mime,
+            "size": len(buffer.getvalue()),
+            "link": item.get("webViewLink", ""),
+            "data": buffer.getvalue(),
+        }
+
     def download(self, file_id: str, dest: str = ".") -> str:
         """Download a Drive file, exporting Google-native docs to a real format.
 
@@ -282,33 +332,14 @@ class GDrive:
         Returns:
             Confirmation with the path written
         """
-        item = self._get_meta(file_id)
-        name, mime = item["name"], item["mimeType"]
-        service = self._get_service()
-
-        if mime.startswith(NATIVE_PREFIX):
-            if mime not in EXPORT_FORMATS:
-                raise ValueError(
-                    f"'{name}' is a {mime.replace(NATIVE_PREFIX, '')} — Drive has "
-                    "no export format for it, so it cannot be downloaded."
-                )
-            export_mime, suffix = EXPORT_FORMATS[mime]
-            request = service.files().export_media(fileId=item["id"], mimeType=export_mime)
-            name = f"{name}{suffix}"
-        else:
-            request = service.files().get_media(fileId=item["id"], supportsAllDrives=True)
+        item = self._read_file(file_id)
+        name = item["name"]
 
         path = Path(dest).expanduser()
         if path.is_dir():
             path = path / name
 
-        buffer = io.BytesIO()
-        downloader = MediaIoBaseDownload(buffer, request)
-        done = False
-        while not done:
-            _, done = downloader.next_chunk()
-
-        path.write_bytes(buffer.getvalue())
+        path.write_bytes(item["data"])
         return f"Downloaded to {path}"
 
     def upload(self, path: str, name: str = None) -> dict:

--- a/connectonion/useful_tools/gmail.py
+++ b/connectonion/useful_tools/gmail.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [os, base64, google.oauth2.credentials, googleapiclient.discovery, googleapiclient.errors] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth google' | tested by [tests/unit/test_gmail.py]
   Data flow: Agent calls Gmail methods → validates the ambient OpenOnion account and refreshes server-owned Google credentials via oo-api → builds Gmail API service → API calls to Gmail REST endpoints → returns formatted results (email summaries, bodies, send confirmations)
   State/Effects: reads GOOGLE_* env vars and OPENONION_API_KEY | persists refreshed tokens to ~/.co/keys.env | makes HTTP calls to Gmail API | can modify mailbox state (mark read/unread, archive, star, send emails)
-  Integration: exposes Gmail class with read_inbox(), get_sent_emails(), search_emails(), get_email_body(), send(), reply(), mark_read(), mark_unread(), archive_email(), star_email(), get_labels(), add_label(), count_unread(), get_all_contacts(), analyze_contact(), get_unanswered_emails(), update_contact() | used as agent tool via Agent(tools=[Gmail()])
+  Integration: exposes Gmail class with read_inbox(), get_sent_emails(), search_emails(), get_email_body(), draft CRUD/attachment methods, send(), reply(), mark_read(), mark_unread(), archive_email(), star_email(), get_labels(), add_label(), count_unread(), get_all_contacts(), analyze_contact(), get_unanswered_emails(), update_contact() | used as agent tool via Agent(tools=[Gmail()])
   Performance: network I/O per API call | batch fetching for list operations | email body fetched separately (lazy loading)
   Errors: raises ValueError if OAuth not configured | HttpError from Google API propagates | returns error strings for display to user
 
@@ -102,6 +102,7 @@ class Gmail:
             )
 
         self._service = None
+        self._scopes = scopes
         self.emails_csv = emails_csv
         self.contacts_csv = contacts_csv
         self._attachment_root = project_root().resolve()
@@ -494,6 +495,242 @@ class Gmail:
             output.append(f"   ID: {att['id']}\n")
 
         return "\n".join(output)
+
+    # === Drafts ===
+
+    def _require_draft_write_scope(self) -> None:
+        """Require one of the scopes accepted by Gmail's draft write APIs."""
+        scopes = self._scopes
+        if not any(scope in scopes for scope in ("gmail.modify", "gmail.compose", "mail.google.com")):
+            raise ValueError(
+                "Gmail draft permission missing.\n"
+                "Reconnect Google to grant draft access:\n"
+                "  co auth google"
+            )
+
+    @staticmethod
+    def _decode_message(raw: str):
+        """Decode Gmail's base64url `raw` field into an EmailMessage."""
+        from email import policy
+        from email.parser import BytesParser
+
+        padded = raw + "=" * (-len(raw) % 4)
+        return BytesParser(policy=policy.default).parsebytes(base64.urlsafe_b64decode(padded))
+
+    @staticmethod
+    def _encode_message(message) -> str:
+        """Encode an EmailMessage for Gmail's `raw` field."""
+        return base64.urlsafe_b64encode(message.as_bytes()).decode("ascii")
+
+    @staticmethod
+    def _attachment_parts(message) -> list[tuple[object, object]]:
+        """Return every attachment with its parent, including nested MIME parts."""
+        found = []
+
+        def visit(parent):
+            if not parent.is_multipart():
+                return
+            for part in parent.iter_parts():
+                if part.get_filename() or part.get_content_disposition() == "attachment":
+                    found.append((parent, part))
+                else:
+                    visit(part)
+
+        visit(message)
+        return found
+
+    @staticmethod
+    def _attachment_dict(part) -> dict:
+        payload = part.get_payload(decode=True)
+        if payload is None:
+            payload = part.as_bytes()
+        return {
+            "name": part.get_filename() or "attachment",
+            "type": part.get_content_type(),
+            "size": len(payload),
+        }
+
+    @staticmethod
+    def _message_body(message) -> str:
+        """Return the draft body without treating an attachment as content."""
+        part = message.get_body(preferencelist=("plain", "html")) if message.is_multipart() else message
+        if part is None or part.get_content_disposition() == "attachment":
+            return ""
+        content = part.get_content()
+        return content if isinstance(content, str) else ""
+
+    def _draft_message(self, draft_id: str):
+        draft = self._get_service().users().drafts().get(
+            userId="me", id=draft_id, format="raw"
+        ).execute()
+        return draft, self._decode_message(draft["message"]["raw"])
+
+    def _draft_dict(self, draft_id: str, message) -> dict:
+        attachments = [self._attachment_dict(part) for _, part in self._attachment_parts(message)]
+        return {
+            "id": draft_id,
+            "to": str(message.get("To", "")),
+            "cc": str(message.get("Cc", "")),
+            "bcc": str(message.get("Bcc", "")),
+            "subject": str(message.get("Subject", "")),
+            "body": self._message_body(message),
+            "attachments": attachments,
+            "attachment_size": sum(item["size"] for item in attachments),
+        }
+
+    def list_drafts(self, last: int = 20) -> list:
+        """List Gmail drafts with recipient, subject, and attachment metadata."""
+        if last < 1:
+            return []
+        service = self._get_service()
+        stubs = service.users().drafts().list(
+            userId="me", maxResults=last
+        ).execute().get("drafts", [])
+        drafts = []
+        for stub in stubs:
+            full = service.users().drafts().get(
+                userId="me", id=stub["id"], format="full"
+            ).execute()
+            message = full.get("message", {})
+            headers = {
+                header.get("name", "").lower(): header.get("value", "")
+                for header in message.get("payload", {}).get("headers", [])
+            }
+
+            def count(parts) -> int:
+                return sum(
+                    (1 if part.get("filename") else count(part.get("parts", [])))
+                    for part in parts
+                )
+
+            drafts.append({
+                "id": stub["id"],
+                "to": headers.get("to", ""),
+                "subject": headers.get("subject", ""),
+                "attachments": count(message.get("payload", {}).get("parts", [])),
+            })
+        return drafts
+
+    def create_draft(self, to: str, subject: str, body: str, cc: str = None,
+                     bcc: str = None) -> dict:
+        """Create a Gmail draft without sending it."""
+        from email.message import EmailMessage
+
+        self._require_draft_write_scope()
+        message = EmailMessage()
+        message.set_content(body)
+        message["To"] = to
+        message["Subject"] = subject
+        if cc:
+            message["Cc"] = cc
+        if bcc:
+            message["Bcc"] = bcc
+        created = self._get_service().users().drafts().create(
+            userId="me", body={"message": {"raw": self._encode_message(message)}}
+        ).execute()
+        return self._draft_dict(created["id"], message)
+
+    def get_draft(self, draft_id: str) -> dict:
+        """Return a draft's exact headers/body and attachment manifest."""
+        _, message = self._draft_message(draft_id)
+        return self._draft_dict(draft_id, message)
+
+    def _update_draft(self, draft_id: str, message) -> dict:
+        self._require_draft_write_scope()
+        self._get_service().users().drafts().update(
+            userId="me",
+            id=draft_id,
+            body={"message": {"raw": self._encode_message(message)}},
+        ).execute()
+        return self._draft_dict(draft_id, message)
+
+    def _add_draft_attachment(self, draft_id: str, name: str, mime_type: str,
+                              data: bytes) -> dict:
+        _, message = self._draft_message(draft_id)
+        existing = sum(
+            item["size"]
+            for item in (self._attachment_dict(part) for _, part in self._attachment_parts(message))
+        )
+        if existing + len(data) > GMAIL_ATTACHMENT_LIMIT:
+            raise ValueError("Attachments exceed Gmail's 25MB send limit.")
+        main, _, sub = (mime_type or "application/octet-stream").partition("/")
+        message.add_attachment(data, maintype=main, subtype=sub or "octet-stream", filename=name)
+        return self._update_draft(draft_id, message)
+
+    def add_draft_attachment(self, draft_id: str, path: str) -> dict:
+        """Stage a local file into a Gmail draft; the draft remains unsent."""
+        from contextlib import ExitStack
+        import mimetypes
+
+        with ExitStack() as stack:
+            name, handle = self._open_attachments([path], stack)[0]
+            data = handle.read(GMAIL_ATTACHMENT_LIMIT + 1)
+        mime_type = mimetypes.guess_type(name)[0] or "application/octet-stream"
+        return self._add_draft_attachment(draft_id, name, mime_type, data)
+
+    def add_draft_link(self, draft_id: str, name: str, url: str) -> dict:
+        """Append a Drive link to a plain-text draft without changing sharing."""
+        _, message = self._draft_message(draft_id)
+        part = message.get_body(preferencelist=("plain",)) if message.is_multipart() else message
+        if part is None or part.get_content_type() != "text/plain":
+            raise ValueError("Draft has no plain-text body; attach the Drive file instead.")
+        body = part.get_content()
+        separator = "" if body.endswith("\n\n") else ("\n" if body.endswith("\n") else "\n\n")
+        part.set_content(f"{body}{separator}{name}: {url}\n")
+        return self._update_draft(draft_id, message)
+
+    def remove_draft_attachment(self, draft_id: str, attachment: int) -> dict:
+        """Remove one attachment by its one-based preview number."""
+        _, message = self._draft_message(draft_id)
+        parts = self._attachment_parts(message)
+        if attachment < 1 or attachment > len(parts):
+            raise ValueError(f"Draft has no attachment #{attachment}.")
+        parent, selected = parts[attachment - 1]
+        parent.set_payload([part for part in parent.iter_parts() if part is not selected])
+        return self._update_draft(draft_id, message)
+
+    def _replace_draft_attachment(self, draft_id: str, attachment: int, name: str,
+                                  mime_type: str, data: bytes) -> dict:
+        _, message = self._draft_message(draft_id)
+        parts = self._attachment_parts(message)
+        if attachment < 1 or attachment > len(parts):
+            raise ValueError(f"Draft has no attachment #{attachment}.")
+        total_without_selected = sum(
+            self._attachment_dict(part)["size"]
+            for index, (_, part) in enumerate(parts, 1)
+            if index != attachment
+        )
+        if total_without_selected + len(data) > GMAIL_ATTACHMENT_LIMIT:
+            raise ValueError("Attachments exceed Gmail's 25MB send limit.")
+        parent, selected = parts[attachment - 1]
+        payload = list(parent.iter_parts())
+        position = payload.index(selected)
+        from email.message import EmailMessage
+        replacement = EmailMessage()
+        main, _, sub = (mime_type or "application/octet-stream").partition("/")
+        replacement.set_content(data, maintype=main, subtype=sub or "octet-stream")
+        replacement.add_header("Content-Disposition", "attachment", filename=name)
+        payload[position] = replacement
+        parent.set_payload(payload)
+        return self._update_draft(draft_id, message)
+
+    def replace_draft_attachment(self, draft_id: str, attachment: int, path: str) -> dict:
+        """Replace one draft attachment with a local file in one update."""
+        from contextlib import ExitStack
+        import mimetypes
+
+        with ExitStack() as stack:
+            name, handle = self._open_attachments([path], stack)[0]
+            data = handle.read(GMAIL_ATTACHMENT_LIMIT + 1)
+        mime_type = mimetypes.guess_type(name)[0] or "application/octet-stream"
+        return self._replace_draft_attachment(draft_id, attachment, name, mime_type, data)
+
+    def _send_draft(self, draft_id: str) -> dict:
+        """Send an existing draft after the CLI has obtained confirmation."""
+        self._require_draft_write_scope()
+        return self._get_service().users().drafts().send(
+            userId="me", body={"id": draft_id}
+        ).execute()
 
     def _open_attachments(self, attachments: list, stack) -> list[tuple[str, object]]:
         """Open and validate attachments, retaining the checked file objects."""

--- a/docs/blog/2026-09-05-the-draft-that-was-still-number-one.md
+++ b/docs/blog/2026-09-05-the-draft-that-was-still-number-one.md
@@ -1,0 +1,32 @@
+# The draft that was still number one
+
+The Gmail draft workflow looked straightforward: list drafts, choose a number,
+attach a file, and preview before sending. The first discoverability test found
+that the piped listing did not print row numbers. Given only that output, the
+model chose `co gmail draft preview 0`. Numbering the output fixed that test.
+
+A second audit found a quieter problem. If a later listing returned no drafts,
+the command printed “none” but retained the previous numbering cache. Row one
+could still resolve to a draft from an earlier listing. The screen and the
+command disagreed about what “one” meant.
+
+An empty listing now clears those numbers. The skill also tells the reader to
+use the ID printed by draft creation, or list again before choosing a number.
+Creating a draft does not make it row one. That distinction matters when the
+next command changes attachment state.
+
+The same audit followed the send prompt to its less visible exit. Answering
+“no” already kept the draft and printed a preview command. Ending input or
+interrupting the prompt needed the same recovery path. Those cases now exit
+with code 1, retain the draft, and name the command to inspect it again.
+
+The focused suite passes 241 tests, including regressions for stale numbering
+and all three interruption signals. Two text-only tip tests gave a fresh model
+only synthetic output and a goal. It chose the existing create command after
+an empty listing and the exact preview command after an interrupted send.
+Neither test had access to a mailbox or a shell.
+
+The useful question turned out to be what the next caller can infer from the
+last output. A command can report a true result and still leave behind state
+that makes the next action wrong. Testing that transition caught what checking
+each success message on its own had missed.

--- a/docs/blog/2026-09-05-the-draft-that-was-still-number-one.md
+++ b/docs/blog/2026-09-05-the-draft-that-was-still-number-one.md
@@ -30,3 +30,13 @@ The useful question turned out to be what the next caller can infer from the
 last output. A command can report a true result and still leave behind state
 that makes the next action wrong. Testing that transition caught what checking
 each success message on its own had missed.
+
+Expanding the audit to the rest of Gmail and Drive found the same stale-row
+problem after empty inbox and file searches. Drive's piped rows exposed full
+IDs but still invited the caller to choose a number it could not see. A fifth
+column now supplies that number without moving the original four columns.
+
+The expanded harness exercises twenty command paths, including both bare
+commands. All twenty output-only tip tests pass, and the focused suite now
+passes 277 tests. Send, upload, and trash calls in that harness go to mocks.
+The model only chooses a command; the harness never executes its reply.

--- a/docs/cli/gdrive.md
+++ b/docs/cli/gdrive.md
@@ -20,7 +20,7 @@ co gdrive get 3
 co gdrive put report.pdf
 ```
 
-That's the whole surface. Everything below is detail.
+Each result prints a next command, including when output is piped.
 
 ## Setup
 
@@ -47,6 +47,8 @@ co gdrive list -n 50
 Files are numbered. **Numbers mean your last listing** — `co gdrive get 3`
 downloads the third row of the table you just saw. Running `co gdrive` again
 renumbers.
+List and search share their numbering cache. An empty result clears the old
+numbers; it does not leave an earlier row available for `get` or `rm`.
 
 Trashed files are excluded.
 
@@ -81,13 +83,14 @@ Google Docs, Sheets, and Slides have no file bytes of their own, so they are
 | Google Drawing | PDF (`.pdf`) |
 
 Everything else downloads byte-for-byte. Folders and Forms have no export
-format at all — the command says so rather than writing a broken file.
+format at all — the command fails rather than writing a broken file.
 Shortcuts resolve to whatever they point at.
 
 To stage a Drive file directly into an unsent Gmail draft, keep the current
 Drive listing and use its row number:
 
 ```bash
+co gmail draft list               # select an existing draft independently
 co gdrive list -n 20
 co gmail draft attach 1 3 --drive
 co gmail draft attach 1 3 --drive --link
@@ -126,6 +129,15 @@ co gdrive list -n 100 | cut -f4      # just the ids
 co gdrive search report | cut -f1    # just the names
 ```
 
+These commands also print a final tip line, which is not a file row. If parsing
+rows, filter for five tab-separated fields first:
+
+```bash
+co gdrive list | awk -F '\t' 'NF == 5 { print $4 }'
+```
+
+The tip names the fifth column as the source of the number for `co gdrive get`.
+
 ## Using it from an agent
 
 ```python
@@ -146,6 +158,20 @@ drive.upload("report.pdf")
 ```
 
 ## Troubleshooting
+
+| Exit / result | Recovery command |
+|---|---|
+| 0, listing or search results | `co gdrive get <# from this listing>` |
+| 0, empty search | `co gdrive list` |
+| 1, missing permission | `co auth google` |
+| 1, unknown row or unreadable cache | `co gdrive list` |
+| 1, missing upload file | `co gdrive put <path to an existing file>` |
+| 1, provider, connection, or local I/O failure | `co gdrive list` |
+| 2, missing download argument | `co gdrive get --help` |
+
+Provider error bodies are omitted. A lost upload response does not establish
+that the upload failed. Inspect the latest listing before uploading again to
+avoid duplicates. The printed recovery command remains visible through pipes.
 
 - **"Google account not connected"** → run `co auth google`.
 - **"Google Drive permission missing"** → your token predates Drive support;

--- a/docs/cli/gdrive.md
+++ b/docs/cli/gdrive.md
@@ -84,6 +84,18 @@ Everything else downloads byte-for-byte. Folders and Forms have no export
 format at all — the command says so rather than writing a broken file.
 Shortcuts resolve to whatever they point at.
 
+To stage a Drive file directly into an unsent Gmail draft, keep the current
+Drive listing and use its row number:
+
+```bash
+co gdrive list -n 20
+co gmail draft attach 1 3 --drive
+co gmail draft attach 1 3 --drive --link
+```
+
+The first form reads the file into the Gmail draft without writing a local
+copy. The link form changes neither Drive content nor sharing permissions.
+
 ### `co gdrive put <path>` — Upload
 
 ```bash

--- a/docs/cli/gdrive.md
+++ b/docs/cli/gdrive.md
@@ -117,8 +117,9 @@ it from drive.google.com if that was a mistake.
 ## Piping
 
 In a terminal you get a Rich table with truncated columns. When output is
-piped, each file is one tab-separated row of `name`, `type`, `size`, and the
-**full file id**, so scripts never receive a truncated value:
+piped, each file is one tab-separated row of `name`, `type`, `size`, the
+**full file id**, and the **row number** used by `get`. The original four
+columns keep their positions; the row number is column five:
 
 ```bash
 co gdrive list -n 100 | cut -f4      # just the ids

--- a/docs/cli/gmail.md
+++ b/docs/cli/gmail.md
@@ -18,11 +18,13 @@ co gmail read 3
 
 # Create, review, and then explicitly send a draft
 co gmail draft create alice@example.com "Hello" "Thanks for the meeting today!"
+co gmail draft list               # choose the new draft's row from this listing
 co gmail draft preview 1
 co gmail draft send 1
 ```
 
-That's the whole surface. Everything below is detail.
+Use the row that matches your draft; `create` prints its full ID but does not
+assign it row 1. You can use that ID directly instead of listing again.
 
 ## Setup
 
@@ -55,6 +57,8 @@ co gmail inbox -u        # unread only
 Emails are numbered. **Numbers mean your last listing** — `co gmail read 3`
 opens the third row of the table you just saw. Running `co gmail` again
 renumbers.
+An empty inbox or search result clears older message numbers, so a later
+`read 1` cannot silently use a row from the previous listing.
 
 A green ● marks unread.
 
@@ -90,6 +94,7 @@ asks for interactive confirmation. There is no confirmation-bypass flag.
 ```bash
 co gmail draft list
 co gmail draft create alice@example.com "Report" "Please review."
+co gmail draft list               # select the matching row before using a number
 co gmail draft attach 1 report.pdf
 co gmail draft preview 1
 co gmail draft send 1
@@ -99,6 +104,9 @@ Drafts are numbered independently from inbox messages. A draft number means a
 row from the most recent `co gmail draft list`; the mapping is cached in
 `~/.co/gmail_last_drafts.json`. Attachment numbers come from `draft preview`.
 A full Gmail draft ID works anywhere a draft number does.
+Creating a draft does not change this numbering. An empty draft list clears it.
+Answering no, ending input, or interrupting the confirmation prompt keeps the
+draft, exits 1, and prints its preview command again.
 
 Use local or Drive files without first copying Drive content to disk:
 
@@ -143,6 +151,8 @@ co gmail sent -n 25
 ```
 
 Read-only listing; it does **not** touch the read/reply numbering.
+To read a sent message, run `co gmail search in:sent`, then choose a number from
+that search result.
 
 ### `co gmail search <query>` — Search
 
@@ -197,6 +207,19 @@ gmail.get_draft(draft["id"])
 ```
 
 ## Troubleshooting
+
+| Exit / result | Recovery command |
+|---|---|
+| 0, inbox or search result | `co gmail read <# from this listing>` |
+| 1, missing permission | `co auth google` |
+| 1, unknown message number or unreadable numbering cache | `co gmail inbox` |
+| 1, send/reply connection failure | `co gmail sent` |
+| 1, declined draft confirmation | `co gmail draft preview <draft ID>` |
+| 2, missing read argument | `co gmail read --help` |
+
+Read the printed cause and next command even when piping output. Provider error
+bodies are omitted. A connection failure after sending can mean the response
+was lost after delivery: inspect sent mail before repeating the send or reply.
 
 - **"Google account not connected"** → run `co auth google`.
 - **Missing Gmail scopes** → run `co auth google` again to re-consent.

--- a/docs/cli/gmail.md
+++ b/docs/cli/gmail.md
@@ -1,4 +1,4 @@
-# Gmail CLI (co gmail)
+# Gmail CLI (`co gmail`)
 
 Send and read email from your Gmail account right in the terminal — the same
 Gmail API access your agents get from the [Gmail tool](../useful_tools/gmail.md),
@@ -16,8 +16,10 @@ co gmail
 # Read message #3 from the inbox list
 co gmail read 3
 
-# Send a message
-co gmail send alice@example.com "Hello" "Thanks for the meeting today!"
+# Create, review, and then explicitly send a draft
+co gmail draft create alice@example.com "Hello" "Thanks for the meeting today!"
+co gmail draft preview 1
+co gmail draft send 1
 ```
 
 That's the whole surface. Everything below is detail.
@@ -33,7 +35,8 @@ co auth google
 This opens the Google OAuth flow and saves `GOOGLE_*` credentials (access
 token, refresh token, scopes, email) to your project `.env` and
 `~/.co/keys.env`. Tokens auto-refresh — the access token is renewed at the
-start of every command, so you authorize once.
+start of every command, so you authorize once. Draft creation and editing need
+the `gmail.modify` scope; reconnect if an older token does not have it.
 
 See [Google Integration](../integrations/google.md) for the requested scopes.
 
@@ -77,7 +80,43 @@ cat reply.txt | co gmail reply 3 -
 Threaded — the reply goes back on the original conversation. A message of `-`
 reads the body from stdin.
 
-### `co gmail send <to> <subject> <message>` — Send
+### `co gmail draft` — Build and review an unsent message
+
+The draft workflow is the safe path when attachments or Drive files are
+involved. Creating, attaching, removing, replacing, and previewing do not send
+mail. Only `draft send` can send, and it always prints the final preview and
+asks for interactive confirmation. There is no confirmation-bypass flag.
+
+```bash
+co gmail draft list
+co gmail draft create alice@example.com "Report" "Please review."
+co gmail draft attach 1 report.pdf
+co gmail draft preview 1
+co gmail draft send 1
+```
+
+Drafts are numbered independently from inbox messages. A draft number means a
+row from the most recent `co gmail draft list`; the mapping is cached in
+`~/.co/gmail_last_drafts.json`. Attachment numbers come from `draft preview`.
+A full Gmail draft ID works anywhere a draft number does.
+
+Use local or Drive files without first copying Drive content to disk:
+
+```bash
+co gdrive list -n 20
+co gmail draft attach 1 3 --drive          # attach Drive row 3 as bytes
+co gmail draft attach 1 3 --drive --link   # append its Drive URL instead
+co gmail draft remove 1 2
+co gmail draft replace 1 1 corrected.pdf
+co gmail draft replace 1 1 3 --drive
+```
+
+Google Docs, Sheets, Slides, and Drawings are exported with the same formats as
+`co gdrive get`. A Drive link does not change the file's sharing permissions;
+the recipient still needs access. The combined decoded attachment size must be
+at most 25 MB.
+
+### `co gmail send <to> <subject> <message>` — Send immediately
 
 ```bash
 co gmail send alice@example.com "Report" "See notes below."
@@ -91,6 +130,10 @@ message of `-` reads the body from stdin. Repeat `-a`/`--attach` to attach
 several files; their combined size must be at most 25 MB. Because the human
 operator explicitly chooses these paths, the CLI may attach a file outside the
 current project. Agent-facing `Gmail()` tools remain limited to project files.
+
+This command sends immediately and exists for backward compatibility and
+automation. Use `co gmail draft` when a human should inspect recipients, body,
+and the attachment manifest before delivery.
 
 ### `co gmail sent` — Recently sent
 
@@ -122,7 +165,12 @@ and agents never receive a truncated value:
 
 ```bash
 co gmail inbox -n 50 | grep "ID:"
+co gmail draft list | cat
+co gmail draft preview 1 | cat
 ```
+
+The plain piped forms keep the literal next-command tip, including after
+failures, so the recovery step remains visible to scripts and agents.
 
 ## Using it from an agent
 
@@ -142,12 +190,22 @@ gmail = Gmail()
 gmail.list_inbox(last=10, unread=True)
 gmail.list_search("from:alice@example.com")
 gmail.send("alice@example.com", "Report", "See attached.")
+
+draft = gmail.create_draft("alice@example.com", "Report", "Please review.")
+gmail.add_draft_attachment(draft["id"], "report.pdf")
+gmail.get_draft(draft["id"])
 ```
 
 ## Troubleshooting
 
 - **"Google account not connected"** → run `co auth google`.
 - **Missing Gmail scopes** → run `co auth google` again to re-consent.
+- **`No draft #N in your last draft listing`** → run
+  `co gmail draft list` and use a current number.
+- **`Draft has no attachment #N`** → run `co gmail draft preview <draft>` and
+  use the current manifest number.
+- **A Drive link opens as access denied for the recipient** → change sharing in
+  Drive yourself, or attach the file bytes with `--drive` instead of `--link`.
 - **`No email #N in your last listing`** → the number is out of range or the
   listing changed; run `co gmail` to refresh the numbering.
 - **Credentials found in one project but not another** → fixed in 1.3.1;

--- a/docs/design-decisions/064-gmail-draft-attachments.md
+++ b/docs/design-decisions/064-gmail-draft-attachments.md
@@ -1,0 +1,79 @@
+# 064 — Gmail draft attachments are provider-native and review-gated
+
+## Status
+
+Accepted for ConnectOnion 1.8.2.
+
+## Problem
+
+`co gmail send --attach` sends immediately. That is useful for automation but
+is a poor interaction for assembling a message from several local and Drive
+files: a person cannot inspect the final manifest, correct one attachment, or
+abort after seeing the composed result.
+
+## Decision
+
+Expose a visible nested `co gmail draft` group with seven verbs: `list`,
+`create`, `attach`, `remove`, `replace`, `preview`, and `send`.
+
+Gmail's provider draft is the source of truth. The implementation reads its raw
+RFC 5322 message, edits MIME parts, and replaces the draft through Gmail's
+draft-update endpoint. It does not keep a second local draft manifest that can
+drift from Gmail. The Gmail draft ID remains stable across updates.
+
+Local files use the existing regular-file, symlink, and 25 MB attachment
+guards. A Drive file is downloaded or exported into bounded memory and inserted
+directly into the MIME draft; no temporary copy is written and the Drive item
+is not changed. `--drive --link` appends the file's web URL and explicitly does
+not modify Drive sharing.
+
+Only `co gmail draft send` sends. It prints recipients, body, and the final
+attachment manifest, then asks for confirmation with a default of no. It has no
+non-interactive bypass. Declining leaves the Gmail draft intact. Draft sending
+is private in the Python tool so an agent cannot bypass the CLI's review gate.
+
+## CLI contract review
+
+The project CLI design guide led to these interface choices:
+
+- the workflow is discoverable in `co gmail --help` rather than hidden in flags;
+- the CLI routing table and matching `co-mail-and-drive` skill name the same
+  seven commands;
+- every successful or guarded-failure path prints a literal next command, and
+  that tip remains in non-terminal output;
+- numbers resolve only through the last matching listing cache, while a full
+  provider ID remains valid;
+- guarded failures exit `1`; Typer syntax failures exit `2`;
+- send confirmation cannot be bypassed by a convenience flag.
+
+## Alternatives rejected
+
+- **Only add more flags to immediate `gmail send`.** This leaves no stable
+  object to preview or correct before delivery.
+- **Keep the draft manifest locally.** Two sources of truth can disagree after
+  Gmail web or another client edits the draft.
+- **Download Drive files to a temporary path.** The CLI needs bytes, not a
+  user-visible copy; bounded in-memory transfer reduces residue.
+- **Offer `draft send --yes`.** That would turn the review gate into an optional
+  convention and make accidental agent-driven delivery easier.
+
+## API contract
+
+This design uses Gmail `users.drafts.list`, `get`, `create`, `update`, and
+`send`, plus Drive `files.get` media downloads or `files.export` for supported
+Google-native documents. Gmail draft updates replace the whole message, so
+each edit starts from the latest provider copy.
+
+References:
+
+- <https://developers.google.com/workspace/gmail/api/guides/drafts>
+- <https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.drafts>
+- <https://developers.google.com/workspace/drive/api/guides/manage-downloads>
+
+## Security and operational limits
+
+The CLI reuses the standard Google session and never prints token values or raw
+provider error bodies. Gmail draft writes require a token with `gmail.modify`,
+`gmail.compose`, or full Gmail scope. The shipped OAuth flow grants
+`gmail.modify`. Drive links can still fail for recipients who lack access;
+users must change sharing themselves or attach the bytes instead.

--- a/docs/design-decisions/064-google-cli-audit.md
+++ b/docs/design-decisions/064-google-cli-audit.md
@@ -1,0 +1,82 @@
+# Gmail and Drive CLI audit — 2026-09-05
+
+Scope: all Gmail commands, its draft group, and all Drive commands. Outlook and
+agent-mail are not included. Method: `cli-skill-design`, with the `co-browser`
+worked example. Providers are mocked for all mutations in this audit.
+
+The audit adds missing terminal/piped tips, clears stale numbers on empty
+listings, uses resolved IDs in reply tips, and sanitizes provider/network errors.
+Drive TSV gains a fifth row-number column; existing column positions remain.
+Connection failures after writes point to inspection rather than repeat writes.
+
+## Reproduce
+
+```bash
+python -m pytest tests/unit/test_google_cli_design.py tests/unit/test_gmail.py tests/unit/test_gmail_commands.py tests/unit/test_gdrive.py tests/unit/test_gdrive_commands.py tests/e2e/cli/test_cli_gmail.py tests/e2e/cli/test_cli_gdrive.py -q
+PYTHONPATH=. python tests/unit/test_google_cli_design.py | cat
+PYTHONPATH=. python tests/unit/test_google_cli_design.py --tip-test
+```
+
+Focused suite: **277 passed**. The pipe run prints each command's captured CLI
+output, including its next-step tip. Provider methods are mocked; Gmail listing
+formatting uses the real formatter. Cache files live in a temporary directory.
+
+## Help / SKILL parity
+
+The automated check compares actual visible command registrations with every
+command mentioned in the matching skill, and verifies each appears in help.
+
+| Group | CLI and SKILL set | Difference |
+|---|---|---|
+| Gmail | draft, inbox, read, reply, search, send, sent | none |
+| Gmail draft | attach, create, list, preview, remove, replace, send | none |
+| Drive | get, list, put, rm, search | none |
+
+## Output-only tip tests
+
+Fresh text-only `llm_do` calls, pinned to `co/gemini-3.7-flash`. Input is captured
+command output and the goal only. Model replies are graded, never executed.
+All 20 command paths passed; quotes around `Thanks` are equivalent shell syntax.
+
+| Command | Tip command | Goal | Reply | Pass |
+|---|---|---|---|---|
+| gmail | `co gmail read <#>` | read first email | `co gmail read 1` | yes |
+| gmail inbox | `co gmail read <#>` | read first email | `co gmail read 1` | yes |
+| gmail search | `co gmail read <#>` | read first match | `co gmail read 1` | yes |
+| gmail read | `co gmail reply msg-a <message>` | reply Thanks | `co gmail reply msg-a "Thanks"` | yes |
+| gmail reply | `co gmail sent` | check sent mail | `co gmail sent` | yes |
+| gmail send | `co gmail sent` | check sent mail | `co gmail sent` | yes |
+| gmail sent | `co gmail search in:sent` | find sent messages to read | `co gmail search in:sent` | yes |
+| gmail draft list | `co gmail draft preview <# from this listing>` | preview first draft | `co gmail draft preview 1` | yes |
+| gmail draft create | `co gmail draft attach draft-a <path>` | attach report.pdf | `co gmail draft attach draft-a report.pdf` | yes |
+| gmail draft attach | `co gmail draft preview draft-a` | preview staged draft | `co gmail draft preview draft-a` | yes |
+| gmail draft remove | `co gmail draft preview draft-a` | preview updated draft | `co gmail draft preview draft-a` | yes |
+| gmail draft replace | `co gmail draft preview draft-a` | preview updated draft | `co gmail draft preview draft-a` | yes |
+| gmail draft preview | `co gmail draft send draft-a` | proceed to confirmation gate | `co gmail draft send draft-a` | yes |
+| gmail draft send (declined) | `co gmail draft preview draft-a` | inspect kept draft | `co gmail draft preview draft-a` | yes |
+| gdrive | `co gdrive get <# from column 5>` | download first file | `co gdrive get 1` | yes |
+| gdrive list | `co gdrive get <# from column 5>` | download first file | `co gdrive get 1` | yes |
+| gdrive search | `co gdrive get <# from column 5>` | download first match | `co gdrive get 1` | yes |
+| gdrive get | `co gdrive list` | show more files | `co gdrive list` | yes |
+| gdrive put | `co gdrive list` | check uploads | `co gdrive list` | yes |
+| gdrive rm | `co gdrive list` | show remaining files | `co gdrive list` | yes |
+
+## Exit reproductions
+
+All rows use the same isolated CLI runner, with mocked provider outcomes.
+The usage errors come from the real command parser.
+
+| Exit | Provoked by | Cause printed | Next command |
+|---|---|---|---|
+| 0 | gmail inbox | one numbered message | `co gmail read <#>` |
+| 0 | gdrive list | one TSV row with row number | `co gdrive get <# from column 5>` |
+| 1 | gmail inbox, injected HTTP 403 | Google request failed (HTTP 403) | `co auth google` |
+| 1 | gdrive list, injected OSError | local I/O or Google connection failed | `co gdrive list` |
+| 1 | gmail draft send, answer n | not sent, draft kept | `co gmail draft preview draft-a` |
+| 2 | gmail read, missing ID | Missing argument email_id | `co gmail read --help` |
+| 2 | gdrive get, missing ID | Missing argument file_id | `co gdrive get --help` |
+
+The regression suite also injects lost responses into Gmail send/reply and
+Drive upload and verifies the recovery command inspects provider state.
+No live send, upload, trash, or download was performed by this expanded audit.
+The earlier disposable-draft acceptance is described separately in the PR.

--- a/docs/integrations/google.md
+++ b/docs/integrations/google.md
@@ -1,6 +1,6 @@
 # Google Integration (co auth google)
 
-> Send emails via Gmail and read calendar events from your AI agents. 30-second setup.
+> Work with Gmail, Google Calendar, and Google Drive from ConnectOnion.
 
 ---
 
@@ -13,11 +13,11 @@ co auth google
 What happens:
 1. Clears any existing Google connection (allows switching accounts)
 2. Opens browser to Google OAuth consent screen
-3. You authorize Gmail Send + Calendar Read permissions
+3. You authorize the Gmail, Calendar, and Drive permissions used by the tools
 4. Credentials saved to `.env` (both local and global `~/.co/keys.env`)
 5. Ready to use Gmail and Calendar tools immediately
 
-**That's it.** Your agents can now send emails and read your calendar.
+**That's it.** Your agents can now work with Gmail, Calendar, and Drive.
 
 **Switching accounts?** Just run `co auth google` again - it will clear the old connection and let you pick a new Google account.
 
@@ -37,16 +37,10 @@ This creates your `OPENONION_API_KEY` which is required for Google OAuth to work
 
 ## What Gets Saved
 
-After successful authentication, your `.env` file contains:
-
-```bash
-# Google OAuth Credentials
-GOOGLE_ACCESS_TOKEN=ya29.a0A...
-GOOGLE_REFRESH_TOKEN=1//0g...
-GOOGLE_TOKEN_EXPIRES_AT=2025-12-31T23:59:59
-GOOGLE_SCOPES=gmail.send,calendar.readonly
-GOOGLE_EMAIL=your.email@gmail.com
-```
+After successful authentication, ConnectOnion saves the Google account email,
+granted scopes, access token, refresh token, and expiry. Treat both credential
+files as secrets; use `co status` to check the connection rather than
+printing either file.
 
 **Security notes:**
 - Credentials are saved to both local `.env` and `~/.co/keys.env`
@@ -62,14 +56,16 @@ When you run `co auth google`, we request these Google scopes:
 
 | Scope | Purpose | What agents can do |
 |-------|---------|-------------------|
-| `gmail.send` | Send emails on your behalf | Use `send_email()` tool to send emails |
-| `calendar.readonly` | Read calendar events | Read your calendar to check availability |
-| `userinfo.email` | Get your email address | Identify which Google account is connected |
+| `gmail.send` | Send email | Send a direct message or confirmed Gmail draft |
+| `gmail.readonly` | Read Gmail | List, search, and inspect messages and drafts |
+| `gmail.modify` | Modify Gmail | Mark messages, reply, and create/edit drafts |
+| `calendar` | Work with Calendar | Read and manage calendar events |
+| `drive` | Work with Drive | List, read, upload, and trash Drive files |
+| `userinfo.email`, `userinfo.profile` | Account identity | Identify the connected Google account |
 
-**Privacy**: We only request the minimum permissions needed. We cannot:
-- Read your inbox (use built-in `get_emails()` for that)
-- Delete or modify calendar events
-- Access your Google Drive or other services
+These are broad account permissions. Only connect an account whose Gmail,
+Calendar, and Drive data you intend ConnectOnion to access. Draft attachment
+commands read Drive content but do not change Drive files or sharing.
 
 ---
 
@@ -183,14 +179,10 @@ co auth google
 
 ### Credentials Not Working
 
-Check if credentials are properly saved:
+Check the connection without printing credentials:
 
 ```bash
-# Check local .env
-cat .env | grep GOOGLE_
-
-# Check global keys
-cat ~/.co/keys.env | grep GOOGLE_
+co status
 ```
 
 If credentials exist but don't work, re-authenticate:
@@ -225,14 +217,8 @@ To disconnect your Google account:
    - Visit https://o.openonion.ai
    - Click "Disconnect Google Account"
 
-3. Manually remove credentials:
-   ```bash
-   # Remove from local .env
-   sed -i '' '/^GOOGLE_/d' .env
-
-   # Remove from global keys
-   sed -i '' '/^GOOGLE_/d' ~/.co/keys.env
-   ```
+3. Remove the Google connection from the OpenOnion dashboard and revoke it in
+   Google Account Settings. Avoid printing or copying the local token files.
 
 ---
 

--- a/docs/useful_tools/gmail.md
+++ b/docs/useful_tools/gmail.md
@@ -202,6 +202,7 @@ co gmail read 3 --mark-read                         # explicitly mark read
 co gmail send bob@example.com "Hi" "Body text"
 co gmail search "from:alice@example.com is:unread"
 co gmail draft create bob@example.com "Report" "Please review."
+co gmail draft list               # choose the matching row; create prints an ID
 co gmail draft attach 1 report.pdf
 co gmail draft preview 1
 co gmail draft send 1          # previews and asks; there is no --yes

--- a/docs/useful_tools/gmail.md
+++ b/docs/useful_tools/gmail.md
@@ -88,6 +88,35 @@ Your agent can now read and manage Gmail.
 - Agent-facing `Gmail()` instances can attach only files inside the current project; resolved symlinks cannot escape it
 - Attachments have a 25 MB combined limit, enforced before file contents are read
 
+### Drafts
+
+Draft methods edit provider-native Gmail drafts and never send them. The
+terminal's separate `co gmail draft send` command performs the final preview
+and confirmation; draft sending is intentionally not exposed as a public agent
+method.
+
+**`list_drafts(last=20)`**
+- List draft IDs, recipients, subjects, and attachment counts
+
+**`create_draft(to, subject, body, cc=None, bcc=None)`**
+- Create and return an unsent draft
+
+**`get_draft(draft_id)`**
+- Return recipients, body, and the exact attachment manifest
+
+**`add_draft_attachment(draft_id, path)`**
+- Stage a local project file; the draft remains unsent
+- Uses the same path and 25 MB protections as `send()`
+
+**`add_draft_link(draft_id, name, url)`**
+- Append a link to a plain-text body; this does not change sharing permissions
+
+**`remove_draft_attachment(draft_id, attachment)`**
+- Remove the one-based attachment number from `get_draft()`
+
+**`replace_draft_attachment(draft_id, attachment, path)`**
+- Replace one attachment with a local project file in one draft update
+
 **`mark_read(email_id)`**
 - Mark email as read
 
@@ -172,6 +201,10 @@ co gmail read 3                                     # open #3, preserve unread s
 co gmail read 3 --mark-read                         # explicitly mark read
 co gmail send bob@example.com "Hi" "Body text"
 co gmail search "from:alice@example.com is:unread"
+co gmail draft create bob@example.com "Report" "Please review."
+co gmail draft attach 1 report.pdf
+co gmail draft preview 1
+co gmail draft send 1          # previews and asks; there is no --yes
 ```
 
 ## See Also

--- a/tests/e2e/cli/test_cli_gmail.py
+++ b/tests/e2e/cli/test_cli_gmail.py
@@ -148,8 +148,84 @@ def test_gmail_help_lists_every_subcommand():
     result = runner.invoke(app, ["gmail", "--help"])
 
     assert result.exit_code == 0
-    for command in ["inbox", "read", "reply", "send", "sent", "search"]:
+    for command in ["inbox", "read", "reply", "send", "sent", "search", "draft"]:
         assert command in result.output
+
+
+def test_gmail_draft_help_lists_every_subcommand():
+    result = runner.invoke(app, ["gmail", "draft", "--help"])
+
+    assert result.exit_code == 0
+    for command in ["list", "create", "attach", "remove", "replace", "preview", "send"]:
+        assert command in result.output
+
+
+def test_gmail_draft_list_routes_limit():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_draft_list") as handler:
+        result = runner.invoke(app, ["gmail", "draft", "list", "-n", "7"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(last=7)
+
+
+def test_gmail_draft_create_routes_headers():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_draft_create") as handler:
+        result = runner.invoke(app, [
+            "gmail", "draft", "create", "r@example.com", "Report", "Body",
+            "--cc", "c@example.com", "--bcc", "b@example.com",
+        ])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(
+        "r@example.com", "Report", "Body", cc="c@example.com", bcc="b@example.com"
+    )
+
+
+def test_gmail_draft_attach_routes_drive_link():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_draft_attach") as handler:
+        result = runner.invoke(app, [
+            "gmail", "draft", "attach", "2", "3", "--drive", "--link",
+        ])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("2", "3", drive=True, link=True)
+
+
+def test_gmail_draft_remove_routes_attachment_number():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_draft_remove") as handler:
+        result = runner.invoke(app, ["gmail", "draft", "remove", "2", "1"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("2", 1)
+
+
+def test_gmail_draft_replace_routes_drive_source():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_draft_replace") as handler:
+        result = runner.invoke(app, [
+            "gmail", "draft", "replace", "2", "1", "drive-file", "--drive",
+        ])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("2", 1, "drive-file", drive=True)
+
+
+def test_gmail_draft_preview_routes_id():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_draft_preview") as handler:
+        result = runner.invoke(app, ["gmail", "draft", "preview", "2"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("2")
+
+
+def test_gmail_draft_send_routes_id_without_a_bypass_flag():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_draft_send") as handler:
+        result = runner.invoke(app, ["gmail", "draft", "send", "2"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("2")
+
+    help_result = runner.invoke(app, ["gmail", "draft", "send", "--help"])
+    assert "--yes" not in help_result.output
 
 
 def test_unknown_gmail_subcommand_fails():

--- a/tests/unit/test_gdrive.py
+++ b/tests/unit/test_gdrive.py
@@ -228,7 +228,7 @@ class TestDownload:
 
     def _stub_download(self, monkeypatch, payload=b"filebytes"):
         """Make MediaIoBaseDownload write payload into the buffer in one chunk."""
-        def fake_downloader(buffer, request):
+        def fake_downloader(buffer, request, chunksize=None):
             downloader = MagicMock()
 
             def next_chunk():
@@ -325,6 +325,91 @@ class TestDownload:
             drive_with_service(service).download("file-1", dest=str(target))
 
         assert target.read_bytes() == b"filebytes"
+
+
+class TestReadFileForAttachment:
+    """Drive-to-Gmail reads stay in memory and obey Gmail's byte budget."""
+
+    @staticmethod
+    def _stub_download(monkeypatch, payload=b"filebytes"):
+        def fake_downloader(buffer, request, chunksize=None):
+            downloader = MagicMock()
+
+            def next_chunk():
+                buffer.write(payload)
+                return (None, True)
+
+            downloader.next_chunk.side_effect = next_chunk
+            return downloader
+
+        monkeypatch.setattr("connectonion.useful_tools.gdrive.MediaIoBaseDownload", fake_downloader)
+
+    def test_binary_file_returns_name_type_link_and_bytes(self, monkeypatch):
+        self._stub_download(monkeypatch, b"%PDF")
+        service = MagicMock()
+        service.files.return_value.get.return_value.execute.return_value = file_resource(size="4")
+
+        with patch.dict(os.environ, ENV, clear=False):
+            item = drive_with_service(service)._read_file("file-1", max_bytes=10)
+
+        assert item == {
+            "id": "file-1",
+            "name": "Report.pdf",
+            "type": "application/pdf",
+            "size": 4,
+            "link": "https://drive.google.com/file/d/file-1/view",
+            "data": b"%PDF",
+        }
+        service.files.return_value.get_media.assert_called_once()
+
+    def test_native_doc_is_exported_for_attachment(self, monkeypatch):
+        self._stub_download(monkeypatch, b"# Notes")
+        service = MagicMock()
+        service.files.return_value.get.return_value.execute.return_value = file_resource(
+            name="Notes", mimeType="application/vnd.google-apps.document", size=None,
+        )
+
+        with patch.dict(os.environ, ENV, clear=False):
+            item = drive_with_service(service)._read_file("file-1")
+
+        assert item["name"] == "Notes.md"
+        assert item["type"] == "text/markdown"
+        assert item["data"] == b"# Notes"
+        service.files.return_value.export_media.assert_called_once_with(
+            fileId="file-1", mimeType="text/markdown"
+        )
+
+    def test_known_oversize_is_rejected_before_downloading(self):
+        service = MagicMock()
+        service.files.return_value.get.return_value.execute.return_value = file_resource(size="11")
+
+        with patch.dict(os.environ, ENV, clear=False):
+            with pytest.raises(ValueError, match="attachment limit"):
+                drive_with_service(service)._read_file("file-1", max_bytes=10)
+
+        service.files.return_value.get_media.assert_not_called()
+
+    def test_export_growth_is_rejected_during_download(self, monkeypatch):
+        self._stub_download(monkeypatch, b"123456")
+        service = MagicMock()
+        service.files.return_value.get.return_value.execute.return_value = file_resource(
+            name="Notes", mimeType="application/vnd.google-apps.document", size=None,
+        )
+
+        with patch.dict(os.environ, ENV, clear=False):
+            with pytest.raises(ValueError, match="attachment limit"):
+                drive_with_service(service)._read_file("file-1", max_bytes=5)
+
+    def test_get_file_returns_only_metadata(self):
+        service = MagicMock()
+        service.files.return_value.get.return_value.execute.return_value = file_resource()
+
+        with patch.dict(os.environ, ENV, clear=False):
+            item = drive_with_service(service)._get_file("file-1")
+
+        assert item["link"].startswith("https://drive.google.com/")
+        assert "data" not in item
+        service.files.return_value.get_media.assert_not_called()
 
 
 class TestUploadAndDelete:

--- a/tests/unit/test_gdrive_commands.py
+++ b/tests/unit/test_gdrive_commands.py
@@ -131,7 +131,7 @@ class TestHandleList:
 
         assert "no files" in capsys.readouterr().out
 
-    def test_empty_listing_writes_no_cache(self):
+    def test_empty_listing_clears_numbers(self):
         """An empty listing must not clobber the numbering from the last one."""
         drive = MagicMock()
         drive.list_files.return_value = []
@@ -139,7 +139,7 @@ class TestHandleList:
         with patch.object(gdrive_commands, "_gdrive", return_value=drive):
             handle_gdrive_list()
 
-        assert not gdrive_commands.LIST_CACHE.exists()
+        assert json.loads(gdrive_commands.LIST_CACHE.read_text()) == {}
 
     def test_table_and_cache(self, monkeypatch, capsys):
         monkeypatch.setattr(gdrive_commands, "console", Console(force_terminal=True, width=120))
@@ -168,7 +168,7 @@ class TestHandleList:
         assert "file-1" in output and "file-2" in output
         # Real tabs, not Rich's space-expanded ones — `cut -f4` must work.
         assert output.splitlines()[0].split("\t") == [
-            "Document 1.pdf", "application/pdf", "2048", "file-1",
+            "Document 1.pdf", "application/pdf", "2048", "file-1", "1",
         ]
 
     def test_limit_reaches_the_tool(self):

--- a/tests/unit/test_gmail.py
+++ b/tests/unit/test_gmail.py
@@ -51,7 +51,7 @@ class TestGmailInit:
     """Tests for Gmail initialization and scope validation."""
 
     @patch.dict(os.environ, {
-        "GOOGLE_SCOPES": "gmail.readonly gmail.send",
+        "GOOGLE_SCOPES": "gmail.readonly gmail.send gmail.modify",
         "GOOGLE_ACCESS_TOKEN": "test_token",
         "GOOGLE_REFRESH_TOKEN": "test_refresh"
     })
@@ -1247,6 +1247,9 @@ class TestGmailIntegration:
         assert 'search_emails' in agent.tools
         assert 'send' in agent.tools
         assert 'reply' in agent.tools
+        assert 'create_draft' in agent.tools
+        assert 'add_draft_attachment' in agent.tools
+        assert '_send_draft' not in agent.tools
         assert 'get_labels' in agent.tools
         assert 'get_all_contacts' in agent.tools
         assert 'update_contact' in agent.tools
@@ -1545,3 +1548,209 @@ class TestGmailSendAttachments:
             gmail.send("r@example.com", "S", "B", attachments=[str(huge)])
 
         gmail._get_service.assert_not_called()
+
+
+class TestGmailDraftAttachments:
+    """Draft edits rewrite one raw MIME message and never call messages.send."""
+
+    @staticmethod
+    def _raw(body="Body", attachments=()):
+        import base64
+        from email.message import EmailMessage
+
+        message = EmailMessage()
+        message["To"] = "recipient@example.com"
+        message["Subject"] = "Quarterly report"
+        message.set_content(body)
+        for name, mime_type, data in attachments:
+            main, sub = mime_type.split("/", 1)
+            message.add_attachment(data, maintype=main, subtype=sub, filename=name)
+        return base64.urlsafe_b64encode(message.as_bytes()).decode("ascii")
+
+    @staticmethod
+    def _gmail(service, scopes="gmail.readonly gmail.send gmail.modify drive"):
+        from connectonion.useful_tools.gmail import Gmail
+
+        with patch.dict(os.environ, {"GOOGLE_SCOPES": scopes}):
+            gmail = Gmail(allow_external_attachments=True)
+        gmail._get_service = Mock(return_value=service)
+        return gmail
+
+    @staticmethod
+    def _updated_message(service):
+        from connectonion.useful_tools.gmail import Gmail
+
+        body = service.users().drafts().update.call_args.kwargs["body"]
+        return Gmail._decode_message(body["message"]["raw"])
+
+    def test_draft_write_needs_compose_or_modify_scope(self):
+        service = MagicMock()
+        gmail = self._gmail(service, scopes="gmail.readonly gmail.send")
+
+        with pytest.raises(ValueError, match="co auth google"):
+            gmail.create_draft("r@example.com", "S", "B")
+
+        service.users.assert_not_called()
+
+    def test_create_makes_a_draft_not_a_sent_message(self):
+        service = MagicMock()
+        service.users().drafts().create().execute.return_value = {"id": "draft-1"}
+        gmail = self._gmail(service)
+
+        result = gmail.create_draft("r@example.com", "Subject", "Exact body")
+
+        assert result["id"] == "draft-1"
+        raw = service.users().drafts().create.call_args.kwargs["body"]["message"]["raw"]
+        message = gmail._decode_message(raw)
+        assert message["To"] == "r@example.com"
+        assert message["Subject"] == "Subject"
+        assert message.get_content().strip() == "Exact body"
+        service.users().messages().send.assert_not_called()
+
+    def test_list_fetches_details_and_counts_nested_attachments(self):
+        service = MagicMock()
+        service.users().drafts().list().execute.return_value = {
+            "drafts": [{"id": "draft-1"}]
+        }
+        service.users().drafts().get().execute.return_value = {
+            "message": {
+                "payload": {
+                    "headers": [
+                        {"name": "To", "value": "r@example.com"},
+                        {"name": "Subject", "value": "Report"},
+                    ],
+                    "parts": [{
+                        "mimeType": "multipart/mixed",
+                        "parts": [{"filename": "report.pdf", "body": {"size": 4}}],
+                    }],
+                }
+            }
+        }
+
+        drafts = self._gmail(service).list_drafts(last=5)
+
+        assert drafts == [{
+            "id": "draft-1",
+            "to": "r@example.com",
+            "subject": "Report",
+            "attachments": 1,
+        }]
+        assert service.users().drafts().get.call_args.kwargs["format"] == "full"
+
+    def test_preview_returns_body_and_attachment_manifest(self):
+        service = MagicMock()
+        service.users().drafts().get().execute.return_value = {
+            "message": {"raw": self._raw(attachments=[
+                ("report.pdf", "application/pdf", b"%PDF"),
+            ])}
+        }
+
+        draft = self._gmail(service).get_draft("draft-1")
+
+        assert draft["body"].strip() == "Body"
+        assert draft["attachments"] == [{
+            "name": "report.pdf", "type": "application/pdf", "size": 4,
+        }]
+        assert draft["attachment_size"] == 4
+
+    def test_local_file_is_staged_with_detected_type(self, tmp_path):
+        service = MagicMock()
+        service.users().drafts().get().execute.return_value = {
+            "message": {"raw": self._raw()}
+        }
+        local = tmp_path / "invoice.pdf"
+        local.write_bytes(b"%PDF")
+
+        result = self._gmail(service).add_draft_attachment("draft-1", str(local))
+
+        part = list(self._updated_message(service).iter_attachments())[0]
+        assert part.get_filename() == "invoice.pdf"
+        assert part.get_content_type() == "application/pdf"
+        assert part.get_payload(decode=True) == b"%PDF"
+        assert result["attachment_size"] == 4
+        service.users().messages().send.assert_not_called()
+
+    def test_combined_size_is_checked_before_update(self, tmp_path):
+        from connectonion.useful_tools import gmail as gmail_module
+
+        service = MagicMock()
+        service.users().drafts().get().execute.return_value = {
+            "message": {"raw": self._raw(attachments=[
+                ("old.bin", "application/octet-stream", b"123"),
+            ])}
+        }
+        local = tmp_path / "new.bin"
+        local.write_bytes(b"456")
+
+        with patch.object(gmail_module, "GMAIL_ATTACHMENT_LIMIT", 5):
+            with pytest.raises(ValueError, match="25MB"):
+                self._gmail(service).add_draft_attachment("draft-1", str(local))
+
+        service.users().drafts().update.assert_not_called()
+
+    def test_remove_uses_one_based_preview_number(self):
+        service = MagicMock()
+        service.users().drafts().get().execute.return_value = {
+            "message": {"raw": self._raw(attachments=[
+                ("one.txt", "text/plain", b"1"),
+                ("two.txt", "text/plain", b"2"),
+            ])}
+        }
+
+        result = self._gmail(service).remove_draft_attachment("draft-1", 1)
+
+        assert [item["name"] for item in result["attachments"]] == ["two.txt"]
+        assert [part.get_filename() for part in self._updated_message(service).iter_attachments()] == ["two.txt"]
+
+    def test_missing_attachment_number_does_not_update(self):
+        service = MagicMock()
+        service.users().drafts().get().execute.return_value = {
+            "message": {"raw": self._raw()}
+        }
+
+        with pytest.raises(ValueError, match="#2"):
+            self._gmail(service).remove_draft_attachment("draft-1", 2)
+
+        service.users().drafts().update.assert_not_called()
+
+    def test_replace_is_one_atomic_update(self, tmp_path):
+        service = MagicMock()
+        service.users().drafts().get().execute.return_value = {
+            "message": {"raw": self._raw(attachments=[
+                ("old.txt", "text/plain", b"old"),
+            ])}
+        }
+        local = tmp_path / "new.csv"
+        local.write_bytes(b"a,b")
+
+        result = self._gmail(service).replace_draft_attachment("draft-1", 1, str(local))
+
+        assert result["attachments"] == [{
+            "name": "new.csv", "type": "text/csv", "size": 3,
+        }]
+        service.users().drafts().update.assert_called_once()
+
+    def test_drive_link_changes_plain_body_but_not_attachment_manifest(self):
+        service = MagicMock()
+        service.users().drafts().get().execute.return_value = {
+            "message": {"raw": self._raw(attachments=[
+                ("old.txt", "text/plain", b"old"),
+            ])}
+        }
+
+        result = self._gmail(service).add_draft_link(
+            "draft-1", "Budget", "https://drive.google.com/file/d/1/view"
+        )
+
+        assert "Budget: https://drive.google.com/file/d/1/view" in result["body"]
+        assert [item["name"] for item in result["attachments"]] == ["old.txt"]
+
+    def test_send_draft_uses_drafts_send_only(self):
+        service = MagicMock()
+        service.users().drafts().send().execute.return_value = {"id": "message-1"}
+
+        result = self._gmail(service)._send_draft("draft-1")
+
+        assert result == {"id": "message-1"}
+        assert service.users().drafts().send.call_args.kwargs["body"] == {"id": "draft-1"}
+        service.users().messages().send.assert_not_called()

--- a/tests/unit/test_gmail_commands.py
+++ b/tests/unit/test_gmail_commands.py
@@ -176,15 +176,15 @@ class TestHandleGmailInbox:
 
         assert "no emails" in capsys.readouterr().out
 
-    def test_empty_inbox_writes_no_cache(self, capsys):
-        """An empty listing must not clobber the numbering from the last one."""
+    def test_empty_inbox_clears_numbers(self, capsys):
+        """An empty listing must not retain older rows."""
         gmail = MagicMock()
         gmail.list_inbox.return_value = []
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             handle_gmail_inbox(last=10, unread=True)
 
-        assert not gmail_commands.INBOX_CACHE.exists()
+        assert json.loads(gmail_commands.INBOX_CACHE.read_text()) == {}
         assert "no unread emails" in capsys.readouterr().out
 
     def test_table_and_cache(self, monkeypatch, capsys):
@@ -478,14 +478,14 @@ class TestHandleGmailSendAndSearch:
         gmail.list_search.assert_called_once_with("invoice", max_results=5)
         assert "no emails matching" in capsys.readouterr().out
 
-    def test_search_empty_result_writes_no_cache(self):
+    def test_search_empty_result_clears_numbers(self):
         gmail = MagicMock()
         gmail.list_search.return_value = []
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             handle_gmail_search("invoice", last=5)
 
-        assert not gmail_commands.INBOX_CACHE.exists()
+        assert json.loads(gmail_commands.INBOX_CACHE.read_text()) == {}
 
     def test_search_results_share_the_inbox_numbering_contract(self, monkeypatch, capsys):
         """`co gmail read <#>` after a search must open the search hit."""

--- a/tests/unit/test_gmail_commands.py
+++ b/tests/unit/test_gmail_commands.py
@@ -24,6 +24,13 @@ from connectonion.cli.commands.gmail_commands import (
     _gmail,
     _resolve_email_id,
     _when,
+    handle_gmail_draft_attach,
+    handle_gmail_draft_create,
+    handle_gmail_draft_list,
+    handle_gmail_draft_preview,
+    handle_gmail_draft_remove,
+    handle_gmail_draft_replace,
+    handle_gmail_draft_send,
     handle_gmail_inbox,
     handle_gmail_read,
     handle_gmail_reply,
@@ -62,6 +69,7 @@ def plain(text):
 def _isolate_cache(tmp_path, monkeypatch):
     """Never touch the real ~/.co/gmail_last_inbox.json."""
     monkeypatch.setattr(gmail_commands, "INBOX_CACHE", tmp_path / ".co" / "gmail_last_inbox.json")
+    monkeypatch.setattr(gmail_commands, "DRAFT_CACHE", tmp_path / ".co" / "gmail_last_drafts.json")
 
 
 class TestGmailGuard:
@@ -122,6 +130,15 @@ class TestGmailGuard:
         with patch.dict(os.environ, {**CONNECTED_ENV, "GOOGLE_SCOPES": urls}, clear=False):
             from connectonion.useful_tools.gmail import Gmail
             assert isinstance(_gmail(), Gmail)
+
+    def test_draft_write_without_compose_or_modify_exits_with_fix(self, capsys):
+        with patch.dict(os.environ, READONLY_ENV, clear=False):
+            with pytest.raises(typer.Exit):
+                _gmail(require_draft_write=True)
+
+        output = plain(capsys.readouterr().out)
+        assert "draft permission missing" in output
+        assert "co auth google" in output
 
 
 class TestWhen:
@@ -548,3 +565,213 @@ class TestGmailSendAttachmentChecks:
 
         assert "25MB" in capsys.readouterr().out
         gmail.send.assert_not_called()
+
+
+def sample_draft(**overrides):
+    draft = {
+        "id": "draft-1",
+        "to": "recipient@example.com",
+        "cc": "",
+        "bcc": "",
+        "subject": "Quarterly report",
+        "body": "Exact body\n",
+        "attachments": [{
+            "name": "report.pdf", "type": "application/pdf", "size": 4,
+        }],
+        "attachment_size": 4,
+    }
+    draft.update(overrides)
+    return draft
+
+
+class TestGmailDraftCommands:
+    """The CLI is a staged workflow and every result prints one next command."""
+
+    def test_list_piped_caches_numbers_and_keeps_preview_tip(self, monkeypatch, capsys):
+        monkeypatch.setattr(gmail_commands, "console", Console(force_terminal=False, width=120))
+        gmail = MagicMock()
+        gmail.list_drafts.return_value = [{
+            "id": "draft-1", "to": "r@example.com", "subject": "Report", "attachments": 1,
+        }]
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_draft_list(last=5)
+
+        output = plain(capsys.readouterr().out)
+        assert "1.\tr@example.com" in output
+        assert "draft-1" in output
+        assert "co gmail draft preview <# from this listing>" in output
+        assert json.loads(gmail_commands.DRAFT_CACHE.read_text()) == {"1": "draft-1"}
+
+    def test_empty_list_points_to_create(self, capsys):
+        gmail = MagicMock()
+        gmail.list_drafts.return_value = []
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_draft_list()
+
+        assert "co gmail draft create" in plain(capsys.readouterr().out)
+
+    def test_create_stays_unsent_and_points_to_attach(self, capsys):
+        gmail = MagicMock()
+        gmail.create_draft.return_value = sample_draft()
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_draft_create("r@example.com", "S", "B")
+
+        gmail.create_draft.assert_called_once_with("r@example.com", "S", "B", cc=None, bcc=None)
+        gmail._send_draft.assert_not_called()
+        assert "co gmail draft attach draft-1 <path>" in plain(capsys.readouterr().out)
+
+    def test_create_reads_body_from_stdin(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", io.StringIO("Piped body"))
+        gmail = MagicMock()
+        gmail.create_draft.return_value = sample_draft()
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_draft_create("r@example.com", "S", "-")
+
+        assert gmail.create_draft.call_args.args[2] == "Piped body"
+
+    def test_attach_local_stages_and_points_to_preview(self, capsys):
+        gmail = MagicMock()
+        gmail.add_draft_attachment.return_value = sample_draft()
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_draft_attach("draft-1", "report.pdf")
+
+        gmail.add_draft_attachment.assert_called_once_with("draft-1", "report.pdf")
+        gmail._send_draft.assert_not_called()
+        assert "co gmail draft preview draft-1" in plain(capsys.readouterr().out)
+
+    def test_attach_drive_file_reads_bytes_without_writing_local_file(self, capsys):
+        gmail = MagicMock()
+        gmail._add_draft_attachment.return_value = sample_draft()
+        drive = MagicMock()
+        drive._read_file.return_value = {
+            "name": "Budget.csv", "type": "text/csv", "data": b"a,b",
+        }
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            with patch("connectonion.cli.commands.gdrive_commands._gdrive", return_value=drive):
+                handle_gmail_draft_attach("draft-1", "drive-file", drive=True)
+
+        drive._read_file.assert_called_once()
+        gmail._add_draft_attachment.assert_called_once_with(
+            "draft-1", "Budget.csv", "text/csv", b"a,b"
+        )
+        assert "co gmail draft preview draft-1" in plain(capsys.readouterr().out)
+
+    def test_attach_drive_link_does_not_download_or_change_sharing(self, capsys):
+        gmail = MagicMock()
+        gmail.add_draft_link.return_value = sample_draft(attachments=[], attachment_size=0)
+        drive = MagicMock()
+        drive._get_file.return_value = {
+            "name": "Budget", "link": "https://drive.google.com/file/d/1/view",
+        }
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            with patch("connectonion.cli.commands.gdrive_commands._gdrive", return_value=drive):
+                handle_gmail_draft_attach("draft-1", "drive-file", drive=True, link=True)
+
+        drive._read_file.assert_not_called()
+        gmail.add_draft_link.assert_called_once_with(
+            "draft-1", "Budget", "https://drive.google.com/file/d/1/view"
+        )
+        assert "Drive link added" in plain(capsys.readouterr().out)
+
+    def test_link_without_drive_is_a_fix_it_error(self, capsys):
+        with pytest.raises(typer.Exit):
+            handle_gmail_draft_attach("draft-1", "report.pdf", link=True)
+
+        output = plain(capsys.readouterr().out)
+        assert "--link requires --drive" in output
+        assert "co gmail draft attach draft-1" in output
+
+    def test_remove_points_back_to_preview(self, capsys):
+        gmail = MagicMock()
+        gmail.remove_draft_attachment.return_value = sample_draft(attachments=[], attachment_size=0)
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_draft_remove("draft-1", 1)
+
+        gmail.remove_draft_attachment.assert_called_once_with("draft-1", 1)
+        assert "co gmail draft preview draft-1" in plain(capsys.readouterr().out)
+
+    def test_replace_with_local_file_points_back_to_preview(self, capsys):
+        gmail = MagicMock()
+        gmail.replace_draft_attachment.return_value = sample_draft()
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_draft_replace("draft-1", 1, "new.pdf")
+
+        gmail.replace_draft_attachment.assert_called_once_with("draft-1", 1, "new.pdf")
+        assert "co gmail draft preview draft-1" in plain(capsys.readouterr().out)
+
+    def test_preview_prints_exact_body_manifest_and_send_tip(self, capsys):
+        gmail = MagicMock()
+        gmail.get_draft.return_value = sample_draft()
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_draft_preview("draft-1")
+
+        output = plain(capsys.readouterr().out)
+        assert "Exact body" in output
+        assert "report.pdf (application/pdf, 4 bytes)" in output
+        assert "co gmail draft send draft-1" in output
+
+    def test_send_decline_keeps_draft_and_exits_nonzero(self, capsys):
+        gmail = MagicMock()
+        gmail.get_draft.return_value = sample_draft()
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            with patch.object(typer, "confirm", return_value=False):
+                with pytest.raises(typer.Exit) as exited:
+                    handle_gmail_draft_send("draft-1")
+
+        assert exited.value.exit_code == 1
+        gmail._send_draft.assert_not_called()
+        output = plain(capsys.readouterr().out)
+        assert "Not sent" in output
+        assert "co gmail draft preview draft-1" in output
+
+    def test_send_confirms_after_preview_and_points_to_sent(self, capsys):
+        gmail = MagicMock()
+        gmail.get_draft.return_value = sample_draft()
+        gmail._send_draft.return_value = {"id": "message-1"}
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            with patch.object(typer, "confirm", return_value=True):
+                handle_gmail_draft_send("draft-1")
+
+        output = plain(capsys.readouterr().out)
+        assert "Exact body" in output
+        gmail._send_draft.assert_called_once_with("draft-1")
+        assert "co gmail sent" in output
+
+    def test_unknown_cached_number_points_to_list(self, capsys):
+        gmail_commands.DRAFT_CACHE.parent.mkdir(parents=True)
+        gmail_commands.DRAFT_CACHE.write_text(json.dumps({"1": "draft-1"}))
+
+        with patch.object(gmail_commands, "_gmail", return_value=MagicMock()):
+            with pytest.raises(typer.Exit):
+                handle_gmail_draft_preview("9")
+
+        assert "co gmail draft list" in plain(capsys.readouterr().out)
+
+    def test_provider_permission_error_is_sanitized(self, capsys):
+        from googleapiclient.errors import HttpError
+
+        response = MagicMock(status=403, reason="Forbidden")
+        gmail = MagicMock()
+        gmail.list_drafts.side_effect = HttpError(
+            response, b'{"access_token":"must-not-appear"}'
+        )
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            with pytest.raises(typer.Exit):
+                handle_gmail_draft_list()
+
+        output = plain(capsys.readouterr().out)
+        assert "must-not-appear" not in output
+        assert "co auth google" in output

--- a/tests/unit/test_gmail_commands.py
+++ b/tests/unit/test_gmail_commands.py
@@ -612,6 +612,27 @@ class TestGmailDraftCommands:
 
         assert "co gmail draft create" in plain(capsys.readouterr().out)
 
+    def test_empty_list_invalidates_previous_numbers(self):
+        gmail_commands.DRAFT_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        gmail_commands.DRAFT_CACHE.write_text(json.dumps({"1": "old-draft"}))
+        gmail = MagicMock()
+        gmail.list_drafts.return_value = []
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_draft_list()
+        assert gmail_commands._resolve_draft_id("1") == ""
+
+    @pytest.mark.parametrize("interruption", [typer.Abort, KeyboardInterrupt, EOFError])
+    def test_interrupted_confirmation_keeps_draft_and_prints_tip(self, interruption, capsys):
+        gmail = MagicMock()
+        gmail.get_draft.return_value = sample_draft()
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            with patch.object(typer, "confirm", side_effect=interruption):
+                with pytest.raises(typer.Exit) as exc:
+                    gmail_commands.handle_gmail_draft_send("draft-1")
+        assert exc.value.exit_code == 1
+        gmail._send_draft.assert_not_called()
+        assert "co gmail draft preview draft-1" in plain(capsys.readouterr().out)
+
     def test_create_stays_unsent_and_points_to_attach(self, capsys):
         gmail = MagicMock()
         gmail.create_draft.return_value = sample_draft()

--- a/tests/unit/test_google_cli_design.py
+++ b/tests/unit/test_google_cli_design.py
@@ -1,0 +1,178 @@
+"""Output-only CLI audit. All providers and caches are isolated.
+
+Run as a module file with --tip-test to grade actual captured output with
+llm_do. Without that flag, emit the same output through a pipe for inspection.
+No selected model command is ever executed.
+"""
+import json
+import os
+import re
+import sys
+import tempfile
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.console import Console
+from typer.testing import CliRunner
+from typer.main import get_command
+
+from connectonion.cli.main import app
+from connectonion.cli.commands import gmail_commands as gm, gdrive_commands as gd
+
+
+CASES = [
+    (['gmail'], 'Read the first listed email', 'co gmail read 1'),
+    (['gmail', 'inbox'], 'Read the first listed email', 'co gmail read 1'),
+    (['gmail', 'search', 'test'], 'Read the first matching email', 'co gmail read 1'),
+    (['gmail', 'read', 'msg-a'], 'Reply with body Thanks', 'co gmail reply msg-a Thanks'),
+    (['gmail', 'reply', 'msg-a', 'Thanks'], 'Check sent mail', 'co gmail sent'),
+    (['gmail', 'send', 'a@example.invalid', 'Test', 'Hello'], 'Check sent mail', 'co gmail sent'),
+    (['gmail', 'sent'], 'Find sent messages to read', 'co gmail search in:sent'),
+    (['gmail', 'draft', 'list'], 'Preview the first listed draft', 'co gmail draft preview 1'),
+    (['gmail', 'draft', 'create', 'a@example.invalid', 'Test', 'Hello'], 'Attach report.pdf', 'co gmail draft attach draft-a report.pdf'),
+    (['gmail', 'draft', 'attach', 'draft-a', 'report.pdf'], 'Preview the staged draft', 'co gmail draft preview draft-a'),
+    (['gmail', 'draft', 'remove', 'draft-a', '1'], 'Preview the updated draft', 'co gmail draft preview draft-a'),
+    (['gmail', 'draft', 'replace', 'draft-a', '1', 'report.pdf'], 'Preview the updated draft', 'co gmail draft preview draft-a'),
+    (['gmail', 'draft', 'preview', 'draft-a'], 'Proceed to the confirmation gate', 'co gmail draft send draft-a'),
+    (['gmail', 'draft', 'send', 'draft-a'], 'Inspect the kept draft', 'co gmail draft preview draft-a'),
+    (['gdrive'], 'Download the first listed file', 'co gdrive get 1'),
+    (['gdrive', 'list'], 'Download the first listed file', 'co gdrive get 1'),
+    (['gdrive', 'search', 'Report'], 'Download the first matching file', 'co gdrive get 1'),
+    (['gdrive', 'get', 'file-a'], 'Show more files', 'co gdrive list'),
+    (['gdrive', 'put', 'report.pdf'], 'Check uploaded files', 'co gdrive list'),
+    (['gdrive', 'rm', 'file-a'], 'Show remaining files', 'co gdrive list'),
+]
+
+
+@pytest.mark.parametrize('path', [('gmail',), ('gmail', 'draft'), ('gdrive',)])
+def test_help_and_skill_parity(path):
+    command = get_command(app)
+    for name in path:
+        command = command.commands[name]
+    visible = {name for name, child in command.commands.items() if not child.hidden}
+    skill = (Path(__file__).resolve().parents[2] / 'connectonion/useful_skills/co-mail-and-drive/SKILL.md').read_text()
+    documented = set(re.findall(r'co ' + ' '.join(path) + r' ([a-z-]+)', skill))
+    result = CliRunner().invoke(app, [*path, '--help'])
+    assert result.exit_code == 0
+    assert visible == documented
+    assert all(re.search(r'\b' + name + r'\b', result.output) for name in visible)
+
+
+def capture(args, root, failure=None):
+    gmail, drive = MagicMock(), MagicMock()
+    email = dict(id='msg-a', **{'from': 'a@example.invalid'}, subject='Test',
+                 date='Sat, 05 Sep 2026 10:00:00 +0000', unread=False, snippet='Hello')
+    gmail.list_inbox.return_value = gmail.list_search.return_value = [email]
+    from connectonion.useful_tools.gmail import Gmail
+    gmail._format_dicts.side_effect = lambda emails: Gmail._format_dicts(gmail, emails)
+    gmail.get_email_body.return_value = 'From: a@example.invalid\n--- Email Body ---\nHello'
+    gmail.get_sent_emails.return_value = '1. ID: sent-a, Subject: Test'
+    draft = dict(id='draft-a', to='a@example.invalid', subject='Test', body='Hello',
+                 attachments=[], attachment_size=0)
+    gmail.list_drafts.return_value = [dict(draft, attachments=0)]
+    for name in ('create_draft', 'get_draft', 'add_draft_attachment',
+                 'remove_draft_attachment', 'replace_draft_attachment'):
+        getattr(gmail, name).return_value = draft
+    drive.list_files.return_value = drive.search_files.return_value = [
+        dict(id='file-a', name='Report.pdf', type='application/pdf', size=5, modified='')]
+    drive.download.return_value = 'Downloaded to report.pdf'
+    drive.upload.return_value = dict(name='Report.pdf', link='')
+    if failure is not None:
+        gmail.list_inbox.side_effect = drive.list_files.side_effect = failure
+        gmail.send.side_effect = gmail.reply.side_effect = drive.upload.side_effect = failure
+    with ExitStack() as stack:
+        stack.enter_context(patch.dict(os.environ, {'GOOGLE_EMAIL': 'sender@example.invalid'}))
+        for module, name, value in ((gm, '_gmail', lambda **kw: gmail),
+                                    (gd, '_gdrive', lambda: drive),
+                                    (gm, 'INBOX_CACHE', root / 'inbox.json'),
+                                    (gm, 'DRAFT_CACHE', root / 'drafts.json'),
+                                    (gd, 'LIST_CACHE', root / 'drive.json')):
+            stack.enter_context(patch.object(module, name, value))
+        stack.enter_context(patch.object(gm, 'console', Console(force_terminal=False, width=200)))
+        stack.enter_context(patch.object(gd, 'console', Console(force_terminal=False, width=200)))
+        stack.enter_context(patch.object(Path, 'is_file', return_value=True))
+        return CliRunner().invoke(app, args, input='n\n', prog_name='co')
+
+
+@pytest.mark.parametrize('args,goal,expected', CASES)
+def test_every_command_emits_a_piped_tip(args, goal, expected, tmp_path):
+    result = capture(args, tmp_path)
+    assert result.exit_code == (1 if args[:3] == ['gmail', 'draft', 'send'] else 0), result.output
+    assert 'co ' in result.output.strip().splitlines()[-1]
+
+
+@pytest.mark.parametrize('surface', ['gmail', 'gdrive'])
+def test_provider_error_is_safe_and_actionable(surface, tmp_path):
+    from googleapiclient.errors import HttpError
+    from httplib2 import Response
+    error = HttpError(Response({'status': '403'}), b'PRIVATE_PROVIDER_BODY')
+    result = capture([surface], tmp_path, error)
+    assert result.exit_code == 1
+    assert 'PRIVATE_PROVIDER_BODY' not in result.output
+    assert 'HTTP 403' in result.output and 'co auth google' in result.output
+
+
+@pytest.mark.parametrize('surface', ['gmail', 'gdrive'])
+def test_network_error_is_safe_and_actionable(surface, tmp_path):
+    result = capture([surface], tmp_path, OSError('PRIVATE_ERROR'))
+    assert result.exit_code == 1
+    assert 'PRIVATE_ERROR' not in result.output
+    assert 'Next: co ' in result.output
+
+
+@pytest.mark.parametrize('args,next_command', [
+    (['gmail', 'send', 'a@example.invalid', 'Test', 'Hello'], 'co gmail sent'),
+    (['gmail', 'reply', 'msg-a', 'Thanks'], 'co gmail sent'),
+    (['gdrive', 'put', 'report.pdf'], 'co gdrive list'),
+])
+def test_ambiguous_writes_point_to_inspection(args, next_command, tmp_path):
+    result = capture(args, tmp_path, OSError('lost response'))
+    assert result.exit_code == 1
+    assert 'may have completed' in result.output
+    assert result.output.strip().endswith(next_command)
+
+
+@pytest.mark.parametrize('module,cache,handler,args,method', [
+    (gm, 'INBOX_CACHE', gm.handle_gmail_inbox, (), 'list_inbox'),
+    (gm, 'INBOX_CACHE', gm.handle_gmail_search, ('missing',), 'list_search'),
+    (gd, 'LIST_CACHE', gd.handle_gdrive_list, (), 'list_files'),
+    (gd, 'LIST_CACHE', gd.handle_gdrive_search, ('missing',), 'search_files'),
+])
+def test_empty_listing_cannot_reuse_old_row(module, cache, handler, args, method, tmp_path):
+    path = tmp_path / 'cache.json'
+    path.write_text(json.dumps({'1': 'old-id'}))
+    client = MagicMock()
+    getattr(client, method).return_value = []
+    with patch.object(module, cache, path), patch.object(module, '_gmail' if module is gm else '_gdrive', return_value=client):
+        handler(*args)
+        resolved = gm._resolve_email_id(client, '1') if module is gm else gd._resolve_file_id('1')
+        assert resolved == ''
+
+
+@pytest.mark.parametrize('surface,subcommand', [('gmail', 'read'), ('gdrive', 'get')])
+def test_usage_error_names_help(surface, subcommand, tmp_path):
+    result = capture([surface, subcommand], tmp_path)
+    assert result.exit_code == 2
+    assert f' {surface} {subcommand} --help' in result.output
+
+
+if __name__ == '__main__':
+    import shlex
+    with tempfile.TemporaryDirectory(prefix='google-cli-audit-') as directory:
+        for args, goal, expected in CASES:
+            result = capture(args, Path(directory))
+            if '--tip-test' in sys.argv:
+                from connectonion import llm_do
+                reply = llm_do(
+                    f'You just ran a shell command. Its full output was:\n\n{result.output}\n\n'
+                    f'Your goal: {goal}. Reply with ONE shell command and nothing else.',
+                    model='co/gemini-3.7-flash',
+                ).strip()
+                passed = shlex.split(reply) == shlex.split(expected)
+                print(json.dumps(dict(command='co ' + ' '.join(args), tip=result.output.strip().splitlines()[-1],
+                                      goal=goal, reply=reply, passed=passed)), flush=True)
+            else:
+                print('COMMAND: co ' + ' '.join(args))
+                print(result.output)


### PR DESCRIPTION
## Summary

Gmail and Drive commands now provide actionable next steps in terminal and piped output, with safe recovery after provider errors. Gmail drafts add a staged attachment workflow with mandatory confirmation before sending.

- add a visible, provider-native `co gmail draft` workflow for listing, creating, attaching, removing, replacing, previewing, and confirmation-gated sending
- stage local files or bounded in-memory Drive downloads/exports; `--drive --link` appends the existing URL without changing Drive sharing
- keep draft sending private to the CLI gate, sanitize provider errors, preserve literal next-command tips in non-terminal output, and document the 1.8.2 contract

Target release: **1.8.2**.

## Safety contract

- create/attach/remove/replace/preview never send
- `co gmail draft send` always prints recipients, body, and the exact attachment manifest, then prompts with default **no**
- there is no `--yes` or other confirmation bypass
- agent tool extraction can expose draft creation/editing but cannot expose the private `_send_draft` method
- local files retain the regular-file/symlink checks and combined 25 MB limit
- Drive bytes are bounded in memory; no temporary local copy is written
- Drive links do not mutate content or sharing
- token values and raw provider error bodies are never printed

## Routing table

| Intent | Command |
|---|---|
| list drafts | `co gmail draft list` |
| create an unsent draft | `co gmail draft create <to> <subject> <message>` |
| stage local bytes | `co gmail draft attach <draft> <path>` |
| stage Drive bytes/export | `co gmail draft attach <draft> <file> --drive` |
| append a Drive URL | `co gmail draft attach <draft> <file> --drive --link` |
| remove an attachment | `co gmail draft remove <draft> <attachment#>` |
| replace an attachment | `co gmail draft replace <draft> <attachment#> <source> [--drive]` |
| inspect the final message | `co gmail draft preview <draft>` |
| preview, confirm, send | `co gmail draft send <draft>` |

## CLI design review

The `cli-skill-design` review rejected hiding attachment state in direct-send flags or a second local manifest. A nested group makes the workflow visible in help, while Gmail remains the single source of truth. The review also drove stable listing caches, literal one-step tips, nonzero guarded failures, provider-safe error output, and removal of any non-interactive send bypass.

### Help / skill parity

Both directions produced the same sorted set (empty diff):

```text
attach
create
list
preview
remove
replace
send
```

The matching skill is `connectonion/useful_skills/co-mail-and-drive/SKILL.md`.

### Per-command tip test

Each case gave a fresh text-only `llm_do` call the synthetic command output and goal, with model pinned to `co/gemini-3.7-flash`. The first list attempt exposed that piped rows lacked numbers (`preview 0`); the output was fixed, its unit test tightened, and the final case rerun.

| command | tip printed | goal | fresh agent replied | pass |
|---|---|---|---|---|
| `list` | `co gmail draft preview <# from this listing>` | preview first row | `co gmail draft preview 1` | yes |
| `create` | `co gmail draft attach r-draft-test <path>` | attach `/tmp/report.pdf` | `co gmail draft attach r-draft-test /tmp/report.pdf` | yes |
| `attach` | `co gmail draft preview r-draft-test` | inspect staged draft | `co gmail draft preview r-draft-test` | yes |
| `remove` | `co gmail draft preview r-draft-test` | inspect after removal | `co gmail draft preview r-draft-test` | yes |
| `replace` | `co gmail draft preview r-draft-test` | inspect replacement | `co gmail draft preview r-draft-test` | yes |
| `preview` | `co gmail draft send r-draft-test` | proceed to review gate | `co gmail draft send r-draft-test` | yes |
| `send` (declined) | `co gmail draft preview r-draft-test` | inspect kept draft | `co gmail draft preview r-draft-test` | yes |

Piping was checked directly. A live non-terminal `draft list -n 1` printed a numbered full-ID row plus the preview tip. A guarded failure run through `| cat` retained its retry command and exit 1.

### Exit / fix-it reproduction

| exit | provoked by | printed cause | next command named |
|---|---|---|---|
| `0` | `co gmail draft list -n 1` | numbered listing | `co gmail draft preview <# from this listing>` |
| `1` | `co gmail draft attach r-example report.pdf --link` | `--link requires --drive` | full retry with `--drive --link` |
| `1` | `co gmail draft send 1`, answered `n` | not sent; draft kept | `co gmail draft preview <id>` |
| `2` | `co gmail draft attach` | missing `draft_id` | `co gmail draft attach --help` |

## Verification

Focused unit/e2e suite after rebasing onto current `origin/main`:

```text
277 passed in 1.06s
```

Command:

```text
python -m pytest tests/unit/test_gmail.py tests/unit/test_gmail_commands.py tests/unit/test_gdrive.py tests/unit/test_gdrive_commands.py tests/e2e/cli/test_cli_gmail.py tests/e2e/cli/test_cli_gdrive.py -q
```

Complete local suite:

```text
7967 passed, 21 skipped, 12 failed, 182 deselected in 262.21s
```

The same exact 12 failures reproduce when only those tests are run from a clean detached `origin/main` worktree: one stale global `co` entry point, one locally installed Onionwright `Artifact` contract mismatch, and ten wheel checks whose child venv cannot import the globally absent existing `python-dotenv` dependency. No Gmail/Drive test failed. Merge remains gated on green PR CI.

Additional checks:

- `git diff origin/main...HEAD --check`
- Python compile check for the four changed source modules
- CLI help exposes all seven commands and `draft send --help` has no `--yes`
- repository docs, tool docs, OAuth scope docs, matching skill, and design decision 064 updated
- `mkdocs build --strict` was not available in the existing environment (`No module named mkdocs`)
- no separate `docs-site` checkout exists in this workspace, so it was not updated

## Safe live acceptance

Used only the standard existing local Google session; no credential file or token value was read, copied, or printed.

- `co status`
- Gmail draft list and Gmail metadata search
- Drive metadata list and search only (no Drive content read or mutation)
- created a synthetic draft addressed to `acceptance@example.invalid`
- attached local fixture A, previewed it, atomically replaced it with fixture B, previewed it, removed it, and previewed the empty final manifest
- invoked `draft send`, inspected the final preview, answered `n`, and recorded exit 1
- confirmed no email was sent, deleted the exact synthetic draft after acceptance, removed the local fixtures, and refreshed the draft numbering cache

No email was sent. No Drive file or sharing setting was modified.


# Gmail and Drive CLI audit — 2026-09-05

Scope: all Gmail commands, its draft group, and all Drive commands. Outlook and
agent-mail are not included. Method: `cli-skill-design`, with the `co-browser`
worked example. Providers are mocked for all mutations in this audit.

The audit adds missing terminal/piped tips, clears stale numbers on empty
listings, uses resolved IDs in reply tips, and sanitizes provider/network errors.
Drive TSV gains a fifth row-number column; existing column positions remain.
Connection failures after writes point to inspection rather than repeat writes.

## Reproduce

```bash
python -m pytest tests/unit/test_google_cli_design.py tests/unit/test_gmail.py tests/unit/test_gmail_commands.py tests/unit/test_gdrive.py tests/unit/test_gdrive_commands.py tests/e2e/cli/test_cli_gmail.py tests/e2e/cli/test_cli_gdrive.py -q
PYTHONPATH=. python tests/unit/test_google_cli_design.py | cat
PYTHONPATH=. python tests/unit/test_google_cli_design.py --tip-test
```

Focused suite: **277 passed**. The pipe run prints each command's captured CLI
output, including its next-step tip. Provider methods are mocked; Gmail listing
formatting uses the real formatter. Cache files live in a temporary directory.

## Help / SKILL parity

The automated check compares actual visible command registrations with every
command mentioned in the matching skill, and verifies each appears in help.

| Group | CLI and SKILL set | Difference |
|---|---|---|
| Gmail | draft, inbox, read, reply, search, send, sent | none |
| Gmail draft | attach, create, list, preview, remove, replace, send | none |
| Drive | get, list, put, rm, search | none |

## Output-only tip tests

Fresh text-only `llm_do` calls, pinned to `co/gemini-3.7-flash`. Input is captured
command output and the goal only. Model replies are graded, never executed.
All 20 command paths passed; quotes around `Thanks` are equivalent shell syntax.

| Command | Tip command | Goal | Reply | Pass |
|---|---|---|---|---|
| gmail | `co gmail read <#>` | read first email | `co gmail read 1` | yes |
| gmail inbox | `co gmail read <#>` | read first email | `co gmail read 1` | yes |
| gmail search | `co gmail read <#>` | read first match | `co gmail read 1` | yes |
| gmail read | `co gmail reply msg-a <message>` | reply Thanks | `co gmail reply msg-a "Thanks"` | yes |
| gmail reply | `co gmail sent` | check sent mail | `co gmail sent` | yes |
| gmail send | `co gmail sent` | check sent mail | `co gmail sent` | yes |
| gmail sent | `co gmail search in:sent` | find sent messages to read | `co gmail search in:sent` | yes |
| gmail draft list | `co gmail draft preview <# from this listing>` | preview first draft | `co gmail draft preview 1` | yes |
| gmail draft create | `co gmail draft attach draft-a <path>` | attach report.pdf | `co gmail draft attach draft-a report.pdf` | yes |
| gmail draft attach | `co gmail draft preview draft-a` | preview staged draft | `co gmail draft preview draft-a` | yes |
| gmail draft remove | `co gmail draft preview draft-a` | preview updated draft | `co gmail draft preview draft-a` | yes |
| gmail draft replace | `co gmail draft preview draft-a` | preview updated draft | `co gmail draft preview draft-a` | yes |
| gmail draft preview | `co gmail draft send draft-a` | proceed to confirmation gate | `co gmail draft send draft-a` | yes |
| gmail draft send (declined) | `co gmail draft preview draft-a` | inspect kept draft | `co gmail draft preview draft-a` | yes |
| gdrive | `co gdrive get <# from column 5>` | download first file | `co gdrive get 1` | yes |
| gdrive list | `co gdrive get <# from column 5>` | download first file | `co gdrive get 1` | yes |
| gdrive search | `co gdrive get <# from column 5>` | download first match | `co gdrive get 1` | yes |
| gdrive get | `co gdrive list` | show more files | `co gdrive list` | yes |
| gdrive put | `co gdrive list` | check uploads | `co gdrive list` | yes |
| gdrive rm | `co gdrive list` | show remaining files | `co gdrive list` | yes |

## Exit reproductions

All rows use the same isolated CLI runner, with mocked provider outcomes.
The usage errors come from the real command parser.

| Exit | Provoked by | Cause printed | Next command |
|---|---|---|---|
| 0 | gmail inbox | one numbered message | `co gmail read <#>` |
| 0 | gdrive list | one TSV row with row number | `co gdrive get <# from column 5>` |
| 1 | gmail inbox, injected HTTP 403 | Google request failed (HTTP 403) | `co auth google` |
| 1 | gdrive list, injected OSError | local I/O or Google connection failed | `co gdrive list` |
| 1 | gmail draft send, answer n | not sent, draft kept | `co gmail draft preview draft-a` |
| 2 | gmail read, missing ID | Missing argument email_id | `co gmail read --help` |
| 2 | gdrive get, missing ID | Missing argument file_id | `co gdrive get --help` |

The regression suite also injects lost responses into Gmail send/reply and
Drive upload and verifies the recovery command inspects provider state.
No live send, upload, trash, or download was performed by this expanded audit.
The earlier disposable-draft acceptance is described separately in the PR.
