### PR TITLE
fix(gmail): bind row references to account and listing context

### DIFF
--- a/connectonion/cli/commands/gmail_commands.py
+++ b/connectonion/cli/commands/gmail_commands.py
@@ -2,7 +2,7 @@
 Purpose: CLI surface for the user's Gmail mailbox — send, list (inbox/sent), read, reply, and search from the terminal
 LLM-Note:
   Dependencies: imports from [os, sys, json, pathlib, typer, dotenv, rich.console, rich.panel, rich.table, ...useful_tools.gmail.Gmail] | imported by [cli/main.py via handle_gmail_*()] | hits the Gmail API through the Gmail tool
-  Data flow: _gmail() loads GOOGLE_* from the global default or explicit --env-file → Gmail() instance | inbox/search: list_inbox()/list_search() → numbered Rich table (plain ID-bearing text when piped) → saves {#: message_id} to ~/.co/gmail_last_inbox.json | draft list → ~/.co/gmail_last_drafts.json | draft edits parse and replace Gmail's raw MIME message | Drive attachment reads reuse GDrive without writing local files
+  Data flow: _gmail() loads GOOGLE_* from the global default or explicit --env-file → Gmail() instance | inbox/search/sent and drafts → numbered Rich table (full IDs when piped) → immutable account-bound IDs under global gmail-listings/; rows require --listing | draft edits parse and replace Gmail's raw MIME message | Drive attachment reads reuse GDrive without writing local files
   State/Effects: writes Gmail inbox/draft numbering caches under ~/.co | draft commands create/update Gmail drafts, but only draft send can deliver and it always asks for confirmation | read changes mailbox state only with --mark-read | Gmail refreshes expired tokens via oo-api and saves the selected credential record
   Integration: exposes inbox/read/reply/send/sent/search plus draft list/create/attach/remove/replace/preview/send handlers for cli/main.py | presentation mirrors outlook_commands.py | Gmail/Drive API logic lives in useful_tools | requires prior 'co auth google'
   Errors: guarded failures exit 1 with a next command; provider and transport errors are sanitized by google_errors | send/reply connection failures point to sent-mail inspection because delivery may have completed
@@ -19,17 +19,20 @@ from rich.panel import Panel
 from rich.table import Table
 from .google_errors import google_errors
 from .command_tips import print_tip
+from .gmail_listings import save_listing, resolve_reference, ListingError
 
 from ...provider_credentials import resolve_provider_credentials
 
 console = Console()
 
-INBOX_CACHE = Path.home() / ".co" / "gmail_last_inbox.json"
-DRAFT_CACHE = Path.home() / ".co" / "gmail_last_drafts.json"
+from ...environment import global_config_dir
+
+INBOX_CACHE = global_config_dir() / "gmail_last_inbox.json"
+DRAFT_CACHE = global_config_dir() / "gmail_last_drafts.json"
 
 
 def _gmail(require_draft_write: bool = False):
-    """Load GOOGLE_* credentials from .env files and return a Gmail instance. Exits 1 with a hint if not connected."""
+    """Load the selected global or explicit GOOGLE_* record and return a Gmail instance. Exits 1 with a hint if not connected."""
     from ...environment import load_environment
     load_environment()
     from ...provider_credentials import resolve_provider_credentials
@@ -83,16 +86,20 @@ def _when(date: str) -> str:
 
 
 def _print_listing(gmail, emails: list, title: str):
-    """Render emails as a numbered table (or plain ID-bearing text when piped) and cache the numbering for read/reply."""
-    INBOX_CACHE.parent.mkdir(exist_ok=True)
-    INBOX_CACHE.write_text(json.dumps({str(i): e["id"] for i, e in enumerate(emails, 1)}), encoding="utf-8")
+    """Render emails as a numbered table (or plain ID-bearing text when piped) and freeze an account-bound listing for read/reply."""
+    token = save_listing(INBOX_CACHE.parent / "gmail-listings", gmail.get_account_email(),
+                         "messages", [email["id"] for email in emails])
+    print(f"Listing: {token} (expires in 15 minutes; use --listing {token} with a row number)")
+    if not emails:
+        return
+    next_id = emails[0]["id"]
 
     if not console.is_terminal:
         # Scripts and agents get the untruncated format with full message ids —
         # and the same next-step tip: piped callers are exactly the AI audience
         # the tip exists for.
-        console.print(gmail._format_dicts(emails), markup=False, highlight=False)
-        print_tip("Read one with: co gmail read <#>")
+        console.print(gmail._format_dicts(emails), markup=False, highlight=False, soft_wrap=True)
+        print_tip(f"Read one with: co gmail read {next_id}")
         return
 
     table = Table(title=title, show_header=True, header_style="bold cyan")
@@ -107,7 +114,7 @@ def _print_listing(gmail, emails: list, title: str):
 
     console.print()
     console.print(table)
-    print_tip("\n[dim]Read one with:[/dim] [bold]co gmail read <#>[/bold]\n")
+    print_tip(f"Read one with: co gmail read {next_id}")
 
 
 @google_errors("co gmail inbox")
@@ -116,8 +123,7 @@ def handle_gmail_inbox(last: int = 10, unread: bool = False):
     gmail = _gmail()
     emails = gmail.list_inbox(last=last, unread=unread)
     if not emails:
-        INBOX_CACHE.parent.mkdir(exist_ok=True)
-        INBOX_CACHE.write_text("{}", encoding="utf-8")
+        _print_listing(gmail, [], "Gmail")
         scope = "unread " if unread else ""
         console.print(f"\n[cyan]Gmail inbox:[/cyan] no {scope}emails\n")
         print_tip("Search mail: co gmail search <query>")
@@ -125,32 +131,19 @@ def handle_gmail_inbox(last: int = 10, unread: bool = False):
     _print_listing(gmail, emails, f"📬 Gmail — {resolve_provider_credentials('google').get('EMAIL') or ''}")
 
 
-def _resolve_email_id(gmail, email_id: str) -> str:
-    """Turn a listing number into a Gmail message id; full ids pass through. Numbers mean the last listing shown."""
-    cached = json.loads(INBOX_CACHE.read_text(encoding="utf-8")) if INBOX_CACHE.exists() else {}
-    if email_id in cached:
-        return cached[email_id]
-
-    if not (email_id.isascii() and email_id.isdigit() and len(email_id) < 5):
-        return email_id  # full Gmail message id
-
-    if INBOX_CACHE.exists() or int(email_id) < 1:
-        # The user is pointing at their last listing and that number wasn't in
-        # it — fetching a fresh (differently numbered) list would silently open
-        # the wrong email.
-        return ""
-
-    emails = gmail.list_inbox(last=int(email_id))
-    if len(emails) < int(email_id):
-        return ""
-    return emails[int(email_id) - 1]["id"]
+def _resolve_email_id(gmail, email_id: str, listing: str | None = None) -> str:
+    number = email_id.removeprefix('#')
+    if not (number.isascii() and number.isdigit() and len(number) < 5):
+        return email_id
+    return resolve_reference(INBOX_CACHE.parent / "gmail-listings", email_id,
+                             gmail.get_account_email(), "messages", listing)
 
 
 @google_errors("co gmail inbox")
-def handle_gmail_read(email_id: str, mark_read: bool = False):
+def handle_gmail_read(email_id: str, mark_read: bool = False, *, listing: str | None = None):
     """Show one Gmail message; mark it read only with explicit opt-in."""
     gmail = _gmail()
-    resolved = _resolve_email_id(gmail, email_id)
+    resolved = _resolve_email_id(gmail, email_id, listing)
     if not resolved:
         console.print(f"\nNo email #{email_id} in your last listing.", markup=False)
         print_tip("Refresh the listing: co gmail inbox")
@@ -168,25 +161,24 @@ def handle_gmail_read(email_id: str, mark_read: bool = False):
     console.print(content.strip() or "[dim](empty body)[/dim]", markup=False, highlight=False)
 
     marked = "Unread state unchanged. "
-    if mark_read and "gmail.modify" in os.getenv("GOOGLE_SCOPES", ""):
-        # Marking read is a mailbox write — the API rejects it on tokens that
-        # only carry gmail.readonly + gmail.send.
+    if mark_read:
+        scopes = resolve_provider_credentials("google").scopes
+        if scopes and not scopes.intersection({"gmail.modify", "https://mail.google.com/"}):
+            print_tip("Not marked read: gmail.modify permission missing.\nNext: co auth google")
+            raise typer.Exit(1)
         gmail.mark_read(resolved)
         marked = "Marked read. "
-    elif mark_read:
-        print_tip("Not marked read: gmail.modify permission missing.\nNext: co auth google")
-        return
     print_tip(f"\n{marked}Reply with: co gmail reply {resolved} <message>")
 
 
 @google_errors("co gmail sent")
-def handle_gmail_reply(email_id: str, message: str):
+def handle_gmail_reply(email_id: str, message: str, *, listing: str | None = None):
     """Reply to an email from the last listing (threaded). A message of '-' reads stdin."""
     if message == "-":
         message = sys.stdin.read()
 
     gmail = _gmail()
-    resolved = _resolve_email_id(gmail, email_id)
+    resolved = _resolve_email_id(gmail, email_id, listing)
     if not resolved:
         console.print(f"\nNo email #{email_id} in your last listing.", markup=False)
         print_tip("Refresh the listing: co gmail inbox")
@@ -242,9 +234,10 @@ def handle_gmail_send(to: str, subject: str, message: str, cc: str = None,
 def handle_gmail_sent(last: int = 10):
     """List recently sent Gmail emails."""
     gmail = _gmail()
-    console.print(f"\n📤 [bold cyan]Gmail sent[/bold cyan] [dim]({resolve_provider_credentials('google').get('EMAIL') or ''})[/dim]\n")
-    console.print(gmail.get_sent_emails(max_results=last), markup=False, highlight=False)
-    print_tip("Find sent messages to read: co gmail search in:sent")
+    emails = gmail.list_search("in:sent", max_results=last)
+    _print_listing(gmail, emails, "Gmail sent")
+    if not emails:
+        print_tip("No sent mail returned. Next: co gmail inbox")
 
 
 @google_errors("co gmail inbox")
@@ -253,8 +246,7 @@ def handle_gmail_search(query: str, last: int = 10):
     gmail = _gmail()
     emails = gmail.list_search(query, max_results=last)
     if not emails:
-        INBOX_CACHE.parent.mkdir(exist_ok=True)
-        INBOX_CACHE.write_text("{}", encoding="utf-8")
+        _print_listing(gmail, [], "Gmail")
         console.print(f"\n[cyan]Search:[/cyan] no emails matching [bold]{query}[/bold]\n")
         print_tip("Show recent mail: co gmail inbox")
         return
@@ -263,14 +255,12 @@ def handle_gmail_search(query: str, last: int = 10):
 
 # === Draft attachment workflow ===
 
-def _resolve_draft_id(draft_id: str) -> str:
-    """Turn a draft-list number into an immutable Gmail draft id."""
-    cached = json.loads(DRAFT_CACHE.read_text(encoding="utf-8")) if DRAFT_CACHE.exists() else {}
-    if draft_id in cached:
-        return cached[draft_id]
-    if draft_id.isascii() and draft_id.isdigit() and len(draft_id) < 5:
-        return ""
-    return draft_id
+def _resolve_draft_id(gmail, draft_id: str, listing: str | None = None) -> str:
+    number = draft_id.removeprefix('#')
+    if not (number.isascii() and number.isdigit() and len(number) < 5):
+        return draft_id
+    return resolve_reference(DRAFT_CACHE.parent / "gmail-listings", draft_id,
+                             gmail.get_account_email(), "drafts", listing)
 
 
 def _draft_call(action, retry_command: str):
@@ -305,19 +295,20 @@ def _draft_call(action, retry_command: str):
         raise typer.Exit(1) from None
 
 
-def _print_draft_list(drafts: list) -> None:
-    DRAFT_CACHE.parent.mkdir(exist_ok=True)
-    DRAFT_CACHE.write_text(
-        json.dumps({str(i): draft["id"] for i, draft in enumerate(drafts, 1)}),
-        encoding="utf-8",
-    )
+def _print_draft_list(gmail, drafts: list) -> None:
+    token = save_listing(DRAFT_CACHE.parent / "gmail-listings", gmail.get_account_email(),
+                         "drafts", [draft["id"] for draft in drafts])
+    print(f"Listing: {token} (expires in 15 minutes; use --listing {token} with a row number)")
+    if not drafts:
+        return
+    next_id = drafts[0]["id"]
     if not console.is_terminal:
         for i, draft in enumerate(drafts, 1):
             print(
                 f"{i}.\t{draft['to']}\t{draft['subject']}\t"
                 f"{draft['attachments']}\t{draft['id']}"
             )
-        print_tip("Preview one with: co gmail draft preview <# from this listing>")
+        print_tip(f"Preview one with: co gmail draft preview {next_id}")
         return
 
     table = Table(title=f"📝 Gmail drafts — {resolve_provider_credentials('google').get('EMAIL') or ''}")
@@ -330,7 +321,7 @@ def _print_draft_list(drafts: list) -> None:
                       str(draft["attachments"]))
     console.print()
     console.print(table)
-    print_tip("\nPreview one with: [bold]co gmail draft preview <# from this listing>[/bold]\n")
+    print_tip(f"Preview one with: co gmail draft preview {next_id}")
 
 
 def _print_draft_preview(draft: dict, tip: bool = True) -> None:
@@ -359,8 +350,8 @@ def _print_draft_preview(draft: dict, tip: bool = True) -> None:
         print_tip(f"\nSend with confirmation: [bold]co gmail draft send {draft['id']}[/bold]\n")
 
 
-def _draft_id_or_exit(draft_id: str) -> str:
-    resolved = _resolve_draft_id(draft_id)
+def _draft_id_or_exit(gmail, draft_id: str, listing: str | None = None) -> str:
+    resolved = _resolve_draft_id(gmail, draft_id, listing)
     if not resolved:
         console.print(f"\n❌ [bold red]No draft #{draft_id} in your last listing.[/bold red]")
         print_tip("List drafts: [bold]co gmail draft list[/bold]\n")
@@ -373,12 +364,11 @@ def handle_gmail_draft_list(last: int = 20):
     gmail = _gmail()
     drafts = _draft_call(lambda: gmail.list_drafts(last=last), "co gmail draft list")
     if not drafts:
-        DRAFT_CACHE.parent.mkdir(exist_ok=True)
-        DRAFT_CACHE.write_text("{}", encoding="utf-8")
+        _print_draft_list(gmail, [])
         console.print("\nGmail drafts: none")
         print_tip("Create one with: [bold]co gmail draft create <to> <subject> <message>[/bold]\n")
         return
-    _print_draft_list(drafts)
+    _print_draft_list(gmail, drafts)
 
 
 @google_errors("co gmail draft list")
@@ -397,14 +387,14 @@ def handle_gmail_draft_create(to: str, subject: str, message: str, cc: str = Non
 
 @google_errors("co gmail draft list")
 def handle_gmail_draft_attach(draft_id: str, source: str, drive: bool = False,
-                              link: bool = False):
+                              link: bool = False, *, listing: str | None = None):
     if link and not drive:
         console.print("\n❌ [bold red]--link requires --drive.[/bold red]")
         print_tip(f"Retry with: [bold]co gmail draft attach {draft_id} <Drive file # or id> --drive --link[/bold]\n")
         raise typer.Exit(1)
 
     gmail = _gmail(require_draft_write=True)
-    resolved = _draft_id_or_exit(draft_id)
+    resolved = _draft_id_or_exit(gmail, draft_id, listing)
     if drive:
         from .gdrive_commands import _gdrive, _resolve_file_id
         from ...useful_tools.gmail import GMAIL_ATTACHMENT_LIMIT
@@ -448,9 +438,9 @@ def handle_gmail_draft_attach(draft_id: str, source: str, drive: bool = False,
 
 
 @google_errors("co gmail draft list")
-def handle_gmail_draft_remove(draft_id: str, attachment: int):
+def handle_gmail_draft_remove(draft_id: str, attachment: int, *, listing: str | None = None):
     gmail = _gmail(require_draft_write=True)
-    resolved = _draft_id_or_exit(draft_id)
+    resolved = _draft_id_or_exit(gmail, draft_id, listing)
     updated = _draft_call(
         lambda: gmail.remove_draft_attachment(resolved, attachment),
         f"co gmail draft preview {resolved}",
@@ -461,9 +451,9 @@ def handle_gmail_draft_remove(draft_id: str, attachment: int):
 
 @google_errors("co gmail draft list")
 def handle_gmail_draft_replace(draft_id: str, attachment: int, source: str,
-                               drive: bool = False):
+                               drive: bool = False, *, listing: str | None = None):
     gmail = _gmail(require_draft_write=True)
-    resolved = _draft_id_or_exit(draft_id)
+    resolved = _draft_id_or_exit(gmail, draft_id, listing)
     if drive:
         from .gdrive_commands import _gdrive, _resolve_file_id
         from ...useful_tools.gmail import GMAIL_ATTACHMENT_LIMIT
@@ -493,17 +483,17 @@ def handle_gmail_draft_replace(draft_id: str, attachment: int, source: str,
 
 
 @google_errors("co gmail draft list")
-def handle_gmail_draft_preview(draft_id: str):
+def handle_gmail_draft_preview(draft_id: str, *, listing: str | None = None):
     gmail = _gmail()
-    resolved = _draft_id_or_exit(draft_id)
+    resolved = _draft_id_or_exit(gmail, draft_id, listing)
     draft = _draft_call(lambda: gmail.get_draft(resolved), "co gmail draft list")
     _print_draft_preview(draft)
 
 
 @google_errors("co gmail sent")
-def handle_gmail_draft_send(draft_id: str):
+def handle_gmail_draft_send(draft_id: str, *, listing: str | None = None):
     gmail = _gmail(require_draft_write=True)
-    resolved = _draft_id_or_exit(draft_id)
+    resolved = _draft_id_or_exit(gmail, draft_id, listing)
     draft = _draft_call(lambda: gmail.get_draft(resolved), "co gmail draft list")
     _print_draft_preview(draft, tip=False)
     try:

--- a/connectonion/cli/commands/gmail_listings.py
+++ b/connectonion/cli/commands/gmail_listings.py
@@ -1,0 +1,94 @@
+"""Immutable, short-lived row references for one authenticated Gmail account."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import time
+from uuid import uuid4
+
+LIFETIME_SECONDS = 15 * 60
+MAX_LISTINGS = 128
+MAX_FILE_BYTES = 256 * 1024
+
+
+class ListingError(ValueError):
+    """The caller must use a full provider ID or obtain a fresh listing."""
+
+
+def _account(value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ListingError('Cannot establish the authenticated Gmail account. Run co gmail inbox again.')
+    return hashlib.sha256(value.strip().casefold().encode()).hexdigest()
+
+
+
+def _modified(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except FileNotFoundError:
+        # Another writer may have evicted this old listing after glob returned.
+        return 0
+
+
+def save_listing(directory: Path, account: str, family: str, ids: list[str], *, now: float | None = None) -> str:
+    """Persist IDs only; never cache message bodies, subjects, recipients or tokens."""
+    if family not in {'messages', 'drafts'} or len(ids) > 500 or any(not isinstance(i, str) or not i or len(i) > 256 for i in ids):
+        raise ListingError('Invalid Gmail listing. Run co gmail inbox again.')
+    created = time.time() if now is None else now
+    token = uuid4().hex
+    payload = {'schema_version': 1, 'provider': 'gmail', 'account': _account(account),
+               'family': family, 'listing_id': token, 'created_at': created,
+               'expires_at': created + LIFETIME_SECONDS, 'ids': ids}
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path = directory / f'{token}.json'
+    # A token is returned only after the complete file is durable. O_EXCL keeps
+    # even a UUID collision from replacing a previously published listing.
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, 'w', encoding='utf-8') as stream:
+        json.dump(payload, stream)
+        stream.flush()
+        os.fsync(stream.fileno())
+    files = sorted((entry for entry in directory.glob("*.json")
+                    if re.fullmatch(r"[a-f0-9]{32}\.json", entry.name)),
+                   key=_modified, reverse=True)
+    for old in files[MAX_LISTINGS:]:
+        old.unlink(missing_ok=True)
+    return token
+
+
+def resolve_reference(directory: Path, value: str, account: str, family: str,
+                      listing: str | None = None, *, now: float | None = None) -> str:
+    """Full IDs bypass disk; numeric references require the exact displayed token."""
+    number = value.removeprefix('#')
+    if not (number.isascii() and number.isdigit() and len(number) < 5):
+        return value
+    if not listing:
+        raise ListingError('A row number requires --listing ID from its listing, or use the full Gmail ID.')
+    if not re.fullmatch(r'[a-f0-9]{32}', listing):
+        raise ListingError('Invalid listing ID. Run co gmail inbox or co gmail draft list again.')
+    current = time.time() if now is None else now
+    try:
+        path = directory / f'{listing}.json'
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, 'O_NOFOLLOW', 0))
+        with os.fdopen(descriptor, 'rb') as stream:
+            raw = stream.read(MAX_FILE_BYTES + 1)
+        if len(raw) > MAX_FILE_BYTES:
+            raise ValueError
+        data = json.loads(raw)
+        if (data['schema_version'] != 1 or data['provider'] != 'gmail' or
+                data['account'] != _account(account) or data['family'] != family or
+                data['listing_id'] != listing or
+                not data['created_at'] <= current < data['expires_at'] or
+                data['expires_at'] - data['created_at'] != LIFETIME_SECONDS):
+            raise ValueError
+        ids = data['ids']
+        if not isinstance(ids, list) or not 1 <= int(number) <= len(ids) <= 500:
+            raise ValueError
+        result = ids[int(number) - 1]
+        if not isinstance(result, str) or not result or len(result) > 256:
+            raise ValueError
+        return result
+    except (OSError, ValueError, KeyError, TypeError, OverflowError):
+        raise ListingError('Listing unavailable, expired, or for another account. Relist or use the full Gmail ID.') from None

--- a/connectonion/cli/commands/google_errors.py
+++ b/connectonion/cli/commands/google_errors.py
@@ -23,6 +23,7 @@ def google_errors(next_command: str):
 
             from ...provider_credentials import ProviderCredentialError
             from ...credentials import AmbientCredentialError
+            from .gmail_listings import ListingError
 
             recovery = next_command
             try:
@@ -33,6 +34,8 @@ def google_errors(next_command: str):
             except AmbientCredentialError as exc:
                 cause = str(exc)
                 recovery = "co auth"
+            except ListingError as exc:
+                cause = str(exc)
             except json.JSONDecodeError:
                 cause = "Saved listing numbers are unreadable; refresh the listing."
             except HttpError as exc:

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -1036,22 +1036,24 @@ def gmail_inbox(
 
 @gmail_app.command("read")
 def gmail_read(
-    email_id: str = typer.Argument(..., help="Email # from the last listing, or a full message id"),
+    email_id: str = typer.Argument(..., help="Full message ID, or row # together with --listing ID"),
     mark_read: bool = typer.Option(False, "--mark-read", help="Mark the email as read after showing it"),
+    listing: Optional[str] = typer.Option(None, "--listing", help="Listing ID printed beside row numbers; required when using a number"),
 ):
     """Show one email's full body without changing its unread state."""
     from .commands.gmail_commands import handle_gmail_read
-    handle_gmail_read(email_id, mark_read=mark_read)
+    handle_gmail_read(email_id, mark_read=mark_read, listing=listing)
 
 
 @gmail_app.command("reply")
 def gmail_reply(
-    email_id: str = typer.Argument(..., help="Email # from the last listing, or a full message id"),
+    email_id: str = typer.Argument(..., help="Full message ID, or row # together with --listing ID"),
     message: str = typer.Argument(..., help="Reply body, or '-' to read stdin"),
+    listing: Optional[str] = typer.Option(None, "--listing", help="Listing ID printed beside row numbers; required when using a number"),
 ):
     """Reply to an email from the last listing."""
     from .commands.gmail_commands import handle_gmail_reply
-    handle_gmail_reply(email_id, message)
+    handle_gmail_reply(email_id, message, listing=listing)
 
 
 @gmail_app.command("send", epilog="Examples:  co gmail send a@b.com \"Hi\" \"Quick note\"  |  "
@@ -1120,54 +1122,59 @@ def gmail_draft_create(
 
 @gmail_draft_app.command("attach")
 def gmail_draft_attach(
-    draft_id: str = typer.Argument(..., help="Draft # from the last draft list, or a full draft id"),
+    draft_id: str = typer.Argument(..., help="Full draft ID, or row # together with --listing ID"),
     source: str = typer.Argument(..., help="Local path, or Drive file #/id with --drive"),
     drive: bool = typer.Option(False, "--drive", help="Read the source from the last Drive listing or a Drive id"),
     link: bool = typer.Option(False, "--link", help="With --drive, append its web link instead of attaching bytes"),
+    listing: Optional[str] = typer.Option(None, "--listing", help="Listing ID printed beside row numbers; required when using a number"),
 ):
     """Stage a local/Drive file, or append a Drive link, without sending."""
     from .commands.gmail_commands import handle_gmail_draft_attach
-    handle_gmail_draft_attach(draft_id, source, drive=drive, link=link)
+    handle_gmail_draft_attach(draft_id, source, drive=drive, link=link, listing=listing)
 
 
 @gmail_draft_app.command("remove")
 def gmail_draft_remove(
-    draft_id: str = typer.Argument(..., help="Draft # from the last draft list, or a full draft id"),
+    draft_id: str = typer.Argument(..., help="Full draft ID, or row # together with --listing ID"),
     attachment: int = typer.Argument(..., min=1, help="Attachment # from draft preview"),
+    listing: Optional[str] = typer.Option(None, "--listing", help="Listing ID printed beside row numbers; required when using a number"),
 ):
     """Remove one staged attachment; the draft remains unsent."""
     from .commands.gmail_commands import handle_gmail_draft_remove
-    handle_gmail_draft_remove(draft_id, attachment)
+    handle_gmail_draft_remove(draft_id, attachment, listing=listing)
 
 
 @gmail_draft_app.command("replace")
 def gmail_draft_replace(
-    draft_id: str = typer.Argument(..., help="Draft # from the last draft list, or a full draft id"),
+    draft_id: str = typer.Argument(..., help="Full draft ID, or row # together with --listing ID"),
     attachment: int = typer.Argument(..., min=1, help="Attachment # from draft preview"),
     source: str = typer.Argument(..., help="Local path, or Drive file #/id with --drive"),
     drive: bool = typer.Option(False, "--drive", help="Read the replacement from Drive"),
+    listing: Optional[str] = typer.Option(None, "--listing", help="Listing ID printed beside row numbers; required when using a number"),
 ):
     """Atomically replace one staged attachment without sending."""
     from .commands.gmail_commands import handle_gmail_draft_replace
-    handle_gmail_draft_replace(draft_id, attachment, source, drive=drive)
+    handle_gmail_draft_replace(draft_id, attachment, source, drive=drive, listing=listing)
 
 
 @gmail_draft_app.command("preview")
 def gmail_draft_preview(
-    draft_id: str = typer.Argument(..., help="Draft # from the last draft list, or a full draft id"),
+    draft_id: str = typer.Argument(..., help="Full draft ID, or row # together with --listing ID"),
+    listing: Optional[str] = typer.Option(None, "--listing", help="Listing ID printed beside row numbers; required when using a number"),
 ):
     """Print recipients, body, and the final attachment manifest."""
     from .commands.gmail_commands import handle_gmail_draft_preview
-    handle_gmail_draft_preview(draft_id)
+    handle_gmail_draft_preview(draft_id, listing=listing)
 
 
 @gmail_draft_app.command("send")
 def gmail_draft_send(
-    draft_id: str = typer.Argument(..., help="Draft # from the last draft list, or a full draft id"),
+    draft_id: str = typer.Argument(..., help="Full draft ID, or row # together with --listing ID"),
+    listing: Optional[str] = typer.Option(None, "--listing", help="Listing ID printed beside row numbers; required when using a number"),
 ):
     """Preview a draft and send it only after interactive confirmation."""
     from .commands.gmail_commands import handle_gmail_draft_send
-    handle_gmail_draft_send(draft_id)
+    handle_gmail_draft_send(draft_id, listing=listing)
 
 
 # Google Drive command group. `co gdrive` (no args) lists recent files.

--- a/connectonion/useful_skills/co-mail-and-drive/SKILL.md
+++ b/connectonion/useful_skills/co-mail-and-drive/SKILL.md
@@ -37,7 +37,7 @@ rather than guessing. Sending from the wrong identity is not undoable.
 ```bash
 co gmail                     # bare command = inbox, 10 most recent
 co gmail inbox -n 25 -u      # last 25, unread only
-co gmail read 3              # open #3 from the last listing
+co gmail read 3 --listing <listing-id>              # token from the displayed listing
 co gmail search "from:alice@example.com is:unread"   # -n to widen
 co gmail sent -n 20
 ```
@@ -55,9 +55,10 @@ co outlook sent -n 20
 Gmail search takes full Gmail query syntax (`from:`, `subject:`, `after:2026/07/01`,
 `is:unread`). Outlook search is plain text over subject and body.
 
-`co gmail read` preserves unread state by default. `co gmail read 3 --mark-read`
-marks it read only when the token carries `gmail.modify`; otherwise it prints
-a reauthorization hint. Repeat what the output says, don't assume.
+`co gmail read` preserves unread state by default. `co gmail read 3 --listing <listing-id> --mark-read`
+requires `gmail.modify` or the full-mail grant. A known read-only grant exits
+1; unknown local scope metadata lets the provider decide. Read the output and
+do not describe a failed mark-read action as completed.
 
 ## Send and reply
 
@@ -81,14 +82,14 @@ always previews and asks for interactive confirmation:
 co gmail draft list
 co gmail draft create bob@example.com "Subject" "Body text"
 co gmail draft list           # create prints an ID; it does not assign row 1
-co gmail draft attach 1 report.pdf
+co gmail draft attach <draft-id> report.pdf
 co gdrive list
-co gmail draft attach 1 3 --drive
-co gmail draft attach 1 3 --drive --link
-co gmail draft remove 1 2
-co gmail draft replace 1 1 corrected.pdf
-co gmail draft preview 1
-co gmail draft send 1
+co gmail draft attach <draft-id> 3 --drive
+co gmail draft attach <draft-id> 3 --drive --link
+co gmail draft remove <draft-id> 2
+co gmail draft replace <draft-id> 1 corrected.pdf
+co gmail draft preview <draft-id>
+co gmail draft send <draft-id>
 ```
 
 `draft create`, `attach`, `remove`, `replace`, and `preview` never send. `draft
@@ -96,13 +97,13 @@ send` has no `--yes` or other confirmation bypass. A declined confirmation
 leaves the draft intact and exits `1`. EOF or interruption at the confirmation
 prompt does the same and prints the preview command again.
 
-A Gmail draft number comes from the immediately preceding `co gmail draft
-list`, cached separately at `~/.co/gmail_last_drafts.json`. Attachment numbers
-come from the current `draft preview`. Drive file numbers still come from the
-immediately preceding `co gdrive` listing. Re-list before acting rather than
-carrying numbers across listings.
-An empty draft listing clears its old numbers. After creating a draft, use the
-ID printed by `create`, or list again before choosing a row number.
+Gmail message and draft row numbers require `--listing <listing-id>` from
+the corresponding listing. Tokens bind to the provider-confirmed account and
+expire after 15 minutes; only the newest 128 are retained. Full IDs work without
+tokens. Other listings never retarget an older row. Bare numbers and legacy
+last-listing caches are rejected. Attachment numbers come from the current
+`draft preview`; Drive file numbers still come from the last `co gdrive` listing.
+After creating a draft, prefer its printed full ID.
 
 `--drive` attaches bytes without making a local copy. Native Docs, Sheets,
 Slides, and Drawings are exported using the same formats as `co gdrive get`.
@@ -114,7 +115,7 @@ when output is piped; it is part of the CLI contract.
 
 ```bash
 co gmail send bob@example.com "Subject" "Body text"
-co gmail reply 3 "Sounds good, see you then."
+co gmail reply 18f2c9d0a1b2c3d4 "Sounds good, see you then."
 co gmail send bob@example.com "Report" - < body.md      # '-' body reads stdin
 co gmail send bob@example.com "Invoice" "Attached." --cc a@x.com --attach invoice.pdf
 ```
@@ -160,18 +161,12 @@ co gdrive rm 3                     # move to trash (recoverable)
 
 ## The two gotchas that make you report something false
 
-**1. Numbers mean your last listing.** `read 3` / `get 3` / `draft preview 3`
-resolve against the
-numbering of the listing you just printed, cached in `~/.co/gmail_last_inbox.json`,
-`~/.co/gmail_last_drafts.json`, `~/.co/outlook_last_inbox.json`, and
-`~/.co/gdrive_last_list.json`. List again and the numbers move. Two consequences:
-
-- Never carry a number across two listings — re-list, then act.
-- Gmail `inbox`/`search`, Gmail `draft list`, and Drive `list`/`search` each
-  refresh their own numbering, including clearing it on an empty result. `sent` does
-  **not**: after `co gmail sent`, `read 1` still opens row 1 of the older inbox listing.
-- A number that isn't in the cache gets `No email #N in your last listing` and exit
-  `1` rather than a silently wrong email. Re-list and retry.
+**1. Gmail numbers require a frozen listing token.** Use full IDs where
+possible. Inbox, search, sent, and draft lists each print a token; pass it as
+`--listing <listing-id>` when using a row. Wrong accounts, expired/evicted or
+corrupt listings fail with exit 1 and require relisting. Do not retry a bare
+number or silently select a different row. Outlook and Drive retain their
+existing last-listing numbering: re-list before using their numbers.
 
 **2. Piping changes the output — and you are always piping.** In a terminal these
 commands print a Rich table with truncated columns and a next-step tip. Piped, they
@@ -184,8 +179,7 @@ co outlook contact list | cut -f2   # name<TAB>email<TAB>id
 ```
 
 Never parse a truncated table column; take IDs from the piped output. The piped
-form keeps the "Read one with: co gmail read <#>" tip (#1011) — the row numbers
-are still what `read` wants.
+form keeps the next-command tip and uses the full first Gmail ID.
 
 Two more, for Drive specifically:
 
@@ -250,7 +244,7 @@ For Gmail and Drive, these are the concrete recovery routes:
 
 | Result | Next command |
 |---|---|
-| Gmail listing succeeded | `co gmail read <# from this listing>` |
+| Gmail listing succeeded | `co gmail read <full-message-id>` |
 | Drive listing succeeded | `co gdrive get <# from column 5 when piped>` |
 | Empty Gmail inbox | `co gmail search <query>` |
 | Empty Gmail search | `co gmail inbox` |
@@ -293,7 +287,7 @@ it themselves**, do not try to drive that flow.
 - [ ] Right mailbox chosen (asked, if both were connected)
 - [ ] Exact text shown to the user before any send
 - [ ] Final Gmail attachment manifest shown before any draft send
-- [ ] Numbers used from the listing printed immediately before the action
+- [ ] Gmail numbers paired with their listing token; Outlook/Drive numbers from the latest listing
 - [ ] IDs taken from piped output, never from a truncated table column
 - [ ] `--from` address taken from `co email addresses`, never guessed
 - [ ] Empty search reported as "no match", not as "does not exist"

--- a/connectonion/useful_tools/gmail.py
+++ b/connectonion/useful_tools/gmail.py
@@ -220,6 +220,16 @@ class Gmail:
 
     # === Reading ===
 
+    def get_account_email(self) -> str:
+        """Return the provider-confirmed account for this client, not saved metadata."""
+        if not getattr(self, "_account_email", None):
+            profile = self._get_service().users().getProfile(userId='me').execute()
+            value = profile.get('emailAddress')
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError("Gmail did not return an account identity")
+            self._account_email = value.strip().casefold()
+        return self._account_email
+
     def list_inbox(self, last: int = 10, unread: bool = False) -> list:
         """Fetch inbox emails as dicts (id, from, subject, date, snippet, unread).
 

--- a/docs/acceptance/1.8.4-gmail-listings.md
+++ b/docs/acceptance/1.8.4-gmail-listings.md
@@ -1,0 +1,31 @@
+# Gmail listing correctness acceptance
+
+Target 1.8.4. This is the correctness slice of #1446, stacked on #1450.
+Mailbox expansion and #1424 draft payload review are separate work.
+
+The focused provider, CLI, listing, help/skill and piped-output bundle passes
+240 tests on macOS/Python 3.14. Regression coverage includes overlapping lists,
+account/family mismatches, expiry, eviction, missing/corrupt tokens, legacy bare
+numbers, full-ID bypass, sent IDs, and truthful mark-read failures. The initial
+full run had 8,221 passing tests and one stale piped-output fixture; that fixture
+was corrected and the full rerun is pending.
+
+`python -m build --no-isolation` produced a wheel and sdist with the unchanged
+development base version 1.8.3. Installed with `pip install --no-deps --target`
+outside the checkout, the wheel passed real read-only Gmail inbox/sent listing
+and message-ID verification after process restart in another directory. Both
+frozen listings retained their original IDs and account fingerprint
+`abe6ff1509726914`. No message was sent or changed; outputs report only boolean
+checks and fingerprints. The tested wheel SHA-256 is
+`13986f4e0476f33709658c52bde73aeba023dff8466b025f04d6255d53466945`.
+
+The pinned `co/gemini-3.7-flash` audit uses mocked provider output and never
+executes model-selected commands. Its first candidate run passed 19/20: the
+sent case retained the old search-oriented goal and the model invented a list
+command. The goal now asks to read the first listed sent email, matching the
+new direct-read tip; the final rerun is pending. A preliminary invocation
+imported the original editable install and stopped before any model call;
+`PYTHONPATH=.` selects the candidate explicitly.
+
+Implementation is proposed for review. This document does not claim a merge,
+release, full mailbox expansion, or live two-account consent test.

--- a/docs/acceptance/1.8.4-gmail-listings.md
+++ b/docs/acceptance/1.8.4-gmail-listings.md
@@ -8,7 +8,10 @@ The focused provider, CLI, listing, help/skill and piped-output bundle passes
 account/family mismatches, expiry, eviction, missing/corrupt tokens, legacy bare
 numbers, full-ID bypass, sent IDs, and truthful mark-read failures. The initial
 full run had 8,221 passing tests and one stale piped-output fixture; that fixture
-was corrected and the full rerun is pending.
+was corrected. The full rerun at `9e0d3942` passed **8,223 tests**, with 23
+skipped, 184 live tests deselected and seven existing warnings (306.21 seconds).
+Command: `python -m pytest -q --tb=short -rf`, isolated temporary home and
+synthetic broker key, with localhost access for browser regressions.
 
 `python -m build --no-isolation` produced a wheel and sdist with the unchanged
 development base version 1.8.3. Installed with `pip install --no-deps --target`
@@ -23,7 +26,7 @@ The pinned `co/gemini-3.7-flash` audit uses mocked provider output and never
 executes model-selected commands. Its first candidate run passed 19/20: the
 sent case retained the old search-oriented goal and the model invented a list
 command. The goal now asks to read the first listed sent email, matching the
-new direct-read tip; the final rerun is pending. A preliminary invocation
+new direct-read tip; the final rerun passed **20/20**. A preliminary invocation
 imported the original editable install and stopped before any model call;
 `PYTHONPATH=.` selects the candidate explicitly.
 

--- a/docs/blog/2026-09-07-row-one-needed-a-listing.md
+++ b/docs/blog/2026-09-07-row-one-needed-a-listing.md
@@ -1,0 +1,24 @@
+# Row One Needed a Listing
+
+Draft for 1.8.4; publish after release acceptance.
+
+`co gmail sent` showed a message as row one. `co gmail read 1` could then open
+row one from an older inbox. The output looked actionable, but its numbers had
+never been written to the cache that `read` used.
+
+Updating the cache after every listing fixes that example. It leaves another:
+one terminal lists an inbox, another searches mail, and the first terminal
+replies to row one. Both commands succeed while choosing a different message
+from the one the operator saw.
+
+The new listing token makes the missing context visible. A row number travels
+with `--listing TOKEN`; a full provider ID needs no token. The token freezes the
+ordered IDs for 15 minutes and belongs to the account Gmail actually reports.
+Saved OAuth email metadata alone cannot establish that identity. A subsequent
+listing cannot replace the old rows, and a lost or expired listing asks the
+caller to list again.
+
+Requiring a token adds typing for numbered references. Using a full ID in the
+printed next command keeps the common path short. The extra context matters
+most when commands overlap, because success must still refer to the message
+that was selected.

--- a/docs/cli/gmail.md
+++ b/docs/cli/gmail.md
@@ -14,13 +14,13 @@ co auth google
 co gmail
 
 # Read message #3 from the inbox list
-co gmail read 3
+co gmail read 3 --listing <listing-id>
 
 # Create, review, and then explicitly send a draft
 co gmail draft create alice@example.com "Hello" "Thanks for the meeting today!"
 co gmail draft list               # choose the new draft's row from this listing
-co gmail draft preview 1
-co gmail draft send 1
+co gmail draft preview <draft-id>
+co gmail draft send <draft-id>
 ```
 
 Use the row that matches your draft; `create` prints its full ID but does not
@@ -55,31 +55,35 @@ co gmail inbox -n 25     # last 25
 co gmail inbox -u        # unread only
 ```
 
-Emails are numbered. **Numbers mean your last listing** — `co gmail read 3`
-opens the third row of the table you just saw. Running `co gmail` again
-renumbers.
-An empty inbox or search result clears older message numbers, so a later
-`read 1` cannot silently use a row from the previous listing.
+Every listing prints a `Listing:` token. A number requires that token, for
+example `co gmail read 3 --listing <listing-id>`. Full IDs need no token.
+Listings are frozen for 15 minutes and bound to the provider-confirmed account.
+Opening another inbox, search, sent, or empty listing cannot change an earlier
+row. Up to 128 listings are retained; expired, evicted, corrupt, or mismatched
+listings fail with exit 1. Relist or use a full ID. Legacy last-listing caches
+are ignored; bare numbers now fail instead of choosing an ambiguous message.
 
 A green ● marks unread.
 
 ### `co gmail read <#>` — Read one email
 
 ```bash
-co gmail read 3                    # by listing number
+co gmail read 3 --listing <listing-id>                    # by listing number
 co gmail read 18f2c9d0a1b2c3d4     # by full message id
-co gmail read 3 --mark-read         # explicitly consume it
+co gmail read 3 --listing <listing-id> --mark-read         # explicitly consume it
 ```
 
 Prints headers in a panel and the body below it. Unread state is preserved by
 default; `--mark-read` opts into changing it
-(only when your token carries `gmail.modify` — a read-only token skips it).
+with `gmail.modify` or the full-mail grant. A known read-only grant exits 1;
+missing local scope metadata lets the provider decide. The command never
+reports success when the requested mark-read action failed.
 
 ### `co gmail reply <#> <message>` — Reply
 
 ```bash
-co gmail reply 3 "Sounds good, see you then."
-cat reply.txt | co gmail reply 3 -
+co gmail reply 18f2c9d0a1b2c3d4 "Sounds good, see you then."
+cat reply.txt | co gmail reply 18f2c9d0a1b2c3d4 -
 ```
 
 Threaded — the reply goes back on the original conversation. A message of `-`
@@ -96,16 +100,18 @@ asks for interactive confirmation. There is no confirmation-bypass flag.
 co gmail draft list
 co gmail draft create alice@example.com "Report" "Please review."
 co gmail draft list               # select the matching row before using a number
-co gmail draft attach 1 report.pdf
-co gmail draft preview 1
-co gmail draft send 1
+co gmail draft attach <draft-id> report.pdf
+co gmail draft preview <draft-id>
+co gmail draft send <draft-id>
 ```
 
-Drafts are numbered independently from inbox messages. A draft number means a
-row from the most recent `co gmail draft list`; the mapping is cached in
-`~/.co/gmail_last_drafts.json`. Attachment numbers come from `draft preview`.
-A full Gmail draft ID works anywhere a draft number does.
-Creating a draft does not change this numbering. An empty draft list clears it.
+Draft numbers use `--listing <listing-id>` from `co gmail draft list` and
+the same account/expiry rules as messages. Message tokens cannot resolve drafts.
+A full Gmail draft ID works without a listing. Attachment numbers come from
+`draft preview` and still refer to that draft's current attachment manifest.
+Creating a draft prints its ID and does not change any frozen listing.
+The ID-only cache lives in the global config directory's `gmail-listings/`;
+it stores an account digest, not the account address or message contents.
 Answering no, ending input, or interrupting the confirmation prompt keeps the
 draft, exits 1, and prints its preview command again.
 
@@ -113,11 +119,11 @@ Use local or Drive files without first copying Drive content to disk:
 
 ```bash
 co gdrive list -n 20
-co gmail draft attach 1 3 --drive          # attach Drive row 3 as bytes
-co gmail draft attach 1 3 --drive --link   # append its Drive URL instead
-co gmail draft remove 1 2
-co gmail draft replace 1 1 corrected.pdf
-co gmail draft replace 1 1 3 --drive
+co gmail draft attach <draft-id> 3 --drive          # attach Drive row 3 as bytes
+co gmail draft attach <draft-id> 3 --drive --link   # append its Drive URL instead
+co gmail draft remove <draft-id> 2
+co gmail draft replace <draft-id> 1 corrected.pdf
+co gmail draft replace <draft-id> 1 3 --drive
 ```
 
 Google Docs, Sheets, Slides, and Drawings are exported with the same formats as
@@ -151,9 +157,9 @@ co gmail sent
 co gmail sent -n 25
 ```
 
-Read-only listing; it does **not** touch the read/reply numbering.
-To read a sent message, run `co gmail search in:sent`, then choose a number from
-that search result.
+Read-only listing with full message IDs and its own frozen listing token.
+Read a sent message directly by ID, or use its row with that token. Older inbox
+and search listings retain their original rows.
 
 ### `co gmail search <query>` — Search
 
@@ -165,8 +171,7 @@ co gmail search "from:alice@example.com is:unread"
 co gmail search "subject:meeting after:2026/07/01" -n 25
 ```
 
-Matches are numbered exactly like the inbox, so `co gmail read <#>` works on
-search results too.
+Search results use the same full-ID and `--listing` rules as the inbox.
 
 ## Piping
 
@@ -177,7 +182,7 @@ and agents never receive a truncated value:
 ```bash
 co gmail inbox -n 50 | grep "ID:"
 co gmail draft list | cat
-co gmail draft preview 1 | cat
+co gmail draft preview <draft-id> | cat
 ```
 
 The plain piped forms keep the literal next-command tip, including after
@@ -211,7 +216,7 @@ gmail.get_draft(draft["id"])
 
 | Exit / result | Recovery command |
 |---|---|
-| 0, inbox or search result | `co gmail read <# from this listing>` |
+| 0, inbox or search result | `co gmail read <full-message-id>` |
 | 1, missing permission | `co auth google` |
 | 1, unknown message number or unreadable numbering cache | `co gmail inbox` |
 | 1, send/reply connection failure | `co gmail sent` |
@@ -224,14 +229,14 @@ was lost after delivery: inspect sent mail before repeating the send or reply.
 
 - **"Google account not connected"** → run `co auth google`.
 - **Missing Gmail scopes** → run `co auth google` again to re-consent.
-- **`No draft #N in your last draft listing`** → run
-  `co gmail draft list` and use a current number.
+- **Unavailable draft listing** → run
+  `co gmail draft list` and use its full ID or its number with `--listing`.
 - **`Draft has no attachment #N`** → run `co gmail draft preview <draft>` and
   use the current manifest number.
 - **A Drive link opens as access denied for the recipient** → change sharing in
   Drive yourself, or attach the file bytes with `--drive` instead of `--link`.
-- **`No email #N in your last listing`** → the number is out of range or the
-  listing changed; run `co gmail` to refresh the numbering.
+- **Unavailable message listing** → relist with `co gmail inbox`, then use a
+  full ID or the new token. An account mismatch cannot fall back to another list.
 - **An intentional project account is no longer selected** → use
   `co --env-file /absolute/project/.env gmail inbox`. The 1.8.4 implementation
   defaults to global settings; see [environment migration](environment.md).

--- a/docs/design-decisions/067-gmail-listing-context.md
+++ b/docs/design-decisions/067-gmail-listing-context.md
@@ -1,0 +1,29 @@
+# DD-067: Gmail rows identify one frozen listing
+
+Date: 2026-09-07. Status: implemented on the 1.8.4 branch; acceptance in progress.
+Related: #1446, #1424, #1450.
+
+`sent` printed row numbers while `read` resolved a previous inbox/search cache.
+A mutable account-scoped cache would fix that case but still let two terminals
+change what the same number means. Every Gmail message and draft listing now
+gets an immutable random token. A numeric reference requires `--listing TOKEN`;
+tips use full provider IDs. Full IDs skip listing reads and profile lookup.
+
+Schema 1 stores provider, SHA-256 of the normalized provider-confirmed mailbox,
+message/draft family, token, creation/expiry times, and ordered full IDs. The
+global config directory retains up to 128 ID-only files, created exclusively
+with mode 0600, each valid for 15 minutes. No subject, recipient, body or token
+credential is cached. Invalid, corrupt, stale, evicted or account-mismatched
+references fail closed with a relisting hint. Legacy mutable caches are ignored.
+Other listings, including empty results, cannot retarget earlier tokens.
+
+This intentionally changes bare-number behavior. A saved email field cannot
+establish account identity because it may be stale; Gmail's profile endpoint
+provides the account. Resolving a missing row by fetching a new inbox would
+hide caller context loss, so that fallback is removed. Sent uses the same
+structured listing and rendering path as search and inbox.
+
+`read --mark-read` remains opt-in. A known insufficient grant exits 1; absent
+scope metadata lets the API decide. Printing the body does not make a failed
+requested mutation successful. Mailbox expansion and draft-send payload safety
+remain separate dependent changes.

--- a/tests/cli/test_tips_survive_piping.py
+++ b/tests/cli/test_tips_survive_piping.py
@@ -37,10 +37,11 @@ def piped_consoles(monkeypatch):
 
 def test_gmail_piped_listing_still_names_the_next_step(tmp_path, capsys):
     gmail = Mock()
+    gmail.get_account_email.return_value = "sender@example.invalid"
     gmail._format_dicts.return_value = "1. a@x.com  hi  ID: 18f2a"
     with patch.object(gmail_commands, "INBOX_CACHE", tmp_path / "gmail.json"):
         gmail_commands._print_listing(gmail, EMAILS, "inbox")
-    assert "Read one with: co gmail read <#>" in capsys.readouterr().out
+    assert "Read one with: co gmail read 18f2a" in capsys.readouterr().out
 
 
 def test_outlook_piped_listing_still_names_the_next_step(tmp_path, capsys):

--- a/tests/e2e/cli/test_cli_gmail.py
+++ b/tests/e2e/cli/test_cli_gmail.py
@@ -46,7 +46,7 @@ def test_gmail_read_routes_id():
         result = runner.invoke(app, ["gmail", "read", "3"])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("3", mark_read=False)
+    handler.assert_called_once_with("3", mark_read=False, listing=None)
 
 
 def test_gmail_read_routes_explicit_mark_read():
@@ -54,7 +54,7 @@ def test_gmail_read_routes_explicit_mark_read():
         result = runner.invoke(app, ["gmail", "read", "3", "--mark-read"])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("3", mark_read=True)
+    handler.assert_called_once_with("3", mark_read=True, listing=None)
 
 
 def test_gmail_send_routes_arguments():
@@ -97,7 +97,7 @@ def test_gmail_reply_routes_id_and_message():
         result = runner.invoke(app, ["gmail", "reply", "2", "Sounds good"])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("2", "Sounds good")
+    handler.assert_called_once_with("2", "Sounds good", listing=None)
 
 
 def test_gmail_reply_routes_stdin_marker():
@@ -105,7 +105,7 @@ def test_gmail_reply_routes_stdin_marker():
         result = runner.invoke(app, ["gmail", "reply", "2", "-"])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("2", "-")
+    handler.assert_called_once_with("2", "-", listing=None)
 
 
 def test_gmail_send_routes_bcc():
@@ -188,7 +188,7 @@ def test_gmail_draft_attach_routes_drive_link():
         ])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("2", "3", drive=True, link=True)
+    handler.assert_called_once_with("2", "3", drive=True, link=True, listing=None)
 
 
 def test_gmail_draft_remove_routes_attachment_number():
@@ -196,7 +196,7 @@ def test_gmail_draft_remove_routes_attachment_number():
         result = runner.invoke(app, ["gmail", "draft", "remove", "2", "1"])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("2", 1)
+    handler.assert_called_once_with("2", 1, listing=None)
 
 
 def test_gmail_draft_replace_routes_drive_source():
@@ -206,7 +206,7 @@ def test_gmail_draft_replace_routes_drive_source():
         ])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("2", 1, "drive-file", drive=True)
+    handler.assert_called_once_with("2", 1, "drive-file", drive=True, listing=None)
 
 
 def test_gmail_draft_preview_routes_id():
@@ -214,7 +214,7 @@ def test_gmail_draft_preview_routes_id():
         result = runner.invoke(app, ["gmail", "draft", "preview", "2"])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("2")
+    handler.assert_called_once_with("2", listing=None)
 
 
 def test_gmail_draft_send_routes_id_without_a_bypass_flag():
@@ -222,7 +222,7 @@ def test_gmail_draft_send_routes_id_without_a_bypass_flag():
         result = runner.invoke(app, ["gmail", "draft", "send", "2"])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("2")
+    handler.assert_called_once_with("2", listing=None)
 
     help_result = runner.invoke(app, ["gmail", "draft", "send", "--help"])
     assert "--yes" not in help_result.output

--- a/tests/unit/test_gmail_commands.py
+++ b/tests/unit/test_gmail_commands.py
@@ -65,6 +65,26 @@ def plain(text):
     return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 
+from connectonion.cli.commands.gmail_listings import save_listing, ListingError
+
+
+def mail_mock():
+    client = MagicMock()
+    client.get_account_email.return_value = 'one@example.test'
+    return client
+
+
+def cached_rows(path):
+    files = list((path.parent / 'gmail-listings').glob('*.json'))
+    data = json.loads(max(files, key=lambda p: p.stat().st_mtime_ns).read_text())
+    return {str(i): value for i, value in enumerate(data['ids'], 1)}
+
+
+def freeze(gmail, ids, family='messages'):
+    return save_listing(gmail_commands.INBOX_CACHE.parent / 'gmail-listings',
+                        gmail.get_account_email(), family, ids)
+
+
 @pytest.fixture(autouse=True)
 def _isolate_cache(tmp_path, monkeypatch):
     """Never touch the real ~/.co/gmail_last_inbox.json."""
@@ -167,7 +187,7 @@ class TestHandleGmailInbox:
     """Inbox listing renders a table and caches the numbering."""
 
     def test_empty_inbox_message(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_inbox.return_value = []
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -177,18 +197,18 @@ class TestHandleGmailInbox:
 
     def test_empty_inbox_clears_numbers(self, capsys):
         """An empty listing must not retain older rows."""
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_inbox.return_value = []
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             handle_gmail_inbox(last=10, unread=True)
 
-        assert json.loads(gmail_commands.INBOX_CACHE.read_text()) == {}
+        assert cached_rows(gmail_commands.INBOX_CACHE) == {}
         assert "no unread emails" in capsys.readouterr().out
 
     def test_table_and_cache(self, monkeypatch, capsys):
         monkeypatch.setattr(gmail_commands, "console", Console(force_terminal=True, width=120))
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_inbox.return_value = sample_emails(3)
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -197,11 +217,11 @@ class TestHandleGmailInbox:
         output = capsys.readouterr().out
         assert "Subject 1" in output
         assert "co gmail read" in output
-        cached = json.loads(gmail_commands.INBOX_CACHE.read_text())
+        cached = cached_rows(gmail_commands.INBOX_CACHE)
         assert cached == {"1": "msg-1", "2": "msg-2", "3": "msg-3"}
 
     def test_flags_reach_the_tool(self):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_inbox.return_value = []
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -214,7 +234,7 @@ class TestHandleGmailInbox:
         monkeypatch.setattr(gmail_commands, "console", Console(force_terminal=True, width=120))
         emails = sample_emails(2)
         emails[0]["date"] = "Unknown"
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_inbox.return_value = emails
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -227,7 +247,7 @@ class TestHandleGmailInbox:
     def test_piped_output_carries_full_ids(self, monkeypatch, capsys):
         """Scripts and agents must get untruncated ids, not a numbered table."""
         monkeypatch.setattr(gmail_commands, "console", Console(force_terminal=False, width=120))
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_inbox.return_value = sample_emails(2)
         gmail._format_dicts.return_value = "ID: msg-1\nID: msg-2"
 
@@ -239,71 +259,42 @@ class TestHandleGmailInbox:
 
     def test_piped_output_still_caches_numbering(self, monkeypatch, capsys):
         monkeypatch.setattr(gmail_commands, "console", Console(force_terminal=False, width=120))
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_inbox.return_value = sample_emails(2)
         gmail._format_dicts.return_value = "listing"
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             handle_gmail_inbox(last=2)
 
-        assert json.loads(gmail_commands.INBOX_CACHE.read_text()) == {"1": "msg-1", "2": "msg-2"}
+        assert cached_rows(gmail_commands.INBOX_CACHE) == {"1": "msg-1", "2": "msg-2"}
 
 
 class TestResolveEmailId:
-    """Short numbers mean the last listing shown."""
-
-    def write_cache(self, mapping):
-        gmail_commands.INBOX_CACHE.parent.mkdir(parents=True, exist_ok=True)
-        gmail_commands.INBOX_CACHE.write_text(json.dumps(mapping))
-
-    def test_number_resolves_through_cache(self):
-        self.write_cache({"1": "msg-a", "2": "msg-b"})
-
-        gmail = MagicMock()
-        assert _resolve_email_id(gmail, "2") == "msg-b"
+    def test_number_resolves_only_through_its_frozen_listing(self):
+        gmail = mail_mock()
+        token = freeze(gmail, ['msg-a', 'msg-b'])
+        assert _resolve_email_id(gmail, '2', token) == 'msg-b'
         gmail.list_inbox.assert_not_called()
 
-    def test_full_id_passes_through(self):
-        gmail = MagicMock()
-        assert _resolve_email_id(gmail, "18f2c9d0a1b2c3d4") == "18f2c9d0a1b2c3d4"
+    @pytest.mark.parametrize('value', ['18f2c9d0a1b2c3d4', '12345', '２'])
+    def test_full_id_bypasses_cache_and_account_request(self, value):
+        gmail = mail_mock()
+        assert _resolve_email_id(gmail, value) == value
+        gmail.get_account_email.assert_not_called()
         gmail.list_inbox.assert_not_called()
 
-    def test_long_numeric_id_passes_through(self):
-        """Gmail ids can be all digits — 5+ digits is an id, not a listing number."""
-        gmail = MagicMock()
-        assert _resolve_email_id(gmail, "12345") == "12345"
+    @pytest.mark.parametrize('value', ['0', '1', '7'])
+    def test_bare_numbers_never_fetch_a_new_inbox(self, value):
+        gmail = mail_mock()
+        with pytest.raises(ListingError, match='--listing'):
+            _resolve_email_id(gmail, value)
         gmail.list_inbox.assert_not_called()
 
-    def test_number_missing_from_cache_returns_empty(self):
-        """Refetching a differently numbered list would open the wrong email."""
-        self.write_cache({"1": "msg-a"})
-
-        gmail = MagicMock()
-        assert _resolve_email_id(gmail, "7") == ""
-        gmail.list_inbox.assert_not_called()
-
-    def test_number_falls_back_to_list_inbox_without_cache(self):
-        """First run of the session: no listing yet, so fetch one."""
-        gmail = MagicMock()
-        gmail.list_inbox.return_value = sample_emails(3)
-
-        assert _resolve_email_id(gmail, "2") == "msg-2"
-
-    def test_number_beyond_inbox_returns_empty(self):
-        gmail = MagicMock()
-        gmail.list_inbox.return_value = sample_emails(1)
-
-        assert _resolve_email_id(gmail, "5") == ""
-
-    def test_zero_returns_empty_without_fetching(self):
-        gmail = MagicMock()
-        assert _resolve_email_id(gmail, "0") == ""
-        gmail.list_inbox.assert_not_called()
-
-    def test_non_ascii_digits_are_not_listing_numbers(self):
-        """Full-width digits can't index a listing; treat them as an id."""
-        gmail = MagicMock()
-        assert _resolve_email_id(gmail, "２") == "２"
+    def test_a_row_outside_the_listing_fails(self):
+        gmail = mail_mock()
+        token = freeze(gmail, ['msg-a'])
+        with pytest.raises(ListingError):
+            _resolve_email_id(gmail, '7', token)
         gmail.list_inbox.assert_not_called()
 
 
@@ -311,21 +302,21 @@ class TestHandleGmailRead:
     """Read is non-destructive unless both the flag and scope allow mutation."""
 
     def _gmail_mock(self):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.get_email_body.return_value = (
             "From: alice@example.com\nSubject: Hello\n--- Email Body ---\nThe body text"
         )
         return gmail
 
     def test_unresolvable_number_exits_with_hint(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_inbox.return_value = []
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             with pytest.raises(typer.Exit):
                 handle_gmail_read("4")
 
-        assert "No email #4" in plain(capsys.readouterr().out)
+        assert "requires --listing" in plain(capsys.readouterr().out)
         gmail.get_email_body.assert_not_called()
 
     def test_prints_header_and_body(self, capsys):
@@ -356,7 +347,9 @@ class TestHandleGmailRead:
 
         with patch.dict(os.environ, READONLY_ENV, clear=False):
             with patch.object(gmail_commands, "_gmail", return_value=gmail):
-                handle_gmail_read("18f2c9d0a1b2c3d4", mark_read=True)
+                with pytest.raises(typer.Exit) as exc:
+                    handle_gmail_read("18f2c9d0a1b2c3d4", mark_read=True)
+                assert exc.value.exit_code == 1
 
         gmail.mark_read.assert_not_called()
         output = plain(capsys.readouterr().out)
@@ -380,7 +373,7 @@ class TestHandleGmailRead:
 
         with patch.dict(os.environ, READONLY_ENV, clear=False):
             with patch.object(gmail_commands, "_gmail", return_value=gmail):
-                handle_gmail_read("2")
+                handle_gmail_read("2", listing=freeze(gmail, ["msg-a", "msg-b"]))
 
         gmail.get_email_body.assert_called_once_with("msg-b")
 
@@ -390,10 +383,10 @@ class TestHandleGmailReply:
     def test_replies_to_cached_number(self, capsys):
         gmail_commands.INBOX_CACHE.parent.mkdir(parents=True, exist_ok=True)
         gmail_commands.INBOX_CACHE.write_text(json.dumps({"1": "msg-a"}))
-        gmail = MagicMock()
+        gmail = mail_mock()
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
-            handle_gmail_reply("1", "Sounds good")
+            handle_gmail_reply("1", "Sounds good", listing=freeze(gmail, ["msg-a"]))
 
         gmail.reply.assert_called_once_with("msg-a", "Sounds good")
         assert "Replied" in plain(capsys.readouterr().out)
@@ -402,30 +395,30 @@ class TestHandleGmailReply:
         gmail_commands.INBOX_CACHE.parent.mkdir(parents=True, exist_ok=True)
         gmail_commands.INBOX_CACHE.write_text(json.dumps({"1": "msg-a"}))
         monkeypatch.setattr(sys, "stdin", io.StringIO("Body from stdin\nline two\n"))
-        gmail = MagicMock()
+        gmail = mail_mock()
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
-            handle_gmail_reply("1", "-")
+            handle_gmail_reply("1", "-", listing=freeze(gmail, ["msg-a"]))
 
         gmail.reply.assert_called_once_with("msg-a", "Body from stdin\nline two\n")
 
     def test_unresolvable_number_does_not_reply(self, capsys):
         gmail_commands.INBOX_CACHE.parent.mkdir(parents=True, exist_ok=True)
         gmail_commands.INBOX_CACHE.write_text(json.dumps({"1": "msg-a"}))
-        gmail = MagicMock()
+        gmail = mail_mock()
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             with pytest.raises(typer.Exit):
                 handle_gmail_reply("9", "Sounds good")
 
         gmail.reply.assert_not_called()
-        assert "No email #9" in plain(capsys.readouterr().out)
+        assert "requires --listing" in plain(capsys.readouterr().out)
 
 
 class TestHandleGmailSendAndSearch:
 
     def test_send_reports_recipient(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
 
         with patch.dict(os.environ, CONNECTED_ENV, clear=False):
             with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -438,7 +431,7 @@ class TestHandleGmailSendAndSearch:
         assert "Sent" in output
 
     def test_send_passes_cc_and_bcc(self):
-        gmail = MagicMock()
+        gmail = mail_mock()
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             handle_gmail_send("bob@example.com", "Hi", "hello",
@@ -450,7 +443,7 @@ class TestHandleGmailSendAndSearch:
 
     def test_send_reads_stdin_body(self, monkeypatch, capsys):
         monkeypatch.setattr(sys, "stdin", io.StringIO("piped body"))
-        gmail = MagicMock()
+        gmail = mail_mock()
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             handle_gmail_send("bob@example.com", "Hi", "-")
@@ -468,7 +461,7 @@ class TestHandleGmailSendAndSearch:
         mock_cls.assert_not_called()
 
     def test_search_empty_result(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_search.return_value = []
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -478,51 +471,45 @@ class TestHandleGmailSendAndSearch:
         assert "no emails matching" in capsys.readouterr().out
 
     def test_search_empty_result_clears_numbers(self):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_search.return_value = []
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             handle_gmail_search("invoice", last=5)
 
-        assert json.loads(gmail_commands.INBOX_CACHE.read_text()) == {}
+        assert cached_rows(gmail_commands.INBOX_CACHE) == {}
 
     def test_search_results_share_the_inbox_numbering_contract(self, monkeypatch, capsys):
         """`co gmail read <#>` after a search must open the search hit."""
         monkeypatch.setattr(gmail_commands, "console", Console(force_terminal=True, width=120))
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_search.return_value = sample_emails(2)
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             handle_gmail_search("invoice", last=2)
 
-        assert json.loads(gmail_commands.INBOX_CACHE.read_text()) == {"1": "msg-1", "2": "msg-2"}
+        assert cached_rows(gmail_commands.INBOX_CACHE) == {"1": "msg-1", "2": "msg-2"}
         assert "Subject 1" in capsys.readouterr().out
 
 
 class TestHandleGmailSent:
-
     def test_prints_sent_listing(self, capsys):
-        gmail = MagicMock()
-        gmail.get_sent_emails.return_value = "Found 1 email(s):\n\n1.  From: me@example.com"
-
-        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
-            with patch.object(gmail_commands, "_gmail", return_value=gmail):
-                handle_gmail_sent(last=5)
-
-        gmail.get_sent_emails.assert_called_once_with(max_results=5)
-        assert "me@example.com" in capsys.readouterr().out
-
-    def test_sent_does_not_disturb_the_read_numbering(self, capsys):
-        """Only inbox and search define what `read <#>` means."""
-        gmail_commands.INBOX_CACHE.parent.mkdir(parents=True, exist_ok=True)
-        gmail_commands.INBOX_CACHE.write_text(json.dumps({"1": "msg-a"}))
-        gmail = MagicMock()
-        gmail.get_sent_emails.return_value = "Found 0 email(s):"
-
-        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+        gmail = mail_mock()
+        gmail.list_search.return_value = sample_emails(1)
+        gmail._format_dicts.return_value = '1. From: me@example.com ID: sent-a'
+        with patch.object(gmail_commands, '_gmail', return_value=gmail):
             handle_gmail_sent(last=5)
+        gmail.list_search.assert_called_once_with('in:sent', max_results=5)
+        assert 'me@example.com' in capsys.readouterr().out
 
-        assert json.loads(gmail_commands.INBOX_CACHE.read_text()) == {"1": "msg-a"}
+    def test_sent_preserves_the_explicit_inbox_listing(self, capsys):
+        gmail = mail_mock()
+        inbox = freeze(gmail, ['inbox-a'])
+        gmail.list_search.return_value = sample_emails(1)
+        with patch.object(gmail_commands, '_gmail', return_value=gmail):
+            handle_gmail_sent(last=5)
+        assert _resolve_email_id(gmail, '1', inbox) == 'inbox-a'
+        assert cached_rows(gmail_commands.INBOX_CACHE) == {'1': 'msg-1'}
 
 
 class TestGmailSendAttachmentChecks:
@@ -530,7 +517,7 @@ class TestGmailSendAttachmentChecks:
     traceback after megabytes have been base64-encoded."""
 
     def test_a_missing_file_is_refused_before_the_api_is_touched(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             with pytest.raises(typer.Exit):
@@ -545,7 +532,7 @@ class TestGmailSendAttachmentChecks:
         is over Graph's limit and well under Gmail's."""
         big = tmp_path / "deck.pdf"
         big.write_bytes(b"x" * 5_000_000)
-        gmail = MagicMock()
+        gmail = mail_mock()
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             handle_gmail_send("bob@example.com", "Hi", "hello", attachments=[str(big)])
@@ -556,7 +543,7 @@ class TestGmailSendAttachmentChecks:
     def test_over_gmails_own_limit_is_refused(self, tmp_path, capsys):
         huge = tmp_path / "video.mov"
         huge.write_bytes(b"x" * 26_000_000)
-        gmail = MagicMock()
+        gmail = mail_mock()
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             with pytest.raises(typer.Exit):
@@ -588,7 +575,7 @@ class TestGmailDraftCommands:
 
     def test_list_piped_caches_numbers_and_keeps_preview_tip(self, monkeypatch, capsys):
         monkeypatch.setattr(gmail_commands, "console", Console(force_terminal=False, width=120))
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_drafts.return_value = [{
             "id": "draft-1", "to": "r@example.com", "subject": "Report", "attachments": 1,
         }]
@@ -599,11 +586,11 @@ class TestGmailDraftCommands:
         output = plain(capsys.readouterr().out)
         assert "1.\tr@example.com" in output
         assert "draft-1" in output
-        assert "co gmail draft preview <# from this listing>" in output
-        assert json.loads(gmail_commands.DRAFT_CACHE.read_text()) == {"1": "draft-1"}
+        assert "co gmail draft preview draft-1" in output
+        assert cached_rows(gmail_commands.DRAFT_CACHE) == {"1": "draft-1"}
 
     def test_empty_list_points_to_create(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_drafts.return_value = []
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -614,15 +601,16 @@ class TestGmailDraftCommands:
     def test_empty_list_invalidates_previous_numbers(self):
         gmail_commands.DRAFT_CACHE.parent.mkdir(parents=True, exist_ok=True)
         gmail_commands.DRAFT_CACHE.write_text(json.dumps({"1": "old-draft"}))
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_drafts.return_value = []
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             handle_gmail_draft_list()
-        assert gmail_commands._resolve_draft_id("1") == ""
+        with pytest.raises(ListingError, match="--listing"):
+            gmail_commands._resolve_draft_id(gmail, "1")
 
     @pytest.mark.parametrize("interruption", [typer.Abort, KeyboardInterrupt, EOFError])
     def test_interrupted_confirmation_keeps_draft_and_prints_tip(self, interruption, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.get_draft.return_value = sample_draft()
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
             with patch.object(typer, "confirm", side_effect=interruption):
@@ -633,7 +621,7 @@ class TestGmailDraftCommands:
         assert "co gmail draft preview draft-1" in plain(capsys.readouterr().out)
 
     def test_create_stays_unsent_and_points_to_attach(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.create_draft.return_value = sample_draft()
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -645,7 +633,7 @@ class TestGmailDraftCommands:
 
     def test_create_reads_body_from_stdin(self, monkeypatch):
         monkeypatch.setattr(sys, "stdin", io.StringIO("Piped body"))
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.create_draft.return_value = sample_draft()
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -654,7 +642,7 @@ class TestGmailDraftCommands:
         assert gmail.create_draft.call_args.args[2] == "Piped body"
 
     def test_attach_local_stages_and_points_to_preview(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.add_draft_attachment.return_value = sample_draft()
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -665,7 +653,7 @@ class TestGmailDraftCommands:
         assert "co gmail draft preview draft-1" in plain(capsys.readouterr().out)
 
     def test_attach_drive_file_reads_bytes_without_writing_local_file(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail._add_draft_attachment.return_value = sample_draft()
         drive = MagicMock()
         drive._read_file.return_value = {
@@ -683,7 +671,7 @@ class TestGmailDraftCommands:
         assert "co gmail draft preview draft-1" in plain(capsys.readouterr().out)
 
     def test_attach_drive_link_does_not_download_or_change_sharing(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.add_draft_link.return_value = sample_draft(attachments=[], attachment_size=0)
         drive = MagicMock()
         drive._get_file.return_value = {
@@ -709,7 +697,7 @@ class TestGmailDraftCommands:
         assert "co gmail draft attach draft-1" in output
 
     def test_remove_points_back_to_preview(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.remove_draft_attachment.return_value = sample_draft(attachments=[], attachment_size=0)
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -719,7 +707,7 @@ class TestGmailDraftCommands:
         assert "co gmail draft preview draft-1" in plain(capsys.readouterr().out)
 
     def test_replace_with_local_file_points_back_to_preview(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.replace_draft_attachment.return_value = sample_draft()
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -729,7 +717,7 @@ class TestGmailDraftCommands:
         assert "co gmail draft preview draft-1" in plain(capsys.readouterr().out)
 
     def test_preview_prints_exact_body_manifest_and_send_tip(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.get_draft.return_value = sample_draft()
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -741,7 +729,7 @@ class TestGmailDraftCommands:
         assert "co gmail draft send draft-1" in output
 
     def test_send_decline_keeps_draft_and_exits_nonzero(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.get_draft.return_value = sample_draft()
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -756,7 +744,7 @@ class TestGmailDraftCommands:
         assert "co gmail draft preview draft-1" in output
 
     def test_send_confirms_after_preview_and_points_to_sent(self, capsys):
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.get_draft.return_value = sample_draft()
         gmail._send_draft.return_value = {"id": "message-1"}
 
@@ -783,7 +771,7 @@ class TestGmailDraftCommands:
         from googleapiclient.errors import HttpError
 
         response = MagicMock(status=403, reason="Forbidden")
-        gmail = MagicMock()
+        gmail = mail_mock()
         gmail.list_drafts.side_effect = HttpError(
             response, b'{"access_token":"must-not-appear"}'
         )

--- a/tests/unit/test_gmail_listing_context.py
+++ b/tests/unit/test_gmail_listing_context.py
@@ -112,13 +112,20 @@ def test_account_binding_uses_provider_profile_instead_of_saved_metadata(monkeyp
 @pytest.mark.parametrize('args', [['read', '1'], ['reply', '1', 'Hello'],
     ['draft', 'preview', '1'], ['draft', 'attach', '1', 'report.pdf'],
     ['draft', 'remove', '1', '1'], ['draft', 'replace', '1', '1', 'report.pdf'], ['draft', 'send', '1']])
-def test_numeric_command_help_exposes_listing_selector(args):
+@pytest.mark.parametrize("color", [False, True])
+def test_numeric_command_help_exposes_listing_selector(args, color, monkeypatch):
+    from click import unstyle
+    from typer import rich_utils
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr(rich_utils, "FORCE_TERMINAL", color)
     from typer.testing import CliRunner
     from connectonion.cli.main import app
     commands = args[:2] if args[0] == 'draft' else args[:1]
-    result = CliRunner().invoke(app, ['gmail', *commands, '--help'])
+    result = CliRunner().invoke(app, ['gmail', *commands, '--help'], color=color)
     assert result.exit_code == 0
-    assert '--listing' in result.output
+    if color:
+        assert '\x1b[' in result.output
+    assert '--listing' in unstyle(result.output)
 
 
 def test_wrong_account_command_cannot_read_or_mutate(tmp_path, monkeypatch):

--- a/tests/unit/test_gmail_listing_context.py
+++ b/tests/unit/test_gmail_listing_context.py
@@ -1,0 +1,149 @@
+"""Row references identify an immutable account-bound listing, never today's last list."""
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+
+def test_another_listing_cannot_retarget_a_row(tmp_path):
+    from connectonion.cli.commands.gmail_listings import save_listing, resolve_reference
+    first = save_listing(tmp_path, 'one@example.test', 'messages', ['inbox-a'], now=100)
+    second = save_listing(tmp_path, 'one@example.test', 'messages', ['sent-b'], now=101)
+    assert first != second
+    assert resolve_reference(tmp_path, '1', 'one@example.test', 'messages', first, now=102) == 'inbox-a'
+    assert resolve_reference(tmp_path, '1', 'one@example.test', 'messages', second, now=102) == 'sent-b'
+
+
+@pytest.mark.parametrize('account,family,time', [('other@example.test','messages',101),
+                                               ('one@example.test','drafts',101),
+                                               ('one@example.test','messages',1001)])
+def test_wrong_account_family_and_expired_listing_fail(tmp_path, account, family, time):
+    from connectonion.cli.commands.gmail_listings import save_listing, resolve_reference, ListingError
+    listing = save_listing(tmp_path, 'one@example.test', 'messages', ['mail-a'], now=100)
+    with pytest.raises(ListingError):
+        resolve_reference(tmp_path, '1', account, family, listing, now=time)
+
+
+def test_unbound_numbers_never_fetch_a_new_inbox(tmp_path):
+    from connectonion.cli.commands.gmail_listings import resolve_reference, ListingError
+    with pytest.raises(ListingError, match='--listing'):
+        resolve_reference(tmp_path, '1', 'one@example.test', 'messages', None)
+    assert not list(tmp_path.iterdir())
+
+
+def test_full_id_ignores_corrupt_cache_and_needs_no_listing(tmp_path):
+    from connectonion.cli.commands.gmail_listings import resolve_reference
+    (tmp_path / 'legacy.json').write_text('{broken')
+    assert resolve_reference(tmp_path, '18fabcdef123', 'one@example.test', 'messages', None) == '18fabcdef123'
+
+
+def test_concurrent_listings_have_independent_frozen_rows(tmp_path):
+    from connectonion.cli.commands.gmail_listings import save_listing, resolve_reference
+    with ThreadPoolExecutor(4) as pool:
+        tokens = list(pool.map(lambda i: save_listing(tmp_path, 'one@example.test', 'messages', [f'mail-{i}']), range(8)))
+    assert len(set(tokens)) == 8
+    for i, token in enumerate(tokens):
+        assert resolve_reference(tmp_path, '1', 'one@example.test', 'messages', token) == f'mail-{i}'
+
+
+def test_missing_corrupt_and_traversal_listing_ids_fail_closed(tmp_path):
+    from connectonion.cli.commands.gmail_listings import resolve_reference, ListingError
+    for token in ['../secret', 'bad', 'a' * 32]:
+        with pytest.raises(ListingError):
+            resolve_reference(tmp_path, '1', 'one@example.test', 'messages', token)
+
+
+def test_sent_emits_its_own_readable_ids_and_listing(tmp_path, monkeypatch, capsys):
+    from unittest.mock import MagicMock
+    from connectonion.cli.commands import gmail_commands as gm
+    gmail = MagicMock()
+    gmail.get_account_email.return_value = 'one@example.test'
+    gmail.list_search.return_value = [{'id': 'sent-id', 'from': 'one@example.test',
+                                      'subject': 'Test', 'date': 'Unknown', 'snippet': '', 'unread': False}]
+    gmail._format_dicts.return_value = '1. ID: sent-id'
+    monkeypatch.setattr(gm, '_gmail', lambda: gmail)
+    monkeypatch.setattr(gm, 'INBOX_CACHE', tmp_path / 'legacy.json')
+    gm.handle_gmail_sent()
+    output = capsys.readouterr().out
+    assert 'sent-id' in output
+    assert 'Listing:' in output
+    assert 'co gmail read sent-id' in output
+    gmail.list_search.assert_called_once_with('in:sent', max_results=10)
+
+
+def test_read_mark_read_missing_scope_exits_nonzero(tmp_path, monkeypatch):
+    from unittest.mock import MagicMock
+    import typer
+    from connectonion.cli.commands import gmail_commands as gm
+    gmail = MagicMock()
+    gmail.get_email_body.return_value = 'From: one@example.test\n--- Email Body ---\nHello'
+    monkeypatch.setattr(gm, '_gmail', lambda: gmail)
+    monkeypatch.setenv('GOOGLE_SCOPES', 'gmail.readonly')
+    with pytest.raises(typer.Exit) as error:
+        gm.handle_gmail_read('full-message-id', mark_read=True)
+    assert error.value.exit_code == 1
+    gmail.mark_read.assert_not_called()
+
+
+def test_read_mark_read_unknown_scope_metadata_lets_the_api_decide(tmp_path, monkeypatch):
+    from unittest.mock import MagicMock
+    from connectonion.cli.commands import gmail_commands as gm
+    gmail = MagicMock()
+    gmail.get_email_body.return_value = 'From: one@example.test\n--- Email Body ---\nHello'
+    monkeypatch.setattr(gm, '_gmail', lambda: gmail)
+    monkeypatch.delenv('GOOGLE_SCOPES', raising=False)
+    gm.handle_gmail_read('full-message-id', mark_read=True)
+    gmail.mark_read.assert_called_once_with('full-message-id')
+
+
+def test_account_binding_uses_provider_profile_instead_of_saved_metadata(monkeypatch):
+    from unittest.mock import MagicMock
+    from connectonion.useful_tools.gmail import Gmail
+    client = Gmail.__new__(Gmail)
+    service = MagicMock()
+    service.users().getProfile().execute.return_value = {'emailAddress': ' Actual@Example.test '}
+    monkeypatch.setattr(client, '_get_service', lambda: service)
+    monkeypatch.setenv('GOOGLE_EMAIL', 'stale@example.test')
+    assert client.get_account_email() == 'actual@example.test'
+    assert client.get_account_email() == 'actual@example.test'
+    assert service.users().getProfile().execute.call_count == 1
+
+
+@pytest.mark.parametrize('args', [['read', '1'], ['reply', '1', 'Hello'],
+    ['draft', 'preview', '1'], ['draft', 'attach', '1', 'report.pdf'],
+    ['draft', 'remove', '1', '1'], ['draft', 'replace', '1', '1', 'report.pdf'], ['draft', 'send', '1']])
+def test_numeric_command_help_exposes_listing_selector(args):
+    from typer.testing import CliRunner
+    from connectonion.cli.main import app
+    commands = args[:2] if args[0] == 'draft' else args[:1]
+    result = CliRunner().invoke(app, ['gmail', *commands, '--help'])
+    assert result.exit_code == 0
+    assert '--listing' in result.output
+
+
+def test_wrong_account_command_cannot_read_or_mutate(tmp_path, monkeypatch):
+    from unittest.mock import MagicMock
+    from typer.testing import CliRunner
+    from connectonion.cli.main import app
+    from connectonion.cli.commands import gmail_commands as gm
+    from connectonion.cli.commands.gmail_listings import save_listing
+    token = save_listing(tmp_path / 'gmail-listings', 'previous@example.test', 'messages', ['private-id'])
+    gmail = MagicMock()
+    gmail.get_account_email.return_value = 'current@example.test'
+    monkeypatch.setattr(gm, '_gmail', lambda: gmail)
+    monkeypatch.setattr(gm, 'INBOX_CACHE', tmp_path / 'legacy.json')
+    result = CliRunner().invoke(app, ['gmail', 'read', '1', '--listing', token, '--mark-read'])
+    assert result.exit_code == 1
+    assert 'another account' in result.output
+    gmail.get_email_body.assert_not_called()
+    gmail.mark_read.assert_not_called()
+
+
+def test_evicted_listing_requires_relisting(tmp_path):
+    from connectonion.cli.commands.gmail_listings import save_listing, resolve_reference, ListingError, MAX_LISTINGS
+    token = save_listing(tmp_path, 'one@example.test', 'messages', ['first'])
+    for i in range(MAX_LISTINGS):
+        save_listing(tmp_path, 'one@example.test', 'messages', [f'mail-{i}'])
+    assert len(list(tmp_path.glob('*.json'))) == MAX_LISTINGS
+    with pytest.raises(ListingError):
+        resolve_reference(tmp_path, '1', 'one@example.test', 'messages', token)

--- a/tests/unit/test_gmail_listing_context.py
+++ b/tests/unit/test_gmail_listing_context.py
@@ -117,6 +117,7 @@ def test_numeric_command_help_exposes_listing_selector(args, color, monkeypatch)
     from click import unstyle
     from typer import rich_utils
     monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
     monkeypatch.setattr(rich_utils, "FORCE_TERMINAL", color)
     from typer.testing import CliRunner
     from connectonion.cli.main import app

--- a/tests/unit/test_google_cli_design.py
+++ b/tests/unit/test_google_cli_design.py
@@ -24,14 +24,14 @@ from connectonion.cli.commands import gmail_commands as gm, gdrive_commands as g
 
 
 CASES = [
-    (['gmail'], 'Read the first listed email', 'co gmail read 1'),
-    (['gmail', 'inbox'], 'Read the first listed email', 'co gmail read 1'),
-    (['gmail', 'search', 'test'], 'Read the first matching email', 'co gmail read 1'),
+    (['gmail'], 'Read the first listed email', 'co gmail read msg-a'),
+    (['gmail', 'inbox'], 'Read the first listed email', 'co gmail read msg-a'),
+    (['gmail', 'search', 'test'], 'Read the first matching email', 'co gmail read msg-a'),
     (['gmail', 'read', 'msg-a'], 'Reply with body Thanks', 'co gmail reply msg-a Thanks'),
     (['gmail', 'reply', 'msg-a', 'Thanks'], 'Check sent mail', 'co gmail sent'),
     (['gmail', 'send', 'a@example.invalid', 'Test', 'Hello'], 'Check sent mail', 'co gmail sent'),
-    (['gmail', 'sent'], 'Find sent messages to read', 'co gmail search in:sent'),
-    (['gmail', 'draft', 'list'], 'Preview the first listed draft', 'co gmail draft preview 1'),
+    (['gmail', 'sent'], 'Read the first listed sent email', 'co gmail read msg-a'),
+    (['gmail', 'draft', 'list'], 'Preview the first listed draft', 'co gmail draft preview draft-a'),
     (['gmail', 'draft', 'create', 'a@example.invalid', 'Test', 'Hello'], 'Attach report.pdf', 'co gmail draft attach draft-a report.pdf'),
     (['gmail', 'draft', 'attach', 'draft-a', 'report.pdf'], 'Preview the staged draft', 'co gmail draft preview draft-a'),
     (['gmail', 'draft', 'remove', 'draft-a', '1'], 'Preview the updated draft', 'co gmail draft preview draft-a'),
@@ -63,6 +63,7 @@ def test_help_and_skill_parity(path):
 
 def capture(args, root, failure=None):
     gmail, drive = MagicMock(), MagicMock()
+    gmail.get_account_email.return_value = 'sender@example.invalid'
     email = dict(id='msg-a', **{'from': 'a@example.invalid'}, subject='Test',
                  date='Sat, 05 Sep 2026 10:00:00 +0000', unread=False, snippet='Hello')
     gmail.list_inbox.return_value = gmail.list_search.return_value = [email]
@@ -145,11 +146,16 @@ def test_empty_listing_cannot_reuse_old_row(module, cache, handler, args, method
     path = tmp_path / 'cache.json'
     path.write_text(json.dumps({'1': 'old-id'}))
     client = MagicMock()
+    client.get_account_email.return_value = "sender@example.invalid"
     getattr(client, method).return_value = []
     with patch.object(module, cache, path), patch.object(module, '_gmail' if module is gm else '_gdrive', return_value=client):
         handler(*args)
-        resolved = gm._resolve_email_id(client, '1') if module is gm else gd._resolve_file_id('1')
-        assert resolved == ''
+        if module is gm:
+            from connectonion.cli.commands.gmail_listings import ListingError
+            with pytest.raises(ListingError):
+                gm._resolve_email_id(client, '1')
+        else:
+            assert gd._resolve_file_id('1') == ''
 
 
 @pytest.mark.parametrize('surface,subcommand', [('gmail', 'read'), ('gdrive', 'get')])


### PR DESCRIPTION
`co gmail sent` printed row numbers that `read` resolved against an older inbox. This change gives every message and draft listing an immutable account-bound token. Full Gmail IDs work directly; numeric references now require the displayed `--listing` token. `read --mark-read` exits 1 when the requested label change fails.

Refs #1446 and #1445. Depends on #1450; base `fix/1.8.4-global-env` at `3b6bf1f9`. This is the correctness slice; mailbox actions/incoming attachments and #1424 draft payload safety remain separate dependent work.

- **Proposed target version:** 1.8.4
- **Estimated release window:** after coordinated 1.8.4 acceptance; no publication date promised
- **Suggested labels:** bug
- **Forward-port tracking issue (stable patches only):** N/A — stacked mainline work; policy correction #1449

Listings use Gmail's profile identity, provider/family binding, 15-minute expiry and a 128-file retention cap. They store full IDs and an account digest without message content or credentials. Concurrent and empty listings cannot retarget earlier rows. Missing/corrupt/stale/mismatched listings fail without implicit fetching; legacy mutable caches and bare numeric scripts require migration. Sent shares the structured inbox/search rendering path and prints a full-ID next command.

Verification: 240 focused tests; full offline suite **8,223 passed, 23 skipped, 184 deselected**, seven existing warnings, at `9e0d3942`. Built wheel/sdist with `python -m build --no-isolation`. Installed-wheel read-only Gmail inbox/sent and message-ID checks passed after process restart in another directory with unchanged account fingerprint. No message was sent or modified. Pinned text-only CLI tip audit **20/20**; no model-selected command executed. Earlier fixture and audit failures are recorded in `docs/acceptance/1.8.4-gmail-listings.md`.

Documentation: `docs/cli/gmail.md`, packaged `co-mail-and-drive` skill, DD 067, and Design Journal draft `docs/blog/2026-09-07-row-one-needed-a-listing.md`. Mostly AI-generated with Codex (GPT-6). No version bump, merge or publication is claimed. The existing metadata workflow can remain red until #1449 merges; this PR does not invent a forward-port tracker to bypass it.

## CI follow-up

The Linux matrix exposed ANSI styling inside the listing-help assertion. The regression now exercises color and plain terminals and checks the unstyled rendered text: **28 targeted cases pass**. Runtime code is unchanged. The PR stack includes #1449 so the metadata gate distinguishes mainline work from maintenance-branch patches. Earlier failing CI runs remain historical evidence, not a clean result.
