### PR TITLE
fix(ci): require forward-port ledgers only on maintenance branches

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Fixes #(issue number)
 - **Estimated release window:** [e.g. next alpha, next stable, future roadmap, or unknown]
 - **Milestone:** [maintainer assigns the confirmed release milestone]
 - **Why this release:** Explain urgency, dependencies, compatibility, and rollback risk.
-- **Forward-port tracking issue (stable patches only):** [link an open `forward-port-required` issue, for example #123; use N/A for non-patch work]
+- **Forward-port tracking issue (stable patches only):** [maintenance-branch patch: link an open `forward-port-required` issue, for example #123; mainline/feature-stack work: N/A — mainline work]
 
 > The author's target is an estimate. Maintainers confirm the release by applying labels and assigning a milestone.
 
@@ -99,7 +99,7 @@ from connectonion import Agent
 - [ ] This PR ships its dev-blog post under docs/blog/ (or a maintainer applied `no-blog`)
 - [ ] My changes generate no new warnings
 - [ ] Any dependent changes have been merged and published
-- [ ] If this targets a stable patch, its separate `forward-port-required`
+- [ ] If this targets a maintenance-branch patch, its separate `forward-port-required`
       tracker names every active higher line, at minimum the current preview,
       and will remain open until all applicable forward-port PRs merge and pass CI
 - [ ] Every piece of evidence the linked issue's **AI implementation contract**

--- a/.github/workflows/triage-metadata.yml
+++ b/.github/workflows/triage-metadata.yml
@@ -73,7 +73,11 @@ jobs:
 
             const stablePatchTarget = /\bnext patch\b/i.test(target || '') ||
               /\b\d+\.\d+\.[1-9]\d*\b/.test(target || '');
-            if (stablePatchTarget) {
+            // A maintenance line needs a ledger for its higher active lines.
+            // Mainline and feature stacks already deliver toward the newest line.
+            const maintenanceBranch = /^release\/\d+\.\d+(?:\.x)?$/.test(item.base?.ref || '');
+            const mainline = item.base?.ref === context.payload.repository.default_branch;
+            if (stablePatchTarget && maintenanceBranch && !mainline) {
               const issueMatch = (forwardTracker || '').match(/(?:#|\/issues\/)(\d+)\b/);
               if (!issueMatch) {
                 core.setFailed(

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -268,6 +268,14 @@ as a separate reviewed workflow change, not an ad hoc second registry writer.
 
 ### Stable patches move forward
 
+A forward-port tracker is required for patch PRs targeting a maintenance branch
+such as `release/1.7` or `release/1.8`. A patch number alone does not create that
+obligation: PRs targeting the repository's default branch, or feature branches
+stacked toward it, already deliver to the newest line. Those PRs use `N/A —
+mainline work` in the template's tracking field. All PRs still name a proposed
+target version and estimated release window. A change targeting a maintenance
+branch keeps its tracker open until the applicable higher lines have evidence.
+
 A stable patch fixes the oldest supported line first; it must not make the
 newest testable line older in behaviour. Once `X.Y.Z` with `Z > 0` is public,
 each applicable product, test, documentation, migration, and operational fix

--- a/docs/blog/2026-09-07-a-patch-number-does-not-name-a-branch.md
+++ b/docs/blog/2026-09-07-a-patch-number-does-not-name-a-branch.md
@@ -1,21 +1,36 @@
-# A patch number does not name a branch
+# A Patch Number Does Not Name a Branch
 
-The 1.8.4 readiness review found a pull request aimed at `main` failing a
-forward-port check. Its proposed version contained a nonzero patch number, so
-the workflow demanded an open issue promising to carry the change to a higher
-line. But the change was already headed to the newest line. Creating an issue
-would satisfy the expression while making the release ledger less truthful.
+Draft for the 1.8.4 release process.
 
-The original check protected a useful rule. A fix on `release/1.7` must reach
-the active higher lines before that work is considered finished. The mistake
-was treating a version string as the destination branch. We kept the open-issue
-and label checks and narrowed their trigger to maintenance branches. Mainline
-and feature stacks still require a release estimate; they do not invent a
-forward-port obligation. If a future maintenance branch uses another naming
-scheme, the policy and regression fixtures must change together.
+The readiness review reached a strange instruction: before a pull request
+could land on `main`, it needed an issue promising to carry the change forward.
+Forward to where? The change was already aimed at the newest line.
 
-The regression executes the workflow's actual JavaScript with synthetic PR
-events. It covers mainline 1.8.4, preview and stacked work, missing metadata,
-and maintenance trackers that are absent, closed, unlabelled or valid. This is
-a proposed process correction. It does not merge a feature, close an existing
-release ledger, or publish 1.8.4.
+At first this looked like another missing metadata field. Several PRs had
+release estimates in prose that the workflow could not parse. Those needed
+the exact field names. This failure survived that correction. The workflow
+parsed 1.8.4, saw a nonzero patch number, and required a forward-port tracker.
+It never checked the destination branch.
+
+Creating an issue would have made the expression happy. It would also have
+left someone responsible for work with no destination. The rule had a valid
+origin: a fix on an older maintenance line must reach the active newer lines.
+The version string had become a shortcut for deciding whether that situation
+existed, and 1.8.4 on main exposed the difference.
+
+The correction keeps the obligation where there is somewhere to port from:
+a patch aimed at a maintenance branch. Mainline and stacked feature work still
+need their release metadata. A regression runs the actual workflow JavaScript
+with both kinds of destination, including a maintenance PR with a closed or
+unlabelled tracker. Narrowing the trigger must not make those cases disappear.
+
+CI then caught a smaller surprise in the documentation. The release checklist
+scanner interpreted the example branch names `release/1.7` and `release/1.8`
+as files a releaser should edit. It too had collapsed two different meanings
+into one string. The scanner now recognizes that explicit branch-name pattern
+while continuing to check the real release files.
+
+Both failures could have been silenced by changing what the text happened to
+look like. Keeping the distinction in the checks makes the next release easier
+to reason about: a version names the artifact, a branch names where the change
+is going, and a forward-port issue names work that still has a destination.

--- a/docs/blog/2026-09-07-a-patch-number-does-not-name-a-branch.md
+++ b/docs/blog/2026-09-07-a-patch-number-does-not-name-a-branch.md
@@ -1,0 +1,21 @@
+# A patch number does not name a branch
+
+The 1.8.4 readiness review found a pull request aimed at `main` failing a
+forward-port check. Its proposed version contained a nonzero patch number, so
+the workflow demanded an open issue promising to carry the change to a higher
+line. But the change was already headed to the newest line. Creating an issue
+would satisfy the expression while making the release ledger less truthful.
+
+The original check protected a useful rule. A fix on `release/1.7` must reach
+the active higher lines before that work is considered finished. The mistake
+was treating a version string as the destination branch. We kept the open-issue
+and label checks and narrowed their trigger to maintenance branches. Mainline
+and feature stacks still require a release estimate; they do not invent a
+forward-port obligation. If a future maintenance branch uses another naming
+scheme, the policy and regression fixtures must change together.
+
+The regression executes the workflow's actual JavaScript with synthetic PR
+events. It covers mainline 1.8.4, preview and stacked work, missing metadata,
+and maintenance trackers that are absent, closed, unlabelled or valid. This is
+a proposed process correction. It does not merge a feature, close an existing
+release ledger, or publish 1.8.4.

--- a/tests/unit/test_the_release_checklist_names_real_files.py
+++ b/tests/unit/test_the_release_checklist_names_real_files.py
@@ -71,6 +71,8 @@ def _paths_named() -> list:
                 continue
             if token.startswith(("docs-site/", "lib/")):  # the sibling repo
                 continue
+            if re.fullmatch(r"release/\d+\.\d+(?:\.x)?", token):
+                continue  # maintenance Git branch names in the release policy
             if "/" in token or token.endswith((".py", ".md", ".toml", ".json", ".tsx")):
                 found.append(token)
     return found

--- a/tests/unit/test_triage_release_target.py
+++ b/tests/unit/test_triage_release_target.py
@@ -1,0 +1,74 @@
+"""Execute the actual workflow script against mainline and maintenance PR events."""
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run_gate(base, target, tracker=None):
+    workflow = yaml.load((ROOT / '.github/workflows/triage-metadata.yml').read_text(), Loader=yaml.BaseLoader)
+    script = workflow['jobs']['labels-and-release-target']['steps'][0]['with']['script']
+    body = f'**Proposed target version:** {target}\n**Estimated release window:** next stable\n'
+    if tracker:
+        body += '**Forward-port tracking issue (stable patches only):** #200\n'
+    context = {'repo': {'owner': 'example', 'repo': 'sdk'}, 'payload': {
+        'repository': {'default_branch': 'main'},
+        'pull_request': {'number': 1, 'title': 'fix: regression', 'labels': [{'name': 'bug'}],
+                         'body': body, 'base': {'ref': base}},
+    }}
+    node = shutil.which('node')
+    assert node, 'Node is required to execute the GitHub Actions JavaScript regression'
+    harness = '''
+const fs = require('fs');
+const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+const errors = [], calls = [];
+const core = {setFailed: message => errors.push(message), notice: () => {}};
+const github = {rest: {issues: {get: async query => {
+  calls.push(query.issue_number);
+  return {data: input.tracker || {state: 'closed', labels: []}};
+}}}};
+(async () => {
+  await new Function('context', 'github', 'core', 'return (async () => {' + input.script + '})();')(input.context, github, core);
+  process.stdout.write(JSON.stringify({errors, calls}));
+})().catch(error => { process.stderr.write(String(error)); process.exitCode = 1; });
+'''
+    result = subprocess.run([node, '-e', harness], input=json.dumps({'script': script, 'context': context, 'tracker': tracker}),
+                            text=True, capture_output=True, timeout=15)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+@pytest.mark.parametrize('base,target', [('main', '1.8.4'), ('main', 'next patch'),
+                                        ('main', '1.8.4rc1'), ('fix/credential-foundation', '1.8.4')])
+def test_mainline_and_stacked_prs_do_not_invent_a_forward_port(base, target):
+    assert run_gate(base, target) == {'errors': [], 'calls': []}
+
+
+@pytest.mark.parametrize('base', ['release/1.7', 'release/1.8'])
+def test_maintenance_patch_still_requires_a_tracker(base):
+    result = run_gate(base, 'next patch')
+    assert len(result['errors']) == 1
+    assert 'forward-port' in result['errors'][0]
+
+
+def test_valid_open_tracker_satisfies_maintenance_gate():
+    assert run_gate('release/1.7', '1.7.5', {'state': 'open', 'labels': [{'name': 'forward-port-required'}]}) == {'errors': [], 'calls': [200]}
+
+
+@pytest.mark.parametrize('tracker', [{'state': 'closed', 'labels': [{'name': 'forward-port-required'}]},
+                                    {'state': 'open', 'labels': []}])
+def test_closed_or_unlabelled_tracker_still_fails(tracker):
+    result = run_gate('release/1.7', '1.7.5', tracker)
+    assert len(result['errors']) == 1
+    assert result['calls'] == [200]
+
+
+def test_release_fields_remain_required_on_main():
+    result = run_gate('main', 'TBD')
+    assert len(result['errors']) == 1
+    assert 'Proposed target version' in result['errors'][0]


### PR DESCRIPTION
A mainline PR targeting 1.8.4 currently fails unless it invents an open forward-port tracker. The gate infers a maintenance branch from the patch number. This change requires that tracker only for patches targeting `release/X.Y` maintenance branches; default-branch and feature-stack PRs still require release metadata.

Refs #1445. No existing tracking issue is closed and no release action is taken. The current base-branch `pull_request_target` workflow will retain its old behavior until this policy merges; a failing metadata check on this draft is expected, not bypassed.

- **Proposed target version:** 1.8.4
- **Estimated release window:** before the 1.8.4 implementation sequence is merged; no publication date promised
- **Suggested labels:** bug
- **Forward-port tracking issue (stable patches only):** N/A — mainline policy correction

Verification:

```text
python -m pytest tests/unit/test_triage_release_target.py tests/unit/test_github_action_metadata.py -q --tb=short
12 passed

git diff --check
(no errors)
```

The new regression executes the actual workflow JavaScript with synthetic GitHub events, covering mainline, feature stacks, preview versions, required metadata, and absent/closed/unlabelled/valid maintenance trackers. The full runtime suite was not repeated for this CI-only diff.

Policy and template wording are updated together. Design Journal: `docs/blog/2026-09-07-a-patch-number-does-not-name-a-branch.md` (draft). Exact base: `21cdf590cb699b7ebcfc89cd9a85050393625b38`.

Mostly AI-generated with Codex (GPT-6). The main limitation is branch naming: maintenance lines must use the documented `release/X.Y` or `release/X.Y.x` form. No GitHub mutation is executed by the regression harness. Implementation is proposed; merge and release remain pending maintainer review.
