### PR TITLE
feat(gmail): add mailbox actions and bounded incoming downloads

### DIFF
--- a/connectonion/cli/commands/gmail_commands.py
+++ b/connectonion/cli/commands/gmail_commands.py
@@ -85,10 +85,18 @@ def _when(date: str) -> str:
     return parsed.astimezone().strftime("%b %d %H:%M")
 
 
+def _print_page_status(gmail, attribute: str, count: int) -> None:
+    page = getattr(gmail, attribute, None)
+    if isinstance(page, dict):
+        more = 'yes' if page.get('nextPageToken') else 'no'
+        print(f'Page: {count} items; more available: {more}. Use --json for continuation context.')
+
+
 def _print_listing(gmail, emails: list, title: str):
     """Render emails as a numbered table (or plain ID-bearing text when piped) and freeze an account-bound listing for read/reply."""
     token = save_listing(INBOX_CACHE.parent / "gmail-listings", gmail.get_account_email(),
                          "messages", [email["id"] for email in emails])
+    _print_page_status(gmail, "_last_message_page", len(emails))
     print(f"Listing: {token} (expires in 15 minutes; use --listing {token} with a row number)")
     if not emails:
         return
@@ -296,6 +304,7 @@ def _draft_call(action, retry_command: str):
 
 
 def _print_draft_list(gmail, drafts: list) -> None:
+    _print_page_status(gmail, "_last_draft_page", len(drafts))
     token = save_listing(DRAFT_CACHE.parent / "gmail-listings", gmail.get_account_email(),
                          "drafts", [draft["id"] for draft in drafts])
     print(f"Listing: {token} (expires in 15 minutes; use --listing {token} with a row number)")

--- a/connectonion/cli/commands/gmail_mailbox_commands.py
+++ b/connectonion/cli/commands/gmail_mailbox_commands.py
@@ -1,0 +1,117 @@
+"""Versioned Gmail mailbox output with no prompts or provider error bodies."""
+
+from contextlib import redirect_stderr, redirect_stdout
+import io
+import json
+import shlex
+import sys
+
+import typer
+
+from ...environment import selected_command
+from ...provider_credentials import ProviderCredentialError
+from ...credentials import AmbientCredentialError
+from ...useful_tools.gmail_mailbox import MailboxError
+from .gmail_listings import ListingError, save_listing
+
+
+def _perform(client, operation: str, args: dict) -> tuple[dict, str]:
+    from . import gmail_commands as gm
+    if operation in {'inbox', 'sent', 'search', 'unanswered'}:
+        if operation == 'unanswered':
+            data = client.list_unanswered(**args)
+        else:
+            query = {'inbox': 'is:unread in:inbox' if args.pop('unread', False) else 'in:inbox',
+                     'sent': 'in:sent', 'search': args.pop('query', '')}[operation]
+            data = client.message_page(query, **args)
+        data['listing_id'] = save_listing(gm.INBOX_CACHE.parent / 'gmail-listings', client.get_account_email(),
+                                          'messages', [row['id'] for row in data['items']])
+        next_command = f'co gmail read {shlex.quote(data["items"][0]["id"])}' if data['items'] else 'co gmail inbox'
+        return data, next_command
+    if operation == 'label.list':
+        return {'items': client._get_service().users().labels().list(userId='me').execute().get('labels', []),
+                'complete': True}, 'co gmail label add --help'
+    if operation == 'draft.list':
+        data = client.draft_page(**args)
+        data['listing_id'] = save_listing(gm.DRAFT_CACHE.parent / 'gmail-listings', client.get_account_email(),
+                                         'drafts', [row['id'] for row in data['items']])
+        tip = f'co gmail draft preview {shlex.quote(data["items"][0]["id"])}' if data['items'] else 'co gmail draft create --help'
+        return data, tip
+    reference = args.pop('email_id', None)
+    if operation == 'draft.preview':
+        id = gm._resolve_draft_id(client, args.pop('draft_id'), args.pop('listing', None))
+        return {**client.get_draft(id), 'complete':True}, f'co gmail draft send {shlex.quote(id)}'
+    id = gm._resolve_email_id(client, reference, args.pop('listing', None))
+    tip = f'co gmail read {shlex.quote(id)} --json'
+    mutation = operation in {'mark.read','mark.unread','archive','star','unstar','label.add','label.remove'}
+    mark_read = args.pop('mark_read', False)
+    if mutation or mark_read:
+        scopes = client._credentials.scopes
+        if scopes and not scopes.intersection({'gmail.modify','https://mail.google.com/'}):
+            raise MailboxError('permission_denied', 'Gmail modify permission is required for this action.')
+    if operation == 'read':
+        data = client.read_message(id)
+        if mark_read:
+            client.mark_read(id)
+        return {**data, 'marked_read':mark_read, 'complete':True}, f'co gmail reply {shlex.quote(id)} <message>'
+    if operation == 'attachments':
+        return {'id':id, 'items':client.list_attachments(id), 'complete':True}, f'co gmail download {shlex.quote(id)} --all --to <directory>'
+    if operation == 'download':
+        return {'id':id, **client.download_attachments(id, **args)}, f'co gmail attachments {shlex.quote(id)} --json'
+    method = {'mark.read':'mark_read', 'mark.unread':'mark_unread', 'archive':'archive_email',
+              'star':'star_email', 'unstar':'unstar_email', 'label.add':'add_label', 'label.remove':'remove_label'}[operation]
+    result = getattr(client, method)(id, **args)
+    return {'id':id, 'action':operation, 'result':result, 'complete':True}, tip
+
+
+def handle_mailbox(operation: str, *, json_output: bool = False, **args) -> None:
+    """Emit one envelope; partial operations exit 1 and retain per-file results."""
+    from googleapiclient.errors import HttpError
+    from google.auth.exceptions import GoogleAuthError
+    from httplib2 import HttpLib2Error
+    from requests import RequestException
+    from .gmail_commands import _gmail
+    result = {'schema_version':1, 'provider':'gmail', 'operation':operation,
+              'account':None, 'status':'error', 'complete':False, 'data':None, 'error':None}
+    next_command = 'co gmail inbox'
+    try:
+        # Existing setup diagnostics are captured so --json stays a single document.
+        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            client = _gmail()
+            result['account'] = client.get_account_email()
+            data, next_command = _perform(client, operation, args)
+        result.update(data=data, complete=data.get('complete', True),
+                      status='success' if data.get('complete', True) else 'partial')
+    except ProviderCredentialError as error:
+        result['error'] = {'code':error.code, 'message':str(error).split('\nNext:',1)[0]}
+        next_command = error.next_command
+    except AmbientCredentialError:
+        result['error'] = {'code':'broker_auth_required', 'message':'OpenOnion authorization is required for Google token refresh.'}
+        next_command = 'co auth'
+    except MailboxError as error:
+        result['error'] = {'code':error.code, 'message':str(error)}
+        if error.code in {'permission_denied', 'auth_required'}:
+            next_command = 'co auth google'
+    except ListingError as error:
+        result['error'] = {'code':'invalid_listing', 'message':str(error)}
+    except (HttpError, GoogleAuthError) as error:
+        status = getattr(getattr(error, 'resp', None), 'status', None)
+        code = {401:'auth_required', 403:'permission_denied', 404:'not_found'}.get(status, 'provider_error')
+        result['error'] = {'code':code, 'message':'Gmail request failed; inspect state before retrying a mutation.'}
+        if code in {'auth_required', 'permission_denied'}:
+            next_command = 'co auth google'
+    except (RequestException, HttpLib2Error, OSError):
+        result['error'] = {'code':'io_error', 'message':'Gmail connection or local I/O failed; inspect state before retrying.'}
+    except typer.Exit:
+        result['error'] = {'code':'auth_required', 'message':'Google account setup or required permission is missing.'}
+        next_command = 'co auth google'
+    except (ValueError, KeyError, TypeError):
+        result['error'] = {'code':'invalid_input', 'message':'Invalid input or malformed Gmail response.'}
+    result['next_command'] = selected_command(next_command)
+    if json_output:
+        print(json.dumps(result, ensure_ascii=False))
+    else:
+        print(json.dumps(result['data'] if result['data'] is not None else result['error'], ensure_ascii=False, indent=2))
+        print(f'Next: {result["next_command"]}', file=sys.stderr)
+    if not result['complete']:
+        raise typer.Exit(1)

--- a/connectonion/cli/commands/gmail_mailbox_registration.py
+++ b/connectonion/cli/commands/gmail_mailbox_registration.py
@@ -1,0 +1,116 @@
+"""The explicit Gmail mailbox leaves and machine-readable usage failures."""
+
+import json
+from typing import Optional
+
+import typer
+from typer.core import TyperCommand
+try:
+    from typer import _click as click
+except ImportError:
+    import click  # Typer versions before the vendored Click runtime
+
+from ...environment import selected_command
+
+
+def handle_mailbox(*args, **kwargs):
+    # Keep --help and unrelated commands free of provider imports.
+    from .gmail_mailbox_commands import handle_mailbox as run
+    return run(*args, **kwargs)
+
+
+def usage_error(message: str, command: str, json_output: bool) -> None:
+    if not json_output:
+        raise typer.BadParameter(message)
+    print(json.dumps({'schema_version':1, 'provider':'gmail', 'operation':command,
+        'account':None, 'status':'error', 'complete':False, 'data':None,
+        'error':{'code':'usage_error', 'message':message},
+        'next_command':selected_command(f'co gmail {command} --help')}))
+    raise typer.Exit(2)
+
+
+class MailboxCommand(TyperCommand):
+    def make_context(self, info_name, args, parent=None, **extra):
+        json_output = '--json' in args
+        try:
+            return super().make_context(info_name, args, parent=parent, **extra)
+        except click.ClickException:
+            if json_output:
+                # Do not echo arbitrary argument values or provider material.
+                prefix = parent.command_path.split('gmail', 1)[-1].strip() if parent else ''
+                command = f'{prefix} {info_name}'.strip()
+                usage_error('Invalid or missing command arguments.', command, True)
+            raise
+
+
+def register_mailbox_commands(app: typer.Typer, group_class: type) -> None:
+    @app.command('mark', cls=MailboxCommand)
+    def mark(email_id: str, read: bool = typer.Option(False, '--read'),
+             unread: bool = typer.Option(False, '--unread'),
+             listing: Optional[str] = typer.Option(None, '--listing'),
+             json_output: bool = typer.Option(False, '--json')):
+        """Set read state; choose exactly one of --read and --unread."""
+        if read == unread:
+            usage_error('Choose exactly one of --read and --unread.', 'mark', json_output)
+        handle_mailbox('mark.read' if read else 'mark.unread', email_id=email_id, listing=listing, json_output=json_output)
+
+    @app.command('archive', cls=MailboxCommand)
+    def archive(email_id: str, listing: Optional[str] = typer.Option(None, '--listing'),
+                json_output: bool = typer.Option(False, '--json')):
+        """Remove INBOX from a message without deleting it."""
+        handle_mailbox('archive', email_id=email_id, listing=listing, json_output=json_output)
+
+    @app.command('star', cls=MailboxCommand)
+    def star(email_id: str, remove: bool = typer.Option(False, '--remove'),
+             listing: Optional[str] = typer.Option(None, '--listing'),
+             json_output: bool = typer.Option(False, '--json')):
+        """Add a star, or remove it with --remove."""
+        handle_mailbox('unstar' if remove else 'star', email_id=email_id, listing=listing, json_output=json_output)
+
+    labels = typer.Typer(cls=group_class, help='List labels and add/remove labels on a message.')
+    app.add_typer(labels, name='label')
+
+    @labels.command('list', cls=MailboxCommand)
+    def label_list(json_output: bool = typer.Option(False, '--json')):
+        """List full label IDs, names and types."""
+        handle_mailbox('label.list', json_output=json_output)
+
+    @labels.command('add', cls=MailboxCommand)
+    def label_add(email_id: str, label: str, listing: Optional[str] = typer.Option(None, '--listing'),
+                  json_output: bool = typer.Option(False, '--json')):
+        """Add a label by its exact name or full ID."""
+        handle_mailbox('label.add', email_id=email_id, label=label, listing=listing, json_output=json_output)
+
+    @labels.command('remove', cls=MailboxCommand)
+    def label_remove(email_id: str, label: str, listing: Optional[str] = typer.Option(None, '--listing'),
+                     json_output: bool = typer.Option(False, '--json')):
+        """Remove a label without changing other labels."""
+        handle_mailbox('label.remove', email_id=email_id, label=label, listing=listing, json_output=json_output)
+
+    @app.command('attachments', cls=MailboxCommand)
+    def attachments(email_id: str, listing: Optional[str] = typer.Option(None, '--listing'),
+                    json_output: bool = typer.Option(False, '--json')):
+        """List nested attachments and inline parts with stable IDs and sizes."""
+        handle_mailbox('attachments', email_id=email_id, listing=listing, json_output=json_output)
+
+    @app.command('download', cls=MailboxCommand)
+    def download(email_id: str, to: str = typer.Option(..., '--to', help='Existing local destination directory'),
+                 attachment: Optional[str] = typer.Option(None, '--attachment', help='Full attachment/part ID from attachments'),
+                 all_attachments: bool = typer.Option(False, '--all'),
+                 listing: Optional[str] = typer.Option(None, '--listing'),
+                 json_output: bool = typer.Option(False, '--json')):
+        """Download selected attachments; keep existing files and report partial failures."""
+        if bool(attachment) == all_attachments:
+            usage_error('Choose exactly one of --attachment ID and --all.', 'download', json_output)
+        handle_mailbox('download', email_id=email_id, directory=to, attachment_id=attachment,
+                       all_attachments=all_attachments, listing=listing, json_output=json_output)
+
+    @app.command('unanswered', cls=MailboxCommand)
+    def unanswered(within_days: int = typer.Option(30, '--within-days', min=1, max=3650),
+                   last: int = typer.Option(20, '--last', '-n', min=1, max=100, help='Maximum threads scanned in one page; filtering may return fewer'),
+                   exclude_automated: bool = typer.Option(False, '--exclude-automated', help='Filter Auto-Submitted and bulk/list/junk headers'),
+                   cursor: Optional[str] = typer.Option(None, '--cursor', help='Continuation from the same account, days, filter and limit'),
+                   json_output: bool = typer.Option(False, '--json')):
+        """Find threads whose latest non-draft message is incoming, regardless of who started them."""
+        handle_mailbox('unanswered', within_days=within_days, last=last,
+                       exclude_automated=exclude_automated, cursor=cursor, json_output=json_output)

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -1012,35 +1012,52 @@ def telegram_send(
 
 # Gmail command group. `co gmail` (no args) shows the Gmail inbox.
 # Uses the GOOGLE_* OAuth tokens saved to .env by `co auth google`.
+from .commands.gmail_mailbox_registration import MailboxCommand, register_mailbox_commands
+
 gmail_app = _typer_app(help="Send and read email from your Gmail account. Bare 'co gmail' shows the inbox.")
 app.add_typer(gmail_app, name="gmail")
 
 
 @gmail_app.callback(invoke_without_command=True)
-def gmail_callback(ctx: typer.Context):
+def gmail_callback(ctx: typer.Context, json_output: bool = typer.Option(False, "--json")):
     """With no subcommand, show the Gmail inbox."""
     if ctx.invoked_subcommand is None:
+        if json_output:
+            from .commands.gmail_mailbox_commands import handle_mailbox
+            return handle_mailbox("inbox", json_output=True, last=10, unread=False, cursor=None)
         from .commands.gmail_commands import handle_gmail_inbox
         handle_gmail_inbox()
+    elif json_output:
+        from .commands.gmail_mailbox_registration import usage_error
+        usage_error("Put --json after the leaf command, or use it with bare co gmail.", "", True)
 
 
-@gmail_app.command("inbox")
+@gmail_app.command("inbox", cls=MailboxCommand)
 def gmail_inbox(
-    last: int = typer.Option(10, "--last", "-n", help="How many emails to show"),
+    last: int = typer.Option(10, "--last", "-n", min=1, max=500, help="How many emails to show"),
     unread: bool = typer.Option(False, "--unread", "-u", help="Only unread emails"),
+    json_output: bool = typer.Option(False, "--json", help="Versioned result envelope with full IDs and account context"),
+    cursor: Optional[str] = typer.Option(None, "--cursor", help="Continuation from the same account, query and limit (15 minute expiry)"),
 ):
     """List recent inbox emails, numbered for read/reply."""
+    if json_output or cursor:
+        from .commands.gmail_mailbox_commands import handle_mailbox
+        return handle_mailbox("inbox", json_output=json_output, last=last, unread=unread, cursor=cursor)
     from .commands.gmail_commands import handle_gmail_inbox
     handle_gmail_inbox(last=last, unread=unread)
 
 
-@gmail_app.command("read")
+@gmail_app.command("read", cls=MailboxCommand)
 def gmail_read(
     email_id: str = typer.Argument(..., help="Full message ID, or row # together with --listing ID"),
     mark_read: bool = typer.Option(False, "--mark-read", help="Mark the email as read after showing it"),
     listing: Optional[str] = typer.Option(None, "--listing", help="Listing ID printed beside row numbers; required when using a number"),
+    json_output: bool = typer.Option(False, "--json", help="Versioned result envelope with full IDs and account context"),
 ):
     """Show one email's full body without changing its unread state."""
+    if json_output:
+        from .commands.gmail_mailbox_commands import handle_mailbox
+        return handle_mailbox("read", json_output=json_output, email_id=email_id, mark_read=mark_read, listing=listing)
     from .commands.gmail_commands import handle_gmail_read
     handle_gmail_read(email_id, mark_read=mark_read, listing=listing)
 
@@ -1072,21 +1089,31 @@ def gmail_send(
     handle_gmail_send(to, subject, message, cc=cc, bcc=bcc, attachments=attach)
 
 
-@gmail_app.command("sent")
+@gmail_app.command("sent", cls=MailboxCommand)
 def gmail_sent(
-    last: int = typer.Option(10, "--last", "-n", help="How many emails to show"),
+    last: int = typer.Option(10, "--last", "-n", min=1, max=500, help="How many emails to show"),
+    json_output: bool = typer.Option(False, "--json", help="Versioned result envelope with full IDs and account context"),
+    cursor: Optional[str] = typer.Option(None, "--cursor", help="Continuation from the same account, query and limit (15 minute expiry)"),
 ):
     """List recently sent emails."""
+    if json_output or cursor:
+        from .commands.gmail_mailbox_commands import handle_mailbox
+        return handle_mailbox("sent", json_output=json_output, last=last, cursor=cursor)
     from .commands.gmail_commands import handle_gmail_sent
     handle_gmail_sent(last=last)
 
 
-@gmail_app.command("search")
+@gmail_app.command("search", cls=MailboxCommand)
 def gmail_search(
     query: str = typer.Argument(..., help="Gmail search query, e.g. 'from:alice@example.com'"),
-    last: int = typer.Option(10, "--last", "-n", help="How many matches to show"),
+    last: int = typer.Option(10, "--last", "-n", min=1, max=500, help="How many matches to show"),
+    json_output: bool = typer.Option(False, "--json", help="Versioned result envelope with full IDs and account context"),
+    cursor: Optional[str] = typer.Option(None, "--cursor", help="Continuation from the same account, query and limit (15 minute expiry)"),
 ):
     """Search your mail with Gmail query syntax."""
+    if json_output or cursor:
+        from .commands.gmail_mailbox_commands import handle_mailbox
+        return handle_mailbox("search", json_output=json_output, query=query, last=last, cursor=cursor)
     from .commands.gmail_commands import handle_gmail_search
     handle_gmail_search(query, last=last)
 
@@ -1098,11 +1125,16 @@ gmail_draft_app = _typer_app(help="Create, inspect, and edit Gmail drafts; sendi
 gmail_app.add_typer(gmail_draft_app, name="draft")
 
 
-@gmail_draft_app.command("list")
+@gmail_draft_app.command("list", cls=MailboxCommand)
 def gmail_draft_list(
     last: int = typer.Option(20, "--last", "-n", min=1, max=500, help="How many drafts to show"),
+    json_output: bool = typer.Option(False, "--json", help="Versioned result envelope with full IDs and account context"),
+    cursor: Optional[str] = typer.Option(None, "--cursor", help="Continuation from the same account, query and limit (15 minute expiry)"),
 ):
     """List Gmail drafts, numbered for later draft commands."""
+    if json_output or cursor:
+        from .commands.gmail_mailbox_commands import handle_mailbox
+        return handle_mailbox("draft.list", json_output=json_output, last=last, cursor=cursor)
     from .commands.gmail_commands import handle_gmail_draft_list
     handle_gmail_draft_list(last=last)
 
@@ -1157,12 +1189,16 @@ def gmail_draft_replace(
     handle_gmail_draft_replace(draft_id, attachment, source, drive=drive, listing=listing)
 
 
-@gmail_draft_app.command("preview")
+@gmail_draft_app.command("preview", cls=MailboxCommand)
 def gmail_draft_preview(
     draft_id: str = typer.Argument(..., help="Full draft ID, or row # together with --listing ID"),
     listing: Optional[str] = typer.Option(None, "--listing", help="Listing ID printed beside row numbers; required when using a number"),
+    json_output: bool = typer.Option(False, "--json", help="Versioned result envelope with full IDs and account context"),
 ):
     """Print recipients, body, and the final attachment manifest."""
+    if json_output:
+        from .commands.gmail_mailbox_commands import handle_mailbox
+        return handle_mailbox("draft.preview", json_output=json_output, draft_id=draft_id, listing=listing)
     from .commands.gmail_commands import handle_gmail_draft_preview
     handle_gmail_draft_preview(draft_id, listing=listing)
 
@@ -1175,6 +1211,9 @@ def gmail_draft_send(
     """Preview a draft and send it only after interactive confirmation."""
     from .commands.gmail_commands import handle_gmail_draft_send
     handle_gmail_draft_send(draft_id, listing=listing)
+
+
+register_mailbox_commands(gmail_app, _OneSuggestion)
 
 
 # Google Drive command group. `co gdrive` (no args) lists recent files.

--- a/connectonion/useful_skills/co-mail-and-drive/SKILL.md
+++ b/connectonion/useful_skills/co-mail-and-drive/SKILL.md
@@ -134,7 +134,52 @@ co outlook cancel 1           # pull one back before it goes
 ```
 
 Outlook can also save an email's attachments: `co outlook download 3 --to ~/Downloads`.
-Gmail has no download command — there is no way to save a Gmail attachment from this CLI.
+
+## Gmail mailbox actions and incoming attachments (1.8.4 candidate)
+
+```bash
+co gmail mark <message-id> --read
+co gmail mark <message-id> --unread
+co gmail archive <message-id>
+co gmail star <message-id>
+co gmail star <message-id> --remove
+co gmail label list --json
+co gmail label add <message-id> <label-name-or-id>
+co gmail label remove <message-id> <label-name-or-id>
+co gmail attachments <message-id> --json
+co gmail download <message-id> --all --to ~/Downloads --json
+co gmail download <message-id> --attachment <attachment-id> --to ~/Downloads --json
+co gmail unanswered --within-days 30 --last 20 --json
+```
+
+Message numbers also work with their explicit `--listing` token. Mark requires
+exactly one of `--read`/`--unread`; download requires exactly one of `--all` or
+`--attachment ID`. Modify operations need `gmail.modify` or the full-mail grant;
+reads/downloads need Gmail read access. Missing local scopes let the API decide.
+Unanswered scans one page of up to `--last` threads whose latest non-draft
+message is incoming; user-started threads are included. `--exclude-automated`
+opts into header-based filtering. Support/billing/invoice senders are included
+by default. The result is a page, never an exact total of replies owed.
+
+Inbox, sent, search, read, draft list/preview and every new mailbox leaf accept
+`--json`. Bare `co gmail --json` is inbox JSON. Put the flag after a subcommand
+when using one. Schema 1 includes `provider`, `account`, `operation`, `status`,
+`complete`, `data`, `error`, and a literal `next_command`; stdout is one JSON
+document. Exit 0 is success, 1 is operational/partial failure, 2 is usage error.
+Normal new-command hints go to stderr. Check per-file results on partial exit.
+
+List JSON includes `data.next_cursor`, `truncated`, and labeled estimates.
+Continue with `--cursor` while repeating the same query/filter/limit. Cursors
+bind account and arguments for 15 minutes; changed/expired cursors require a
+fresh listing. Messages/drafts allow 1–500 items; unanswered scans 1–100 threads
+and can return fewer matches. A changing live mailbox is not a frozen snapshot.
+
+Incoming attachment IDs cover nested named files and explicit inline parts.
+Use the exact ID, including a `part:` prefix when printed. Downloads require an
+existing directory, preserve existing files, and suffix duplicate names. Limits
+are 25 MB per file, 100 MB per invocation and 100 parts. Successful files remain
+on partial failure; inspect each path/hash/error before retrying. These commands
+do not send mail or change Drive sharing.
 
 **Never send on the user's behalf without showing them the exact text and final
 attachment manifest first.** Prefer `co gmail draft`; print its preview and wait

--- a/connectonion/useful_tools/gmail.py
+++ b/connectonion/useful_tools/gmail.py
@@ -65,11 +65,12 @@ from ..credentials import require_ambient_api_key
 from ..provider_credentials import resolve_provider_credentials, refresh_credentials, token_expiry
 from ..project import project_root
 from ._attachment_files import path_of_open_file
+from .gmail_mailbox import GmailMailbox
 
 GMAIL_ATTACHMENT_LIMIT = 25_000_000
 
 
-class Gmail:
+class Gmail(GmailMailbox):
     """Gmail tool for reading and managing emails."""
 
     @property
@@ -250,6 +251,7 @@ class Gmail:
             maxResults=last
         ).execute()
 
+        self._last_message_page = results
         return self._email_dicts(results.get('messages', []), last)
 
     def list_search(self, query: str, max_results: int = 10) -> list:
@@ -265,6 +267,7 @@ class Gmail:
             maxResults=max_results
         ).execute()
 
+        self._last_message_page = results
         return self._email_dicts(results.get('messages', []), max_results)
 
     def read_inbox(self, last: int = 10, unread: bool = False) -> str:
@@ -548,9 +551,11 @@ class Gmail:
         if last < 1:
             return []
         service = self._get_service()
-        stubs = service.users().drafts().list(
+        response = service.users().drafts().list(
             userId="me", maxResults=last
-        ).execute().get("drafts", [])
+        ).execute()
+        self._last_draft_page = response
+        stubs = response.get("drafts", [])
         drafts = []
         for stub in stubs:
             full = service.users().drafts().get(
@@ -1435,190 +1440,12 @@ Emails:
         return f"Analysis for {email}:\n\n{analysis}"
 
     def get_unanswered_emails(self, within_days: int = 120, max_results: int = 20) -> str:
-        """Find emails from the last N days that we haven't replied to.
-
-        Useful for CRM to identify conversations that need follow-up.
-        Checks threads where the last message is FROM someone else (not us).
-
-        Args:
-            within_days: Look back this many days (default: 120 = ~4 months)
-            max_results: Maximum emails to return (default: 20)
-
-        Returns:
-            List of unanswered emails with sender, subject, date, and age
-        """
-        import re
-        from datetime import datetime, timezone
-        from email.utils import parsedate_to_datetime
-
-        service = self._get_service()
-
-        # Get ALL user email addresses including Cloudflare routed addresses (auto-detected)
-        user_emails = self.get_all_my_emails(max_emails=50)
-
-        # Search for inbox emails from the last N days
-        # Use pagination to ensure we find enough unanswered emails
-        query = f"in:inbox newer_than:{within_days}d"
-        unanswered = []
-        seen_threads = set()
-        page_token = None
-        max_pages = 10  # Safety limit to avoid infinite loops
-        pages_fetched = 0
-
-        while len(unanswered) < max_results and pages_fetched < max_pages:
-            results = service.users().messages().list(
-                userId='me',
-                q=query,
-                maxResults=100,  # Fetch in larger batches for efficiency
-                pageToken=page_token
-            ).execute()
-
-            messages = results.get('messages', [])
-            if not messages:
-                break
-
-            for msg in messages:
-                # Get thread to check if we replied
-                thread_id = msg.get('threadId')
-                if thread_id in seen_threads:
-                    continue
-                seen_threads.add(thread_id)
-
-                # Get full thread
-                thread = service.users().threads().get(
-                    userId='me',
-                    id=thread_id,
-                    format='metadata',
-                    metadataHeaders=['From', 'Subject', 'Date']
-                ).execute()
-
-                thread_messages = thread.get('messages', [])
-                if not thread_messages:
-                    continue
-
-                # Check the last message in thread
-                last_msg = thread_messages[-1]
-                headers = last_msg['payload']['headers']
-                last_from = next((h['value'] for h in headers if h['name'] == 'From'), '')
-
-                # Extract email from "Name <email>" format
-                email_match = re.search(r'<([^>]+)>', last_from)
-                last_from_email = email_match.group(1).lower() if email_match else last_from.lower()
-
-                # Skip if last message is from us (we already replied)
-                # Check against ALL our email addresses (primary + aliases)
-                if any(email in last_from_email for email in user_emails):
-                    continue
-
-                # Get first message details
-                first_msg = thread_messages[0]
-                first_headers = first_msg['payload']['headers']
-                first_from = next((h['value'] for h in first_headers if h['name'] == 'From'), '')
-                first_email_match = re.search(r'<([^>]+)>', first_from)
-                first_from_email = first_email_match.group(1).lower() if first_email_match else first_from.lower()
-                subject = next((h['value'] for h in first_headers if h['name'] == 'Subject'), 'No Subject')
-                subject_lower = subject.lower()
-
-                # Skip if WE sent the first message (we initiated, not awaiting reply)
-                # Check against ALL our email addresses (primary + aliases)
-                if any(email in first_from_email for email in user_emails):
-                    continue
-
-                # Skip automated senders by email patterns
-                automated_email_patterns = [
-                    # Generic automated prefixes
-                    'noreply', 'no-reply', 'donotreply', 'do-not-reply',
-                    'notifications@', 'notification@', 'newsletter@', 'news@',
-                    'alerts@', 'alert@', 'updates@', 'update@',
-                    'security@', 'team@', 'support@', 'help@', 'info@',
-                    'marketing@', 'promo@', 'promotions@', 'offers@',
-                    'billing@', 'invoice@', 'receipt@', 'order@',
-                    'feedback@', 'survey@', 'announce@', 'digest@',
-                    'hello@',  # Common marketing prefix
-                    # Common automated domains/subdomains
-                    'mail.instagram.com', 'mail.linkedin.com', 'mail.facebook.com',
-                    'mail.twitter.com', 'mail.x.com', 'mail.google.com',
-                    'facebookmail.com', 'linkedin.com', 'glassdoor.com',
-                    'calendly.com', 'zoom.us', 'mailchimp', 'sendgrid',
-                    'amazonses', 'postmark', 'intercom', 'hubspot',
-                    'mailgun', 'sparkpost', 'constantcontact', 'campaign-archive',
-                    'vimeo.com', 'vimeo@',  # Video platforms
-                    'mongodb.com', 'mongodb@', 'atlassian.com', 'github.com',
-                    'aws.amazon.com', 'cloud.google.com', 'azure.microsoft.com',
-                    # Subdomain patterns (careful - these match anywhere in domain)
-                    'mail.', 'send.', 'email.', 'mailer.', 'bounce.',
-                    'notify.', 'msg.', 'campaigns.',
-                ]
-                if any(p in last_from_email for p in automated_email_patterns):
-                    continue
-
-                # Skip by subject line patterns (common automated email subjects)
-                automated_subject_patterns = [
-                    'your job', 'job alert', 'new jobs', 'jobs for you',
-                    'password reset', 'verify your', 'confirm your',
-                    'security alert', 'new sign-in', 'new login', 'login attempt',
-                    'weekly digest', 'daily digest', 'monthly digest',
-                    'newsletter', 'unsubscribe', 'subscription',
-                    'receipt for', 'invoice', 'payment confirmation', 'order confirmation',
-                    'your order', 'shipping confirmation', 'delivery update',
-                    'welcome to', 'thanks for signing up', 'account created',
-                    'is active', 'expiring soon', 'expires', 'renew',
-                    # Calendar/meeting related
-                    'invitation:', 'invitation from', 'canceled event', 'accepted:', 'declined:',
-                    'updated invitation', 'event canceled', 'meeting canceled',
-                    'from an unknown sender',
-                    # Account related
-                    'account registration', 'registration complete', 'verify your email',
-                    'confirm your email', 'activate your account', 'action required',
-                    'build your first', 'getting started with', 'complete your setup',
-                    # Monthly/periodic reports
-                    'in january', 'in february', 'in march', 'in april', 'in may',
-                    'in june', 'in july', 'in august', 'in september', 'in october',
-                    'in november', 'in december', 'this month', 'last month',
-                    'pro tips', 'tips to', 'getting started',
-                ]
-                if any(p in subject_lower for p in automated_subject_patterns):
-                    continue
-                from_email = next((h['value'] for h in first_headers if h['name'] == 'From'), 'Unknown')
-                date_str = next((h['value'] for h in first_headers if h['name'] == 'Date'), '')
-
-                # Calculate age
-                age_days = within_days  # Default fallback
-                if date_str:
-                    date_obj = parsedate_to_datetime(date_str)
-                    now = datetime.now(timezone.utc)
-                    age_days = (now - date_obj).days
-
-                unanswered.append({
-                    'thread_id': thread_id,
-                    'from': from_email,
-                    'subject': subject,
-                    'date': date_str,
-                    'age_days': age_days,
-                    'messages_in_thread': len(thread_messages)
-                })
-
-                if len(unanswered) >= max_results:
-                    break
-
-            # Pagination: get next page
-            page_token = results.get('nextPageToken')
-            pages_fetched += 1
-            if not page_token:
-                break
-
-        if not unanswered:
-            return f"No unanswered emails found in the last {within_days} days."
-
-        # Format output
-        output = [f"Found {len(unanswered)} unanswered email(s) from the last {within_days} days:\n"]
-        for i, email in enumerate(unanswered, 1):
-            output.append(f"{i}. From: {email['from']}")
-            output.append(f"   Subject: {email['subject']}")
-            output.append(f"   Age: {email['age_days']} days ({email['messages_in_thread']} messages in thread)")
-            output.append(f"   Thread ID: {email['thread_id']}\n")
-
-        return "\n".join(output)
+        """Describe one page of latest-incoming threads; use list_unanswered for cursors."""
+        page = self.list_unanswered(within_days=within_days, last=max_results)
+        output = self._format_dicts(page['items'])
+        if page['truncated']:
+            output += "\nMore candidate threads exist; use list_unanswered and next_cursor to continue."
+        return output
 
     # === CSV Caching ===
 

--- a/connectonion/useful_tools/gmail_mailbox.py
+++ b/connectonion/useful_tools/gmail_mailbox.py
@@ -1,0 +1,293 @@
+"""Gmail mailbox pages, exact reply debt, and bounded incoming attachments."""
+
+import base64
+import binascii
+from email.utils import parseaddr
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import time
+from urllib.parse import quote
+from uuid import uuid4
+
+import requests
+from ..provider_credentials import ProviderCredentialError
+
+ATTACHMENT_LIMIT = 25_000_000
+DOWNLOAD_LIMIT = 100_000_000
+RESPONSE_LIMIT = 40_000_000
+MAX_ATTACHMENTS = 100
+
+
+class MailboxError(ValueError):
+    """An operational failure safe to include in machine output."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+def _headers(message: dict) -> dict:
+    return {item['name'].casefold(): item['value']
+            for item in message.get('payload', {}).get('headers', [])}
+
+
+def _summary(message: dict) -> dict:
+    headers = _headers(message)
+    return {'id': message['id'], 'thread_id': message.get('threadId'),
+            'from': headers.get('from', ''), 'subject': headers.get('subject', ''),
+            'date': headers.get('date', ''), 'snippet': message.get('snippet', ''),
+            'unread': 'UNREAD' in message.get('labelIds', [])}
+
+
+def _cursor_context(account: str, family: str, query: str, last: int) -> dict:
+    return {'version': 1, 'account': hashlib.sha256(account.encode()).hexdigest(),
+            'family': family, 'query': query, 'limit': last}
+
+
+def _decode_cursor(cursor: str | None, context: dict) -> str | None:
+    if not cursor:
+        return None
+    try:
+        if len(cursor) > 16384:
+            raise ValueError
+        data = json.loads(base64.urlsafe_b64decode(cursor.encode()))
+        if (data['context'] != context or not time.time() < data['expires_at'] <= time.time() + 901
+                or not isinstance(data['token'], str) or not data['token']):
+            raise ValueError
+        return data['token']
+    except (ValueError, TypeError, KeyError, binascii.Error, UnicodeError):
+        raise MailboxError('invalid_cursor', 'Invalid, expired or mismatched Gmail cursor; repeat the original listing.') from None
+
+
+def _page(items: list, response: dict, context: dict) -> dict:
+    token = response.get('nextPageToken')
+    cursor = base64.urlsafe_b64encode(json.dumps({'context': context, 'token': token,
+        'expires_at': time.time() + 900}).encode()).decode() if token else None
+    return {'items': items, 'next_cursor': cursor, 'truncated': bool(token),
+            'total_estimate': response.get('resultSizeEstimate'), 'complete': True}
+
+
+def _attachment_parts(payload: dict) -> list[dict]:
+    stack, result, visited = [(payload, '0', 0)], [], 0
+    while stack:
+        part, location, depth = stack.pop()
+        visited += 1
+        if depth > 30 or visited > 1000:
+            raise MailboxError('mime_limit', 'Message exceeds the supported MIME nesting or part count.')
+        headers = {h['name'].casefold(): h['value'] for h in part.get('headers', [])}
+        disposition = headers.get('content-disposition', '').split(';', 1)[0].strip().casefold()
+        filename = part.get('filename', '')
+        body = part.get('body', {})
+        container_only = bool(part.get('parts')) and 'data' not in body and not body.get('attachmentId')
+        if (filename or disposition in {'inline', 'attachment'}) and not container_only:
+            result.append({'id': body.get('attachmentId') or f"part:{part.get('partId') or location}",
+                'filename': filename, 'mime_type': part.get('mimeType', 'application/octet-stream'),
+                'size': body.get('size', 0), 'inline': disposition == 'inline', '_body': body})
+        stack.extend((child, f'{location}.{i}', depth + 1)
+                     for i, child in reversed(list(enumerate(part.get('parts', [])))))
+    if len(result) > MAX_ATTACHMENTS or len({row['id'] for row in result}) != len(result):
+        raise MailboxError('attachment_limit', 'Too many attachments or duplicate provider part identifiers.')
+    return result
+
+
+def _filename(value: str) -> str:
+    name = value.replace('\\', '/').split('/')[-1]
+    name = re.sub(r'[\x00-\x1f\x7f<>:"|?*]', '_', name).strip(' .')
+    if not name or name.upper().split('.')[0] in {'CON','PRN','AUX','NUL', *(f'COM{i}' for i in range(1,10)), *(f'LPT{i}' for i in range(1,10))}:
+        name = 'attachment'
+    return name[:180]
+
+
+def _save_unique(directory: Path, filename: str, data: bytes) -> Path:
+    """Publish a complete private file atomically without replacing any entry."""
+    descriptor = None
+    if os.open in os.supports_dir_fd and os.link in os.supports_dir_fd:
+        descriptor = os.open(directory, os.O_RDONLY | os.O_DIRECTORY | getattr(os, 'O_NOFOLLOW', 0))
+    def at(name):
+        return name if descriptor is not None else directory / name
+    kwargs = {'dir_fd': descriptor} if descriptor is not None else {}
+    temporary = f'.co-gmail-{uuid4().hex}.tmp'
+    try:
+        with os.fdopen(os.open(at(temporary), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600, **kwargs), 'wb') as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        name = _filename(filename)
+        for suffix in range(10000):
+            candidate = name if not suffix else f'{Path(name).stem} ({suffix}){Path(name).suffix}'
+            try:
+                link_args = {'src_dir_fd': descriptor, 'dst_dir_fd': descriptor} if descriptor is not None else {}
+                os.link(at(temporary), at(candidate), **link_args)
+                return directory / candidate
+            except FileExistsError:
+                continue
+        raise MailboxError('name_conflict', 'No unused attachment filename is available.')
+    finally:
+        try:
+            os.unlink(at(temporary), **kwargs)
+        except FileNotFoundError:
+            # Creation can fail before a temporary entry exists.
+            if descriptor is not None:
+                os.close(descriptor)
+                descriptor = None
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+class GmailMailbox:
+    """Provider methods shared by Gmail's SDK and machine-readable CLI."""
+
+    def _mailbox_get(self, path: str, *, params: dict | None = None) -> dict:
+        # Reuse the bound record and broker refresh; never load a second account.
+        self._get_service()
+        for attempt in range(2):
+            with requests.get(f'https://gmail.googleapis.com/gmail/v1/users/me/{path}',
+                    params=params, headers={'Authorization': f'Bearer {self._credentials.get("ACCESS_TOKEN")}'},
+                    timeout=(5, 30), stream=True, allow_redirects=False) as response:
+                if response.status_code == 401 and attempt == 0:
+                    self._refresh_via_backend(None)
+                    continue
+                if response.status_code != 200:
+                    code = {401:'auth_required', 403:'permission_denied', 404:'not_found'}.get(response.status_code, 'provider_error')
+                    raise MailboxError(code, f'Gmail read failed (HTTP {response.status_code}).')
+                chunks, size = [], 0
+                for chunk in response.iter_content(65536):
+                    size += len(chunk)
+                    if size > RESPONSE_LIMIT:
+                        raise MailboxError('response_too_large', 'Gmail response exceeds the 40 MB read limit.')
+                    chunks.append(chunk)
+                try:
+                    data = json.loads(b''.join(chunks))
+                except (ValueError, UnicodeError):
+                    raise MailboxError('invalid_response', 'Gmail returned an invalid JSON response.') from None
+                if not isinstance(data, dict):
+                    raise MailboxError('invalid_response', 'Gmail returned an invalid response shape.')
+                return data
+        raise MailboxError('auth_required', 'Gmail authorization failed after refresh.')
+
+    def message_page(self, query: str, last: int = 10, cursor: str | None = None) -> dict:
+        """Fetch one page; estimates are not exact counts or immutable snapshots."""
+        if not 1 <= last <= 500:
+            raise MailboxError('invalid_limit', 'Message page size must be between 1 and 500.')
+        context = _cursor_context(self.get_account_email(), 'messages', query, last)
+        token = _decode_cursor(cursor, context)
+        response = self._mailbox_get('messages', params={'q': query, 'maxResults': last, 'pageToken': token})
+        items = [_summary(self._mailbox_get(f'messages/{quote(row["id"], safe="")}', params={'format':'metadata'}))
+                 for row in response.get('messages', [])]
+        return _page(items, response, context)
+
+    def read_message(self, email_id: str) -> dict:
+        """Read full IDs, headers and body without changing labels."""
+        message = self._mailbox_get(f'messages/{quote(email_id, safe="")}', params={'format':'full'})
+        return {**_summary(message), 'headers': _headers(message), 'labels': message.get('labelIds', []),
+                'body': self._extract_body(message.get('payload', {})), 'body_truncated': False}
+
+    def draft_page(self, last: int = 20, cursor: str | None = None) -> dict:
+        """Fetch one draft page with full provider IDs and continuation context."""
+        if not 1 <= last <= 500:
+            raise MailboxError('invalid_limit', 'Draft page size must be between 1 and 500.')
+        context = _cursor_context(self.get_account_email(), 'drafts', '', last)
+        response = self._mailbox_get('drafts', params={'maxResults': last, 'pageToken': _decode_cursor(cursor, context)})
+        return _page([self.get_draft(row['id']) for row in response.get('drafts', [])], response, context)
+
+    def list_unanswered(self, within_days: int = 30, last: int = 20,
+                        exclude_automated: bool = False, cursor: str | None = None) -> dict:
+        """Latest non-draft incoming message, irrespective of thread origin."""
+        if not 1 <= within_days <= 3650 or not 1 <= last <= 100:
+            raise MailboxError('invalid_limit', 'Use 1–3650 days and 1–100 threads per unanswered page.')
+        account = self.get_account_email()
+        query = f'newer_than:{within_days}d -in:trash -in:spam'
+        context = _cursor_context(account, 'unanswered', f'{query};automated={exclude_automated}', last)
+        response = self._mailbox_get('threads', params={'q': query, 'maxResults': last, 'pageToken': _decode_cursor(cursor, context)})
+        items = []
+        for row in response.get('threads', []):
+            thread = self._mailbox_get(f'threads/{quote(row["id"], safe="")}', params={'format':'metadata'})
+            messages = [m for m in thread.get('messages', []) if 'DRAFT' not in m.get('labelIds', [])]
+            if not messages:
+                continue
+            latest = max(messages, key=lambda m: int(m.get('internalDate', 0)))
+            if int(latest.get('internalDate', 0)) < (time.time() - within_days * 86400) * 1000:
+                continue
+            headers = _headers(latest)
+            sender = parseaddr(headers.get('from', ''))[1].strip().casefold()
+            if not sender or sender == account or 'SENT' in latest.get('labelIds', []):
+                continue
+            automated = headers.get('auto-submitted', 'no').casefold() != 'no' or headers.get('precedence', '').casefold() in {'bulk','list','junk'}
+            if exclude_automated and automated:
+                continue
+            items.append({**_summary(latest), 'automated': automated, 'messages_in_thread': len(messages)})
+        page = _page(items, response, context)
+        # Gmail estimates candidate threads, not threads that survived filtering.
+        page['candidate_threads_estimate'] = page.pop('total_estimate')
+        page['scanned_threads'] = len(response.get('threads', []))
+        page['filters'] = {'within_days': within_days, 'exclude_automated': exclude_automated}
+        return page
+
+    def list_attachments(self, email_id: str) -> list[dict]:
+        """Include nested named attachments and explicitly inline MIME parts."""
+        message = self._mailbox_get(f'messages/{quote(email_id, safe="")}', params={'format':'full'})
+        return [{k:v for k,v in row.items() if k != '_body'} for row in _attachment_parts(message.get('payload', {}))]
+
+    def download_attachments(self, email_id: str, directory: str | Path, *,
+                             attachment_id: str | None = None, all_attachments: bool = False) -> dict:
+        """Save selected attachments; retain successful files on partial failure."""
+        if bool(attachment_id) == all_attachments:
+            raise MailboxError('invalid_selection', 'Choose exactly one attachment ID or all attachments.')
+        destination = Path(directory).expanduser().resolve(strict=True)
+        if not destination.is_dir():
+            raise MailboxError('invalid_destination', 'Download destination must be an existing directory.')
+        message = self._mailbox_get(f'messages/{quote(email_id, safe="")}', params={'format':'full'})
+        rows = _attachment_parts(message.get('payload', {}))
+        selected = rows if all_attachments else [row for row in rows if row['id'] == attachment_id]
+        if attachment_id and not selected:
+            raise MailboxError('attachment_not_found', 'Attachment ID is not present in this message.')
+        results, consumed = [], 0
+        for row in selected:
+            result = {'id': row['id'], 'filename': row['filename']}
+            try:
+                body = row['_body']
+                size = body.get('size', 0)
+                if not isinstance(size, int) or size < 0 or size > ATTACHMENT_LIMIT or consumed + size > DOWNLOAD_LIMIT:
+                    raise MailboxError('attachment_too_large', 'Attachment exceeds the 25 MB file or 100 MB operation limit.')
+                if body.get('attachmentId'):
+                    body = self._mailbox_get(f'messages/{quote(email_id, safe="")}/attachments/{quote(body["attachmentId"], safe="")}')
+                encoded = body.get('data', '')
+                remaining = min(ATTACHMENT_LIMIT, DOWNLOAD_LIMIT - consumed)
+                if not isinstance(encoded, str) or len(encoded) > (remaining + 2) // 3 * 4:
+                    raise MailboxError('attachment_too_large', 'Encoded attachment exceeds the file limit.')
+                try:
+                    data = base64.b64decode(encoded + '=' * (-len(encoded) % 4), altchars=b'-_', validate=True)
+                except (ValueError, binascii.Error):
+                    raise MailboxError('invalid_attachment', 'Attachment contains invalid base64 data.') from None
+                if len(data) > remaining:
+                    raise MailboxError('attachment_too_large', 'Decoded attachment exceeds the remaining operation limit.')
+                consumed += len(data)
+                if len(data) != size or body.get('size', size) != size:
+                    raise MailboxError('size_mismatch', 'Attachment bytes do not match the provider size.')
+                if consumed > DOWNLOAD_LIMIT:
+                    raise MailboxError('attachment_too_large', 'Download exceeds the 100 MB operation limit.')
+                path = _save_unique(destination, row['filename'], data)
+                result.update(status='saved', path=str(path), size=len(data), sha256=hashlib.sha256(data).hexdigest())
+            except MailboxError as error:
+                result.update(status='failed', error={'code':error.code, 'message':str(error)})
+            except ProviderCredentialError as error:
+                result.update(status='failed', error={'code':error.code, 'message':'Google authorization failed during attachment download.'})
+            except (OSError, requests.RequestException):
+                result.update(status='failed', error={'code':'download_failed', 'message':'Attachment network or local file operation failed.'})
+            results.append(result)
+        return {'items': results, 'complete': all(row['status'] == 'saved' for row in results), 'decoded_bytes': consumed}
+
+    def unstar_email(self, email_id: str) -> str:
+        """Remove a star without affecting any other message label."""
+        self._get_service().users().messages().modify(userId='me', id=email_id, body={'removeLabelIds':['STARRED']}).execute()
+        return f'Unstarred email: {email_id}'
+
+    def remove_label(self, email_id: str, label: str) -> str:
+        """Remove the exact named label or full label ID."""
+        labels = self._get_service().users().labels().list(userId='me').execute().get('labels', [])
+        label_id = next((row['id'] for row in labels if row['name'].casefold() == label.casefold()), label)
+        self._get_service().users().messages().modify(userId='me', id=email_id, body={'removeLabelIds':[label_id]}).execute()
+        return f'Removed label from email: {email_id}'

--- a/docs/acceptance/1.8.4-gmail-mailbox.md
+++ b/docs/acceptance/1.8.4-gmail-mailbox.md
@@ -1,0 +1,38 @@
+# Gmail mailbox implementation and acceptance
+
+Target 1.8.4, #1446; stacked on listing correctness #1451 and credentials #1450.
+Implementation and live acceptance are distinct: the disposable mailbox write
+journey is awaiting explicit operator approval. No live test message has been
+sent by this slice.
+
+Focused provider/routing/listing/pipe/help tests: **288 passed** on macOS/Python
+3.14. Lazy-import and consistent command-group integration: **62 passed**.
+The first full run found those two integration issues, with 8,273 passing,
+23 skipped and 184 live tests deselected; both failures were reproduced and
+fixed. The final full rerun is in progress.
+
+New mailbox output-only discovery audit: **12/12** with pinned
+`co/gemini-3.7-flash`, mocked providers and isolated listing caches. No selected
+command was executed. JSON tests cover typed operational and usage failures,
+account and pagination fields, full IDs, missing/denied scope behavior and
+partial file results. Download regressions cover nested/inline MIME, encoded
+containers, length mismatch, invalid base64, byte caps, duplicate names,
+existing files, symlink collisions and retained success on partial failure.
+
+`python -m build --no-isolation` builds wheel and sdist. The wheel was installed
+outside the checkout with `pip install --no-deps --target`; its SHA-256 is
+`5415157c705029e795e2dc5623d0b6a7fcbc8e92f362dfa9d0ea027e1b3325a0`.
+It retains base version 1.8.3 until the coordinated release candidate is approved.
+Installed read-only page acceptance is in progress.
+
+The prepared live journey uses one synthetic message sent only to the
+configured Gmail account, three tiny text parts (duplicate names and inline
+MIME), label/read/star/archive checks on that message, collision-safe local
+downloads and final movement of the fixture to Trash. Automatic approval review
+requires explicit authorization for these side effects; the broader instruction
+to test with keys.env was not accepted as sufficient. That approval is pending.
+This also means no live download/write or cleanup success is claimed here.
+
+Design Journal passed the existing pinned story rubric after revision around
+the actual regression fixtures. The initial draft's quality failure is retained
+in the local evidence. No merge, package release or completion of #1424 is claimed.

--- a/docs/acceptance/1.8.4-gmail-mailbox.md
+++ b/docs/acceptance/1.8.4-gmail-mailbox.md
@@ -9,7 +9,10 @@ Focused provider/routing/listing/pipe/help tests: **288 passed** on macOS/Python
 3.14. Lazy-import and consistent command-group integration: **62 passed**.
 The first full run found those two integration issues, with 8,273 passing,
 23 skipped and 184 live tests deselected; both failures were reproduced and
-fixed. The final full rerun is in progress.
+fixed. The final full rerun at `d2568bd5` passed **8,277 tests**, with 23 skipped,
+184 live tests deselected and seven existing warnings (295.81 seconds).
+Command: `python -m pytest -q --tb=short -rf`, isolated home and synthetic broker
+key, with localhost access for the browser regressions.
 
 New mailbox output-only discovery audit: **12/12** with pinned
 `co/gemini-3.7-flash`, mocked providers and isolated listing caches. No selected
@@ -23,7 +26,9 @@ existing files, symlink collisions and retained success on partial failure.
 outside the checkout with `pip install --no-deps --target`; its SHA-256 is
 `5415157c705029e795e2dc5623d0b6a7fcbc8e92f362dfa9d0ea027e1b3325a0`.
 It retains base version 1.8.3 until the coordinated release candidate is approved.
-Installed read-only page acceptance is in progress.
+Installed read-only inbox, sent, unanswered and label-list JSON checks passed
+from `/private/tmp`; all four reported schema 1 and account fingerprint
+`abe6ff1509726914`. No mailbox content or account address was printed.
 
 The prepared live journey uses one synthetic message sent only to the
 configured Gmail account, three tiny text parts (duplicate names and inline

--- a/docs/blog/2026-09-07-a-download-can-partly-succeed.md
+++ b/docs/blog/2026-09-07-a-download-can-partly-succeed.md
@@ -1,0 +1,37 @@
+# A Download Can Partly Succeed
+
+Draft for 1.8.4; publish after release acceptance.
+
+The download regression starts with a file already on disk. It is named
+`report.txt`, and its contents are `old`. The simulated Gmail message contains
+two more files with that name. One even arrives as `../../report.txt`.
+The test asks the CLI to download all attachments into the chosen directory.
+
+A successful HTTP response cannot answer whether that operation was safe.
+Opening the first destination for writing would replace the existing file.
+Stripping the incoming path solves the directory escape but makes the two
+attachment names collide again. We need all three sets of bytes at the end,
+inside the selected directory, with the original file untouched.
+
+That is why filename selection happens at publication. Each decoded attachment
+is written to a private temporary file first. After the size check and fsync,
+the client tries to place it under an unused name. If another file already owns
+that name, it tries a numbered suffix. The collision check and placement must
+be one operation; checking that a path does not exist and then opening it
+would leave the same race in a smaller gap.
+
+The next fixture makes the second attachment's base64 invalid. Now the first
+file is safely saved, but the overall request has failed. Rolling the first
+file back would conceal useful completed work. Printing only an error would
+leave the operator unsure whether a retry would create another copy.
+
+The result therefore retains both parts: the first has a destination and hash,
+and the second has an error. The command exits 1. The test checks both the exit
+behavior and the directory, including that no partial second file was published.
+A separate symlink fixture checks that a colliding link cannot redirect the
+write to its target.
+
+These cases changed what counts as completion. The request was to save a set
+of attachments, so the answer has to account for that set. A single success
+sentence cannot describe the moment when one file is complete and the next
+one never made it to disk.

--- a/docs/blog/2026-09-07-a-download-can-partly-succeed.md
+++ b/docs/blog/2026-09-07-a-download-can-partly-succeed.md
@@ -2,36 +2,49 @@
 
 Draft for 1.8.4; publish after release acceptance.
 
-The download regression starts with a file already on disk. It is named
-`report.txt`, and its contents are `old`. The simulated Gmail message contains
-two more files with that name. One even arrives as `../../report.txt`.
-The test asks the CLI to download all attachments into the chosen directory.
+While adding incoming Gmail attachments, I reached a result that the usual success
+message could not describe. The first attachment was on disk. The second could not
+be decoded. The command had done useful work and had failed, both at once.
 
-A successful HTTP response cannot answer whether that operation was safe.
-Opening the first destination for writing would replace the existing file.
-Stripping the incoming path solves the directory escape but makes the two
-attachment names collide again. We need all three sets of bytes at the end,
-inside the selected directory, with the original file untouched.
+This happened in a deliberately broken development fixture, not a customer's
+mailbox. That distinction matters. We had no permission to use a real mailbox as a
+destructive experiment. But the operator's next decision was real enough: should
+they run the command again? An answer that concealed the first file could lead them
+to create another copy. An answer that celebrated the download could make them
+stop looking for the missing second file.
 
-That is why filename selection happens at publication. Each decoded attachment
-is written to a private temporary file first. After the size check and fsync,
-the client tries to place it under an unused name. If another file already owns
-that name, it tries a numbered suffix. The collision check and placement must
-be one operation; checking that a path does not exist and then opening it
-would leave the same race in a smaller gap.
+Before that complication, even choosing a destination had seemed straightforward.
+The selected directory already contained `report.txt`. The message supplied two
+more attachments with the same name, one disguised as `../../report.txt`. Opening
+the destination directly would replace an existing document. Removing the path
+components would stop the escape and leave us with the original collision.
 
-The next fixture makes the second attachment's base64 invalid. Now the first
-file is safely saved, but the overall request has failed. Rolling the first
-file back would conceal useful completed work. Printing only an error would
-leave the operator unsure whether a retry would create another copy.
+The tempting repair was to check whether a name existed and pick a suffix. That
+made the example look safe, but another process could claim the name between the
+check and the write. The protection had to hold when the bytes became visible,
+not just when we chose what to call them.
 
-The result therefore retains both parts: the first has a destination and hash,
-and the second has an error. The command exits 1. The test checks both the exit
-behavior and the directory, including that no partial second file was published.
-A separate symlink fixture checks that a colliding link cannot redirect the
-write to its target.
+So each attachment gets a private temporary file first. Only after decoding,
+checking its size and flushing the bytes do we publish it under an unused name.
+Placement itself refuses a collision; a competing file makes us try the next
+suffix. Existing documents stay where they are. A filename supplied by a message
+does not get to choose a directory outside the one the operator selected.
 
-These cases changed what counts as completion. The request was to save a set
-of attachments, so the answer has to account for that set. A single success
-sentence cannot describe the moment when one file is complete and the next
-one never made it to disk.
+Then the second attachment failed, and a different temptation appeared: remove
+the first file so the whole command could be called a failure. That would simplify
+the status at the cost of throwing away a completed download. It would also make
+the filesystem tell a less useful story merely to preserve a tidy return value.
+
+We kept the file. The result lists its destination and hash alongside the second
+attachment's error, and the command exits with status 1. The operator can see which
+part needs attention. The failed attachment never acquires a final filename.
+
+The regression now checks the directory as well as the result: the old document
+survives, successful bytes have their own names, and no partial second file looks
+complete. Those checks establish the local behavior. An authorized disposable
+mailbox journey is still owed before release acceptance.
+
+The useful change was in what we meant by completion. We were saving a set of
+attachments, not receiving one HTTP response. Once part of that set had reached
+disk, a single success sentence—or a single unexplained error—could no longer
+tell the operator what had happened.

--- a/docs/cli/gmail.md
+++ b/docs/cli/gmail.md
@@ -175,6 +175,70 @@ Search results use the same full-ID and `--listing` rules as the inbox.
 
 ## Piping
 
+### Structured pages and mailbox actions (1.8.4 candidate)
+
+```bash
+co gmail inbox --json
+co gmail search "in:sent" -n 25 --json
+co gmail search "in:sent" -n 25 --cursor <next-cursor> --json
+co gmail read <message-id> --json
+co gmail draft list --json
+co gmail draft preview <draft-id> --json
+co gmail mark <message-id> --read
+co gmail mark <message-id> --unread
+co gmail archive <message-id>
+co gmail star <message-id> --remove
+co gmail label list --json
+co gmail label add <message-id> <label-name-or-id>
+co gmail label remove <message-id> <label-name-or-id>
+co gmail attachments <message-id> --json
+co gmail download <message-id> --all --to ~/Downloads --json
+co gmail download <message-id> --attachment <attachment-id> --to ~/Downloads --json
+co gmail unanswered --within-days 30 --last 20 --json
+```
+
+Every new mailbox command supports `--json`, as do inbox, sent, search, read,
+draft list and draft preview. `co gmail --json` is the default inbox. JSON uses
+one schema-1 envelope: `provider`, `account`, `operation`, `status`, `complete`,
+`data`, `error`, `next_command`. It prints no prompts or extra stdout text.
+New commands put human hints on stderr. Operational/partial failures exit 1;
+invalid flags and missing arguments exit 2. A read with `--mark-read` fails when
+that mutation fails. Unknown scope metadata lets the provider decide.
+
+`data.next_cursor` continues the same account/query/filter/limit for 15 minutes.
+`data.truncated` reports more candidate pages; `complete` means this requested
+page or operation completed, not that the entire mailbox was fetched. Messages
+and drafts allow 1–500 items; unanswered scans 1–100 threads per page and can
+return fewer matches. Provider counts are estimates. Unanswered's estimate is
+explicitly for candidate threads. Live pages may repeat/omit rows if mail changes.
+Human listings also report whether more provider results exist.
+
+Unanswered selects the latest non-draft message by provider timestamp, checks
+that it is incoming and within the selected window, and includes conversations
+you started. Exact normalized mailbox identity and provider SENT evidence avoid
+substring matches and guessed aliases. `--exclude-automated` is optional and
+filters Auto-Submitted and bulk/list/junk headers. Sender names such as support,
+billing and invoice are not automatically filtered.
+
+Incoming attachments include nested named files and explicitly inline parts.
+Provider attachment IDs and `part:<partId>` inline identifiers are stable within
+the message. Attached-message bytes are downloaded as one file; nested children
+are also listed when the provider supplies them as MIME parts. Downloads require
+an existing destination directory and exactly one selector: `--all` or
+`--attachment ID`. Names are sanitized; collisions gain suffixes. Existing files
+and symlinks are never overwritten. Private temporary files become visible only
+after base64 and size checks pass. Limits: 25 MB/file, 100 MB/invocation,
+100 attachments, MIME depth 30/1,000 nodes, and 40 MB per streamed API response.
+Filesystems without atomic hard-link placement report a failure. Partial results
+retain completed files and include each path, hash or error; inspect before retry.
+
+Actions need `gmail.modify` or the full-mail grant. Read/list/download operations
+need Gmail read access. No label creation, automatic reply, Drive sharing or
+scheduled sending is added. [DD-068](../design-decisions/068-gmail-mailbox-pages-and-downloads.md)
+records the transport and pagination decisions.
+
+### Human output
+
 In a terminal you get a Rich table with truncated columns. When output is
 piped, you get the plain listing with **full message ids** instead, so scripts
 and agents never receive a truncated value:

--- a/docs/design-decisions/068-gmail-mailbox-pages-and-downloads.md
+++ b/docs/design-decisions/068-gmail-mailbox-pages-and-downloads.md
@@ -1,0 +1,51 @@
+# DD-068: Gmail mailbox pages and incoming downloads
+
+Date: 2026-09-07. Status: implementation candidate. Related: #1446, #1451.
+
+Gmail's CLI exposes its existing reversible actions and the missing inverses:
+mark read/unread, archive, star/unstar, label list/add/remove. Mutations require
+gmail.modify or the full-mail grant when metadata is known; missing metadata
+lets the provider decide. Read and incoming downloads preserve labels.
+
+Schema 1 JSON carries provider, account, operation, status, complete, data,
+error and next_command. One invocation fetches one provider page. Message and
+draft limits are 1–500; unanswered scans 1–100 candidate threads and can return
+fewer matches. Estimates are labeled; filtered unanswered estimates count
+candidate threads. Continuation cursors expire after 15 minutes and bind the
+account digest, operation family, query/filters and limit. They are context
+checks, not authorization tokens or immutable mailbox snapshots. Repeating a
+page against a changing mailbox can omit or repeat rows. Listing row tokens
+retain DD-067's separate immutable-ID semantics.
+
+Unanswered means the latest non-draft message is incoming and within the chosen
+window. Sort by provider internalDate, compare a parsed normalized exact mailbox,
+and treat Gmail's SENT label as own-send evidence for aliases. Do not infer
+aliases from other correspondents. Include threads the user started and support,
+billing or invoice senders. Optional automated filtering uses Auto-Submitted or
+Precedence headers; it is visible in output and never enabled by default.
+
+Incoming attachment traversal includes named and explicitly attached/inline
+parts, recursively, including attached-message children returned by Gmail.
+An attached message with encoded content is one downloadable object; this
+client does not parse its bytes into a second independent tree. IDs are provider
+attachment IDs or part:<partId> for inline data, with structural path fallback.
+Duplicate IDs fail. Limits: 1,000 MIME nodes, depth 30, 100 attachments, 25 MB
+decoded per file, 100 MB decoded per invocation, and 40 MB per HTTP JSON response.
+HTTP reads stream with timeouts and a byte cap; redirects are rejected. Base64
+and provider length evidence must agree before publication.
+
+Downloads require an existing directory. Strip both path separator forms and
+unsafe/reserved filename characters. Existing names, including symlinks, gain
+numeric suffixes. Write a private temporary file, fsync it, then atomically
+hard-link to an unused destination; never replace an existing entry. Platforms
+without hard-link support report failure rather than silently weakening the
+contract. On platforms with directory descriptors, publication stays relative
+to the opened destination directory. Successful files remain when another file
+fails, with per-file status/hash/error and exit 1 for partial completion.
+
+No label creation, automatic reply, attachment overwrite, Drive sharing or
+scheduled sending is added. Draft content-bound review remains #1424.
+
+Provider contracts: [message pages](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/list),
+[thread pages](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.threads/list),
+and [attachment bodies](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages.attachments/get).

--- a/tests/unit/test_gmail_mailbox.py
+++ b/tests/unit/test_gmail_mailbox.py
@@ -1,0 +1,157 @@
+"""Mailbox semantics and attachment acceptance with synthetic provider data."""
+import base64
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from connectonion.useful_tools.gmail import Gmail
+
+
+@pytest.fixture
+def gmail(monkeypatch):
+    client = Gmail.__new__(Gmail)
+    monkeypatch.setattr(client, 'get_account_email', lambda: 'me@example.test')
+    return client
+
+
+def message(id, sender, timestamp, labels=(), **headers):
+    return {'id': id, 'threadId': 'thread', 'internalDate': str(int(time.time() * 1000) + timestamp), 'labelIds': list(labels),
+            'payload': {'headers': [{'name': k, 'value': v} for k,v in {'From': sender, **headers}.items()]}}
+
+
+def test_unanswered_includes_user_started_support_threads_and_ignores_drafts(gmail, monkeypatch):
+    calls = MagicMock(side_effect=[{'threads': [{'id': 'thread'}]}, {'messages': [
+        message('draft', 'me@example.test', 300, ['DRAFT']),
+        message('incoming', 'Support <support@example.test>', 200),
+        message('original', 'me@example.test', 100, ['SENT'])]}])
+    monkeypatch.setattr(gmail, '_mailbox_get', calls, raising=False)
+    page = gmail.list_unanswered(within_days=30, last=20)
+    assert [row['id'] for row in page['items']] == ['incoming']
+    assert page['filters']['exclude_automated'] is False
+
+
+@pytest.mark.parametrize('sender,labels,expected', [
+    ('Name <ME@example.test>', [], []), ('notme@example.test', [], ['latest']),
+    ('alias@example.test', ['SENT'], []), ('billing@example.test', [], ['latest'])])
+def test_unanswered_uses_exact_mailbox_and_provider_sent_evidence(gmail, monkeypatch, sender, labels, expected):
+    monkeypatch.setattr(gmail, '_mailbox_get', MagicMock(side_effect=[{'threads':[{'id':'thread'}]},
+        {'messages':[message('latest', sender, 100, labels)]}]), raising=False)
+    assert [row['id'] for row in gmail.list_unanswered()['items']] == expected
+
+
+def test_automated_filter_is_opt_in_and_visible(gmail, monkeypatch):
+    def read(path, **kwargs):
+        return {'threads':[{'id':'thread'}]} if path == 'threads' else {
+            'messages':[message('latest', 'billing@example.test', 100, **{'Auto-Submitted':'auto-generated'})]}
+    monkeypatch.setattr(gmail, '_mailbox_get', read, raising=False)
+    assert len(gmail.list_unanswered()['items']) == 1
+    assert gmail.list_unanswered(exclude_automated=True)['items'] == []
+
+
+def part(name, data=b'hello', id='1', **extra):
+    return {'partId': id, 'filename':name, 'mimeType':'text/plain',
+            'body':{'size':len(data), 'data':base64.urlsafe_b64encode(data).decode()}, **extra}
+
+
+def test_nested_and_inline_attachments_have_stable_ids(gmail, monkeypatch):
+    payload = {'parts':[{'parts':[part('a.txt', id='1.0'), part('', id='1.1',
+        headers=[{'name':'Content-Disposition','value':'inline'}])]}]}
+    monkeypatch.setattr(gmail, '_mailbox_get', lambda *a,**kw:{'payload':payload}, raising=False)
+    rows = gmail.list_attachments('message')
+    assert [row['id'] for row in rows] == ['part:1.0', 'part:1.1']
+    assert rows[1]['inline'] is True
+    assert 'data' not in str(rows)
+
+
+def test_download_sanitizes_names_and_never_overwrites(gmail, monkeypatch, tmp_path):
+    (tmp_path / 'report.txt').write_bytes(b'old')
+    payload = {'parts':[part('../../report.txt', b'one', '1'), part('report.txt', b'two', '2')]}
+    monkeypatch.setattr(gmail, '_mailbox_get', lambda *a,**kw:{'payload':payload}, raising=False)
+    result = gmail.download_attachments('message', tmp_path, all_attachments=True)
+    assert result['complete'] is True
+    assert (tmp_path/'report.txt').read_bytes() == b'old'
+    assert {Path(row['path']).read_bytes() for row in result['items']} == {b'one', b'two'}
+    assert all(Path(row['path']).parent == tmp_path for row in result['items'])
+
+
+def test_partial_download_preserves_success_and_reports_bad_data(gmail, monkeypatch, tmp_path):
+    bad = part('bad.txt', id='2'); bad['body']['data'] = '!!!'
+    monkeypatch.setattr(gmail, '_mailbox_get', lambda *a,**kw:{'payload':{'parts':[part('good.txt'),bad]}}, raising=False)
+    result = gmail.download_attachments('message', tmp_path, all_attachments=True)
+    assert result['complete'] is False
+    assert [row['status'] for row in result['items']] == ['saved','failed']
+    assert not (tmp_path/'bad.txt').exists()
+
+
+def test_attachment_length_mismatch_is_failure(gmail, monkeypatch, tmp_path):
+    payload = part('wrong.txt'); payload['body']['size'] = 99
+    monkeypatch.setattr(gmail, '_mailbox_get', lambda *a,**kw:{'payload':payload}, raising=False)
+    result = gmail.download_attachments('message', tmp_path, all_attachments=True)
+    assert result['items'][0]['error']['code'] == 'size_mismatch'
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_page_cursor_cannot_cross_account_or_query(gmail, monkeypatch):
+    from connectonion.useful_tools.gmail_mailbox import MailboxError
+    monkeypatch.setattr(gmail, '_mailbox_get', MagicMock(return_value={'messages':[], 'nextPageToken':'provider-next', 'resultSizeEstimate':123}), raising=False)
+    page = gmail.message_page('in:inbox', last=10)
+    assert page['total_estimate'] == 123 and page['truncated'] is True
+    with pytest.raises(MailboxError, match='cursor'):
+        gmail.message_page('in:sent', last=10, cursor=page['next_cursor'])
+    monkeypatch.setattr(gmail, 'get_account_email', lambda:'other@example.test')
+    with pytest.raises(MailboxError, match='cursor'):
+        gmail.message_page('in:inbox', last=10, cursor=page['next_cursor'])
+
+
+def test_response_stream_is_bounded_before_json_decode(gmail, monkeypatch):
+    from connectonion.useful_tools import gmail_mailbox as module
+    from connectonion.provider_credentials import resolve_provider_credentials
+    gmail._credentials = resolve_provider_credentials('google')
+    monkeypatch.setattr(gmail, '_get_service', lambda:None)
+    monkeypatch.setattr(module, 'RESPONSE_LIMIT', 10)
+    response = MagicMock(status_code=200)
+    response.iter_content.return_value = [b'123456', b'789012']
+    response.__enter__.return_value = response
+    monkeypatch.setattr(module.requests, 'get', MagicMock(return_value=response))
+    with pytest.raises(module.MailboxError, match='limit'):
+        gmail._mailbox_get('messages/id')
+    response.__exit__.assert_called_once()
+    assert module.requests.get.call_args.kwargs['allow_redirects'] is False
+
+
+def test_recent_draft_does_not_make_old_incoming_message_unanswered(gmail, monkeypatch):
+    old = message('old', 'other@example.test', -60 * 86400 * 1000)
+    draft = message('draft', 'me@example.test', 0, ['DRAFT'])
+    monkeypatch.setattr(gmail, '_mailbox_get', MagicMock(side_effect=[{'threads':[{'id':'thread'}]},
+        {'messages':[old, draft]}]), raising=False)
+    assert gmail.list_unanswered(within_days=30)['items'] == []
+
+
+def test_symlink_collision_cannot_replace_or_modify_target(gmail, monkeypatch, tmp_path):
+    outside = tmp_path/'outside'; outside.write_bytes(b'private')
+    directory = tmp_path/'downloads'; directory.mkdir()
+    (directory/'file.txt').symlink_to(outside)
+    monkeypatch.setattr(gmail, '_mailbox_get', lambda *a,**kw:{'payload':part('file.txt')}, raising=False)
+    result = gmail.download_attachments('message', directory, all_attachments=True)
+    assert result['complete'] is True and outside.read_bytes() == b'private'
+    assert Path(result['items'][0]['path']).name == 'file (1).txt'
+
+
+def test_container_without_own_bytes_is_not_a_fake_empty_attachment(gmail, monkeypatch):
+    payload = {'filename':'attached.eml', 'mimeType':'message/rfc822', 'body':{'size':0},
+               'parts':[part('inner.txt', id='1.0')]}
+    monkeypatch.setattr(gmail, '_mailbox_get', lambda *a,**kw:{'payload':payload}, raising=False)
+    assert [row['filename'] for row in gmail.list_attachments('message')] == ['inner.txt']
+
+
+def test_total_budget_stops_later_files_without_losing_saved_files(gmail, monkeypatch, tmp_path):
+    from connectonion.useful_tools import gmail_mailbox as module
+    monkeypatch.setattr(module, 'DOWNLOAD_LIMIT', 7)
+    monkeypatch.setattr(gmail, '_mailbox_get', lambda *a,**kw:{'payload':{'parts':[
+        part('first.txt', b'1234','1'),part('second.txt',b'5678','2')]}}, raising=False)
+    result = gmail.download_attachments('message', tmp_path, all_attachments=True)
+    assert [row['status'] for row in result['items']] == ['saved','failed']
+    assert result['decoded_bytes'] == 4
+    assert result['items'][1]['error']['code'] == 'attachment_too_large'

--- a/tests/unit/test_gmail_mailbox_cli.py
+++ b/tests/unit/test_gmail_mailbox_cli.py
@@ -1,0 +1,96 @@
+"""Public parser, JSON, account context, scopes and partial mutation outcomes."""
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from connectonion.cli.main import app
+from connectonion.cli.commands import gmail_commands as gm
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    client = MagicMock()
+    client.get_account_email.return_value = 'me@example.test'
+    client._credentials.scopes = {'gmail.modify'}
+    client.message_page.return_value = {'items':[], 'truncated':False, 'next_cursor':None, 'total_estimate':0, 'complete':True}
+    client.read_message.return_value = {'id':'message-id', 'body':'Hello', 'headers':{}, 'body_truncated':False}
+    monkeypatch.setattr(gm, '_gmail', lambda:client)
+    monkeypatch.setattr(gm, 'INBOX_CACHE', tmp_path/'legacy.json')
+    return client
+
+
+@pytest.mark.parametrize('args,method', [
+    (['mark','message-id','--read'],'mark_read'), (['mark','message-id','--unread'],'mark_unread'),
+    (['star','message-id'],'star_email'), (['star','message-id','--remove'],'unstar_email'),
+    (['archive','message-id'],'archive_email'),
+    (['label','add','message-id','Projects'],'add_label'), (['label','remove','message-id','Projects'],'remove_label')])
+def test_actions_route_and_emit_one_complete_envelope(client, args, method):
+    getattr(client, method).return_value = 'done'
+    result = CliRunner().invoke(app, ['gmail', *args, '--json'])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert data['schema_version'] == 1 and data['account'] == 'me@example.test'
+    assert data['complete'] is True and data['data']['id'] == 'message-id'
+    assert result.stderr == ''
+    assert getattr(client, method).call_args.args == ('message-id',)
+
+
+@pytest.mark.parametrize('args', [['mark','id'], ['mark','id','--read','--unread'],
+    ['download','id','--to','.'], ['download','id','--to','.','--all','--attachment','a'],
+    ['inbox','--last','501'], ['read']])
+def test_json_usage_failures_are_exit_two_without_provider_access(client, args):
+    result = CliRunner().invoke(app, ['gmail', *args, '--json'])
+    assert result.exit_code == 2, result.output
+    assert json.loads(result.stdout)['error']['code'] == 'usage_error'
+    client.get_account_email.assert_not_called()
+
+
+def test_read_json_does_not_mutate_unless_requested(client):
+    result = CliRunner().invoke(app, ['gmail','read','message-id','--json'])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)['data']['body'] == 'Hello'
+    client.mark_read.assert_not_called()
+
+
+def test_known_readonly_grant_blocks_mutation_and_returns_typed_error(client):
+    client._credentials.scopes = {'gmail.readonly'}
+    result = CliRunner().invoke(app, ['gmail','read','message-id','--mark-read','--json'])
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)['error']['code'] == 'permission_denied'
+    client.mark_read.assert_not_called()
+
+
+def test_unknown_scope_metadata_allows_provider_authority(client):
+    client._credentials.scopes = set()
+    client.mark_read.return_value = 'done'
+    result = CliRunner().invoke(app, ['gmail','mark','message-id','--read','--json'])
+    assert result.exit_code == 0
+    client.mark_read.assert_called_once_with('message-id')
+
+
+def test_partial_download_is_nonzero_with_successes_preserved(client):
+    client.download_attachments.return_value = {'complete':False, 'items':[
+        {'id':'one', 'status':'saved', 'path':'/tmp/one'},
+        {'id':'two', 'status':'failed', 'error':{'code':'size_mismatch'}}]}
+    result = CliRunner().invoke(app, ['gmail','download','message-id','--all','--to','.', '--json'])
+    assert result.exit_code == 1
+    data = json.loads(result.stdout)
+    assert data['status'] == 'partial'
+    assert len(data['data']['items']) == 2
+
+
+def test_inbox_json_exposes_pagination_and_full_ids(client):
+    client.message_page.return_value['items'] = [{'id':'full-very-long-message-id'}]
+    result = CliRunner().invoke(app, ['gmail','inbox','--json'])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert data['data']['items'][0]['id'] == 'full-very-long-message-id'
+    assert data['next_command'] == 'co gmail read full-very-long-message-id'
+
+
+def test_cursor_is_forwarded_with_original_search(client):
+    result = CliRunner().invoke(app, ['gmail','search','in:sent','--last','4','--cursor','cursor', '--json'])
+    assert result.exit_code == 0, result.output
+    client.message_page.assert_called_once_with('in:sent', last=4, cursor='cursor')

--- a/tests/unit/test_gmail_mailbox_tips.py
+++ b/tests/unit/test_gmail_mailbox_tips.py
@@ -1,0 +1,68 @@
+"""Pinned text-only discovery: never execute a model's chosen command."""
+from contextlib import ExitStack
+import json
+from pathlib import Path
+import shlex
+import sys
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from connectonion.cli.main import app
+from connectonion.cli.commands import gmail_commands as gm
+
+CASES = [
+    (['mark','message-a','--read'], 'Read the updated message as JSON', 'co gmail read message-a --json'),
+    (['mark','message-a','--unread'], 'Read the updated message as JSON', 'co gmail read message-a --json'),
+    (['archive','message-a'], 'Read the updated message as JSON', 'co gmail read message-a --json'),
+    (['star','message-a'], 'Read the updated message as JSON', 'co gmail read message-a --json'),
+    (['star','message-a','--remove'], 'Read the updated message as JSON', 'co gmail read message-a --json'),
+    (['label','list'], 'Learn the label-add syntax', 'co gmail label add --help'),
+    (['label','add','message-a','Projects'], 'Read the updated message as JSON', 'co gmail read message-a --json'),
+    (['label','remove','message-a','Projects'], 'Read the updated message as JSON', 'co gmail read message-a --json'),
+    (['attachments','message-a'], 'Download all listed attachments to /tmp', 'co gmail download message-a --all --to /tmp'),
+    (['download','message-a','--all','--to','/tmp'], 'Inspect the message attachment list as JSON', 'co gmail attachments message-a --json'),
+    (['unanswered'], 'Read the first listed email', 'co gmail read message-a'),
+    (['mark','message-a','--json'], 'Learn the required mark flags', 'co gmail mark --help'),
+]
+
+
+def capture(args, directory):
+    client = MagicMock()
+    client.get_account_email.return_value = 'me@example.invalid'
+    client._credentials.scopes = {'gmail.modify'}
+    for name in ['mark_read','mark_unread','archive_email','star_email','unstar_email','add_label','remove_label']:
+        getattr(client,name).return_value = 'Message updated: message-a'
+    client._get_service().users().labels().list().execute.return_value = {'labels':[{'id':'Label_a', 'name':'Projects'}]}
+    client.list_attachments.return_value = [{'id':'attachment-a', 'filename':'report.txt','size':5,'mime_type':'text/plain','inline':False}]
+    client.download_attachments.return_value = {'items':[{'id':'attachment-a','status':'saved','path':'/tmp/report.txt'}],'complete':True}
+    client.list_unanswered.return_value = {'items':[{'id':'message-a','from':'other@example.invalid'}], 'complete':True,'truncated':False,'next_cursor':None}
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(gm, '_gmail', return_value=client))
+        stack.enter_context(patch.object(gm, 'INBOX_CACHE', directory/'legacy.json'))
+        return CliRunner().invoke(app, ['gmail', *args])
+
+
+@pytest.mark.parametrize('args,goal,expected', CASES)
+def test_piped_next_command_is_present(args, goal, expected, tmp_path):
+    result = capture(args, tmp_path)
+    assert result.exit_code == (2 if args == ['mark','message-a','--json'] else 0)
+    if '--json' in args:
+        assert json.loads(result.stdout)['next_command'] == expected
+    elif args[0] == 'attachments':
+        assert 'co gmail download message-a --all --to <directory>' in result.stderr
+    else:
+        assert expected in result.stderr
+
+
+if __name__ == '__main__':
+    from connectonion import llm_do
+    with tempfile.TemporaryDirectory(prefix='gmail-mailbox-tip-') as directory:
+        for args, goal, expected in CASES:
+            result = capture(args, Path(directory))
+            reply = llm_do(f'You ran a shell command. Its full output was:\n{result.output}\n'
+                f'Goal: {goal}. Reply with ONE shell command and nothing else.', model='co/gemini-3.7-flash').strip()
+            print(json.dumps({'command':'co gmail '+' '.join(args), 'goal':goal,
+                'expected':expected, 'reply':reply, 'passed':shlex.split(reply)==shlex.split(expected)}), flush=True)

--- a/tests/unit/test_google_cli_design.py
+++ b/tests/unit/test_google_cli_design.py
@@ -47,14 +47,14 @@ CASES = [
 ]
 
 
-@pytest.mark.parametrize('path', [('gmail',), ('gmail', 'draft'), ('gdrive',)])
+@pytest.mark.parametrize('path', [('gmail',), ('gmail', 'draft'), ('gmail', 'label'), ('gdrive',)])
 def test_help_and_skill_parity(path):
     command = get_command(app)
     for name in path:
         command = command.commands[name]
     visible = {name for name, child in command.commands.items() if not child.hidden}
     skill = (Path(__file__).resolve().parents[2] / 'connectonion/useful_skills/co-mail-and-drive/SKILL.md').read_text()
-    documented = set(re.findall(r'co ' + ' '.join(path) + r' ([a-z-]+)', skill))
+    documented = set(re.findall(r'co ' + ' '.join(path) + r' ([a-z][a-z-]*)', skill))
     result = CliRunner().invoke(app, [*path, '--help'])
     assert result.exit_code == 0
     assert visible == documented


### PR DESCRIPTION
## Preview publication decision — 8 September 2026

The owner explicitly authorized technical-article model review and Gmail/Drive fixture writes, then requested publishing **1.8.4a1 preview first**, followed by local installed-package acceptance. The approved journal is now included. Final 1.8.4 stable still needs the live Gmail/Drive and physical NAS journeys; they do not block this explicitly requested opt-in preview. The earlier pending-export statements below are historical. All required current-head checks must pass before merge; none is waived.

Gmail's provider already supports useful mailbox actions, but the CLI did not expose them or provide incoming attachment downloads. This PR adds mark read/unread, archive, star/remove, label list/add/remove, recursive attachment listing/download, and latest-incoming unanswered pages. Existing list/read surfaces gain versioned JSON and explicit continuation context.

Refs #1446 and #1445. Depends on #1451 (listing correctness), which depends on #1450 (credentials). Base: `fix/1.8.4-gmail-context` at `97baf3cb`. Draft review/send safety remains separate in #1424.

- **Proposed target version:** 1.8.4a1 preview; 1.8.4 stable after acceptance
- **Estimated release window:** after coordinated 1.8.4 acceptance; no publication date promised
- **Suggested labels:** enhancement
- **Forward-port tracking issue (stable patches only):** N/A — stacked mainline work; policy correction #1449

Schema 1 JSON reports account, operation, completeness, typed errors and a quoted next command. Cursors bind account/query/filter/limit for 15 minutes. One invocation fetches one provider page; estimates remain estimates, and filtered unanswered results identify candidate counts separately. Unanswered compares exact normalized mailbox identity and SENT evidence, ignores drafts, includes user-started conversations, and makes automated filtering opt-in.

Attachment reads are streamed and bounded. Nested named/inline parts have stable IDs; encoded attached messages are downloadable while container-only nodes are traversed without inventing empty files. Downloads validate base64 and provider lengths, sanitize paths/names, preserve existing files, and publish private temporary files atomically to unused names. Limits: 25 MB/file, 100 MB/invocation, 100 attachments, depth 30/1,000 MIME nodes, 40 MB HTTP response. Partial completion retains per-file success/failure and exits 1.

Verification: **288 focused tests**, **62 import/group/CLI integration tests**, and **12/12 pinned output-only tip cases**. Wheel/sdist build and installation outside the checkout pass. Installed read-only Gmail inbox/sent/unanswered/label JSON checks passed with unchanged account fingerprint. The first full suite exposed eager provider imports and an inconsistent Typer subgroup; both are fixed. The final full rerun at `d2568bd5` passed **8,277 tests**, with 23 skipped, 184 live tests deselected and seven existing warnings (295.81 seconds). `docs/acceptance/1.8.4-gmail-mailbox.md` records the exact evidence and limitations.

Live mailbox writes/downloads on a disposable self-account fixture remain an acceptance gate. Automatic approval review did not accept the general instruction to test with keys.env as explicit authorization to send a test message or change its labels, so that approval is pending. No live message was sent by this slice and no write acceptance is claimed. This PR remains draft and does not close #1446.

Docs: `docs/cli/gmail.md`, packaged `co-mail-and-drive` skill, DD 068 and the Design Journal draft `docs/blog/2026-09-07-a-download-can-partly-succeed.md` (passed the existing story rubric). Mostly AI-generated with Codex (GPT-6). No merge, version bump or publication is performed.

## CI follow-up

The Linux matrix exposed ANSI styling inside the listing-help assertion. The regression now exercises color and plain terminals and checks the unstyled rendered text: **28 targeted cases pass**. Runtime code is unchanged. The PR stack includes #1449 so the metadata gate distinguishes mainline work from maintenance-branch patches. Earlier failing CI runs remain historical evidence, not a clean result.

