### PR TITLE
fix(gmail): send exactly reviewed drafts and preserve uncertain outcomes

### DIFF
--- a/connectonion/cli/commands/gdrive_commands.py
+++ b/connectonion/cli/commands/gdrive_commands.py
@@ -1,12 +1,4 @@
-"""
-Purpose: CLI surface for the user's Google Drive — list, search, download, upload, and trash files from the terminal
-LLM-Note:
-  Dependencies: imports from [json, os, pathlib, typer, dotenv, rich.console, rich.table, ...useful_tools.gdrive.GDrive] | imported by [cli/main.py via handle_gdrive_*()] | hits the Drive API through the GDrive tool
-  Data flow: _gdrive() loads GOOGLE_* from .env / ~/.co/keys.env and checks the drive scope → GDrive() instance | list/search: list_files()/search_files() → numbered Rich table (tab-separated with full ids when piped) → saves {#: file_id} to ~/.co/gdrive_last_list.json | get/rm: resolve short numbers via that cache → download()/delete()
-  State/Effects: writes ~/.co/gdrive_last_list.json (last listing's # → file id map; "numbers mean your last listing") | downloads write local files | put uploads to Drive | rm trashes (recoverable) rather than deleting
-  Integration: exposes handle_gdrive_list(), handle_gdrive_search(), handle_gdrive_get(), handle_gdrive_put(), handle_gdrive_rm() for cli/main.py | presentation mirrors gmail_commands.py / outlook_commands.py | Drive logic lives in useful_tools/gdrive.py | requires prior 'co auth google'
-  Errors: guarded failures print a next command and exit 1 (typer.Exit); google_errors sanitizes provider/transport failures | empty list/search clears old numbers; piped rows append their row number as column five
-"""
+"""Drive CLI with frozen account-bound listings and read-only inspection."""
 
 import json
 import os
@@ -22,7 +14,10 @@ from ...provider_credentials import resolve_provider_credentials
 
 console = Console()
 
-LIST_CACHE = Path.home() / ".co" / "gdrive_last_list.json"
+from ...environment import global_config_dir
+from .gmail_listings import save_listing, resolve_reference
+
+LIST_CACHE = global_config_dir() / "gdrive_last_list.json"  # legacy location; only its parent is used
 
 
 def _gdrive():
@@ -87,11 +82,10 @@ def _when(timestamp: str) -> str:
     return datetime.fromisoformat(cleaned).astimezone().strftime("%b %d %H:%M")
 
 
-def _print_listing(files: list, title: str):
+def _print_listing(drive, files: list, title: str):
     """Render files as a numbered table (or tab-separated rows with full ids when piped) and cache the numbering."""
-    LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
-    LIST_CACHE.write_text(json.dumps({str(i): f["id"] for i, f in enumerate(files, 1)}), encoding="utf-8")
-
+    token = save_listing(LIST_CACHE.parent / "gdrive-listings", drive.get_account_email(),
+                         "files", [item["id"] for item in files], provider="gdrive")
     if not console.is_terminal:
         # Scripts and agents get full file ids, never a truncated column.
         # Plain print, not console.print: Rich expands \t into spaces, which
@@ -100,7 +94,9 @@ def _print_listing(files: list, title: str):
             print(f"{item['name']}\t{item['type']}\t{item['size']}\t{item['id']}\t{i}")
         # Same next-step tip as the terminal table: piped callers are exactly
         # the AI audience the tip exists for.
-        print_tip("Download one with: co gdrive get <# from column 5>")
+        print(f"Listing: {token} (15 minutes; use --listing {token} with a row)")
+        if files:
+            print_tip(f"Download one with: co gdrive get {files[0]['id']}")
         return
 
     table = Table(title=title, show_header=True, header_style="bold cyan")
@@ -115,7 +111,9 @@ def _print_listing(files: list, title: str):
 
     console.print()
     console.print(table)
-    print_tip("\n[dim]Download one with:[/dim] [bold]co gdrive get <#>[/bold]\n")
+    print(f"Listing: {token} (15 minutes; use --listing {token} with a row)")
+    if files:
+        print_tip(f"Download one with: co gdrive get {files[0]['id']}")
 
 
 @google_errors("co gdrive list")
@@ -124,12 +122,11 @@ def handle_gdrive_list(last: int = 20):
     drive = _gdrive()
     files = drive.list_files(last=last)
     if not files:
-        LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
-        LIST_CACHE.write_text("{}", encoding="utf-8")
+        _print_listing(drive, [], "Drive")
         console.print("\n[cyan]Google Drive:[/cyan] no files\n")
         print_tip("Search by name: co gdrive search <name prefix>")
         return
-    _print_listing(files, f"📁 Drive — {resolve_provider_credentials('google').get('EMAIL') or ''}")
+    _print_listing(drive, files, f"📁 Drive — {resolve_provider_credentials('google').get('EMAIL') or ''}")
 
 
 @google_errors("co gdrive list")
@@ -138,33 +135,29 @@ def handle_gdrive_search(query: str, last: int = 20):
     drive = _gdrive()
     files = drive.search_files(query, last=last)
     if not files:
-        LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
-        LIST_CACHE.write_text("{}", encoding="utf-8")
+        _print_listing(drive, [], "Drive")
         console.print(f"\n[cyan]Drive search:[/cyan] no files matching [bold]{query}[/bold]")
         console.print("[dim]Drive matches word prefixes, not any substring.[/dim]\n")
         print_tip("Show recent files: co gdrive list")
         return
-    _print_listing(files, f"🔎 Drive — {query}")
+    _print_listing(drive, files, f"🔎 Drive — {query}")
 
 
-def _resolve_file_id(file_id: str) -> str:
-    """Turn a listing number into a Drive file id; full ids pass through."""
-    cached = json.loads(LIST_CACHE.read_text(encoding="utf-8")) if LIST_CACHE.exists() else {}
-    if file_id in cached:
-        return cached[file_id]
-
-    if file_id.isascii() and file_id.isdigit() and len(file_id) < 5:
-        # A short number means "row N of what you just showed me" — refetching a
-        # differently ordered listing would silently act on the wrong file.
-        return ""
-    return file_id
+def _resolve_file_id(file_id: str, drive=None, listing: str | None = None) -> str:
+    """Resolve a number only within its frozen provider-confirmed listing."""
+    number = file_id.removeprefix('#')
+    if not (number.isascii() and number.isdigit() and len(number) < 5):
+        return file_id
+    account = drive.get_account_email() if drive is not None else ''
+    return resolve_reference(LIST_CACHE.parent / "gdrive-listings", file_id, account,
+                             "files", listing, provider="gdrive")
 
 
 @google_errors("co gdrive list")
-def handle_gdrive_get(file_id: str, dest: str = "."):
+def handle_gdrive_get(file_id: str, dest: str = ".", *, listing: str | None = None):
     """Download a Drive file. Accepts the listing # or a full file id."""
     drive = _gdrive()
-    resolved = _resolve_file_id(file_id)
+    resolved = _resolve_file_id(file_id, drive, listing)
     if not resolved:
         console.print(f"\nNo file #{file_id} in your last listing.", markup=False)
         print_tip("Refresh the listing: co gdrive list")
@@ -191,10 +184,10 @@ def handle_gdrive_put(path: str, name: str = None):
 
 
 @google_errors("co gdrive list")
-def handle_gdrive_rm(file_id: str):
+def handle_gdrive_rm(file_id: str, *, listing: str | None = None):
     """Move a Drive file to the trash. Accepts the listing # or a full file id."""
     drive = _gdrive()
-    resolved = _resolve_file_id(file_id)
+    resolved = _resolve_file_id(file_id, drive, listing)
     if not resolved:
         console.print(f"\nNo file #{file_id} in your last listing.", markup=False)
         print_tip("Refresh the listing: co gdrive list")
@@ -203,3 +196,38 @@ def handle_gdrive_rm(file_id: str):
     drive.delete(resolved)
     console.print("\n[green]✓ Moved to trash[/green] — restore it from drive.google.com if that was wrong\n")
     print_tip("Show remaining files: co gdrive list")
+
+
+@google_errors("co gdrive list")
+def _inspect_file(file_id: str, listing: str | None = None) -> tuple[str, dict]:
+    drive = _gdrive()
+    return drive.get_account_email(), drive.get_info(_resolve_file_id(file_id, drive, listing))
+
+
+def handle_gdrive_info(file_id: str, *, listing: str | None = None, json_output: bool = False) -> None:
+    """Inspect a full Drive file ID with a single machine-readable result."""
+    from contextlib import redirect_stdout, redirect_stderr
+    import io
+    import shlex
+    from ...environment import selected_command
+    result = {"schema_version":1, "provider":"gdrive", "operation":"info", "account":None,
+              "status":"error", "complete":False, "data":None, "error":None}
+    output = io.StringIO()
+    next_command = 'co gdrive list'
+    try:
+        with redirect_stdout(output), redirect_stderr(output):
+            account, data = _inspect_file(file_id, listing)
+        result.update(account=account, data=data, status="success", complete=True)
+        next_command = f'co gdrive get {shlex.quote(data["id"])}'
+    except typer.Exit:
+        result['error'] = {"code":"inspection_failed", "message":output.getvalue().strip()}
+        if 'co auth google' in output.getvalue():
+            next_command = 'co auth google'
+    result['next_command'] = selected_command(next_command)
+    if json_output:
+        print(json.dumps(result, ensure_ascii=False))
+    else:
+        print(json.dumps(result['data'] or result['error'], ensure_ascii=False, indent=2))
+        print_tip(f'Next: {result["next_command"]}')
+    if not result['complete']:
+        raise typer.Exit(1)

--- a/connectonion/cli/commands/gmail_commands.py
+++ b/connectonion/cli/commands/gmail_commands.py
@@ -345,18 +345,24 @@ def _print_draft_preview(draft: dict, tip: bool = True) -> None:
     console.print("\n--- Body ---", markup=False)
     console.print(draft["body"] or "(empty body)", markup=False, highlight=False)
     console.print("\n--- Attachments ---", markup=False)
-    if draft["attachments"]:
-        for i, item in enumerate(draft["attachments"], 1):
+    items = draft.get("items", draft["attachments"])
+    if items:
+        for i, item in enumerate(items, 1):
             console.print(
                 f"{i}. {item['name']} ({item['type']}, {item['size']} bytes)",
                 markup=False,
                 highlight=False,
             )
-        console.print(f"Total: {draft['attachment_size']} bytes", markup=False)
+            if item.get("source"):
+                console.print(f"   Source: {item['source']}", markup=False)
+            for key in ("drive_file_id", "link", "export_type", "sharing"):
+                if item.get(key):
+                    console.print(f"   {key}: {item[key]}", markup=False)
+        console.print(f"Total file bytes: {draft['attachment_size']}", markup=False)
     else:
         console.print("(none)", markup=False)
     if tip:
-        print_tip(f"\nSend with confirmation: [bold]co gmail draft send {draft['id']}[/bold]\n")
+        print_tip(f"\nReview before sending: [bold]co gmail draft review {draft['id']}[/bold]\n")
 
 
 def _draft_id_or_exit(gmail, draft_id: str, listing: str | None = None) -> str:
@@ -394,9 +400,23 @@ def handle_gmail_draft_create(to: str, subject: str, message: str, cc: str = Non
     print_tip(f"Attach a local file: [bold]co gmail draft attach {draft['id']} <path>[/bold]\n")
 
 
+def _matching_drive(gmail):
+    from .gdrive_commands import _gdrive
+    drive = _gdrive()
+    if drive.get_account_email().casefold() != gmail.get_account_email().casefold():
+        from ...provider_credentials import ProviderCredentialError
+        raise ProviderCredentialError("account_changed", "Drive and Gmail accounts differ; reconnect the selected Google account.", "co auth google")
+    return drive
+
+
+def _drive_source(item: dict) -> dict:
+    return {"source":"drive_attachment", "drive_file_id":item["id"],
+            **{key:item[key] for key in ("link", "export_type", "original_type") if item.get(key)}}
+
+
 @google_errors("co gmail draft list")
 def handle_gmail_draft_attach(draft_id: str, source: str, drive: bool = False,
-                              link: bool = False, *, listing: str | None = None):
+                              link: bool = False, *, listing: str | None = None, drive_listing: str | None = None):
     if link and not drive:
         console.print("\n❌ [bold red]--link requires --drive.[/bold red]")
         print_tip(f"Retry with: [bold]co gmail draft attach {draft_id} <Drive file # or id> --drive --link[/bold]\n")
@@ -405,33 +425,33 @@ def handle_gmail_draft_attach(draft_id: str, source: str, drive: bool = False,
     gmail = _gmail(require_draft_write=True)
     resolved = _draft_id_or_exit(gmail, draft_id, listing)
     if drive:
-        from .gdrive_commands import _gdrive, _resolve_file_id
-        from ...useful_tools.gmail import GMAIL_ATTACHMENT_LIMIT
+        from .gdrive_commands import _resolve_file_id
 
-        file_id = _resolve_file_id(source)
+        drive_client = _matching_drive(gmail)
+        file_id = _resolve_file_id(source, drive_client, drive_listing)
         if not file_id:
             console.print(f"\n❌ [bold red]No Drive file #{source} in your last listing.[/bold red]")
             print_tip("List Drive files: [bold]co gdrive[/bold]\n")
             raise typer.Exit(1)
-        drive_client = _gdrive()
         if link:
-            item = _draft_call(lambda: drive_client._get_file(file_id), "co gdrive")
+            item = _draft_call(lambda: drive_client.get_info(file_id), "co gdrive")
             if not item["link"]:
                 console.print("\n❌ [bold red]Drive returned no web link for this file.[/bold red]")
                 print_tip(f"Attach its bytes: [bold]co gmail draft attach {draft_id} {source} --drive[/bold]\n")
                 raise typer.Exit(1)
             updated = _draft_call(
-                lambda: gmail.add_draft_link(resolved, item["name"], item["link"]),
+                lambda: gmail._add_managed_draft_link(resolved, item),
                 f"co gmail draft attach {draft_id} {source} --drive --link",
             )
         else:
+            budget = gmail._draft_attachment_budget(resolved)
             item = _draft_call(
-                lambda: drive_client._read_file(file_id, max_bytes=GMAIL_ATTACHMENT_LIMIT),
+                lambda: drive_client._read_file(file_id, max_bytes=budget),
                 f"co gmail draft attach {draft_id} {source} --drive",
             )
             updated = _draft_call(
                 lambda: gmail._add_draft_attachment(
-                    resolved, item["name"], item["type"], item["data"]
+                    resolved, item["name"], item["type"], item["data"], source=_drive_source(item)
                 ),
                 f"co gmail draft attach {draft_id} {source} --drive",
             )
@@ -460,27 +480,32 @@ def handle_gmail_draft_remove(draft_id: str, attachment: int, *, listing: str | 
 
 @google_errors("co gmail draft list")
 def handle_gmail_draft_replace(draft_id: str, attachment: int, source: str,
-                               drive: bool = False, *, listing: str | None = None):
+                               drive: bool = False, link: bool = False, *, listing: str | None = None, drive_listing: str | None = None):
+    if link and not drive:
+        console.print("Error: --link requires --drive.")
+        print_tip("Next: co gmail draft replace --help")
+        raise typer.Exit(1)
     gmail = _gmail(require_draft_write=True)
     resolved = _draft_id_or_exit(gmail, draft_id, listing)
     if drive:
-        from .gdrive_commands import _gdrive, _resolve_file_id
-        from ...useful_tools.gmail import GMAIL_ATTACHMENT_LIMIT
+        from .gdrive_commands import _resolve_file_id
 
-        file_id = _resolve_file_id(source)
+        drive_client = _matching_drive(gmail)
+        file_id = _resolve_file_id(source, drive_client, drive_listing)
         if not file_id:
             console.print(f"\n❌ [bold red]No Drive file #{source} in your last listing.[/bold red]")
             print_tip("List Drive files: [bold]co gdrive[/bold]\n")
             raise typer.Exit(1)
+        budget = gmail._draft_attachment_budget(resolved, replacing=attachment) if not link else 0
         item = _draft_call(
-            lambda: _gdrive()._read_file(file_id, max_bytes=GMAIL_ATTACHMENT_LIMIT),
-            f"co gmail draft replace {draft_id} {attachment} {source} --drive",
+            lambda: drive_client.get_info(file_id) if link else drive_client._read_file(file_id, max_bytes=budget),
+            f"co gdrive info {file_id}",
         )
         updated = _draft_call(
-            lambda: gmail._replace_draft_attachment(
-                resolved, attachment, item["name"], item["type"], item["data"]
+            lambda: gmail._replace_draft_link(resolved, attachment, item) if link else gmail._replace_draft_attachment(
+                resolved, attachment, item["name"], item["type"], item["data"], source=_drive_source(item)
             ),
-            f"co gmail draft preview {resolved}",
+            f"co gmail draft review {resolved}",
         )
     else:
         updated = _draft_call(
@@ -499,20 +524,49 @@ def handle_gmail_draft_preview(draft_id: str, *, listing: str | None = None):
     _print_draft_preview(draft)
 
 
-@google_errors("co gmail sent")
-def handle_gmail_draft_send(draft_id: str, *, listing: str | None = None):
-    gmail = _gmail(require_draft_write=True)
+def _print_review(review, *, tip: bool = True) -> None:
+    manifest = review.manifest
+    _print_draft_preview(manifest, tip=False)
+    print(f"Account: {manifest['account']}\nFrom: {manifest['from']}")
+    print(f"Body SHA-256: {manifest['body_sha256']}")
+    print(f"MIME bytes: {manifest['mime_size']} / {manifest['mime_limit']}; encoded bytes: {manifest['encoded_size']}")
+    print(f"Attachment limit: {manifest['attachment_limit']} bytes")
+    for warning in manifest['warnings']:
+        print(f'Warning: {warning}')
+    print(f'Review token: {review.token}')
+    if tip:
+        import shlex
+        print_tip(f'Next: co gmail draft send {shlex.quote(manifest["id"])} --confirm {review.token}')
+
+
+@google_errors("co gmail draft list")
+def handle_gmail_draft_review(draft_id: str, *, listing: str | None = None):
+    from .gmail_draft_review import prepare_review
+    gmail = _gmail()
     resolved = _draft_id_or_exit(gmail, draft_id, listing)
-    draft = _draft_call(lambda: gmail.get_draft(resolved), "co gmail draft list")
-    _print_draft_preview(draft, tip=False)
-    try:
-        confirmed = typer.confirm("\nSend this Gmail draft now?", default=False)
-    except (typer.Abort, KeyboardInterrupt, EOFError):
-        confirmed = False
-    if not confirmed:
-        console.print("\n[yellow]Not sent; the Gmail draft was kept.[/yellow]")
-        print_tip(f"Preview again: [bold]co gmail draft preview {resolved}[/bold]\n")
-        raise typer.Exit(1)
-    sent = _draft_call(lambda: gmail._send_draft(resolved), f"co gmail draft send {resolved}")
+    _print_review(prepare_review(gmail, resolved))
+
+
+@google_errors("co gmail sent")
+def handle_gmail_draft_send(draft_id: str, *, listing: str | None = None, confirm: str | None = None):
+    from .gmail_draft_review import prepare_review, send_reviewed, DraftReviewError
+    gmail = _gmail()
+    resolved = _draft_id_or_exit(gmail, draft_id, listing)
+    if confirm is None:
+        review = prepare_review(gmail, resolved)
+        _print_review(review, tip=False)
+        if not console.is_terminal or not sys.stdin.isatty():
+            raise DraftReviewError('confirmation_required', 'Not sent. Non-interactive send requires a reviewed --confirm token.',
+                                   f'co gmail draft review {resolved}')
+        try:
+            confirmed = typer.confirm("\nSend exactly this reviewed Gmail message?", default=False)
+        except (typer.Abort, KeyboardInterrupt, EOFError):
+            confirmed = False
+        if not confirmed:
+            console.print("\n[yellow]Not sent; the Gmail draft was kept.[/yellow]")
+            print_tip(f"Review again: co gmail draft review {resolved}")
+            raise typer.Exit(1)
+        confirm = review.token
+    sent = send_reviewed(gmail, resolved, confirm)
     console.print(f"\n[green]✓ Sent[/green] Gmail message {sent.get('id', '')}")
     print_tip("List sent mail: [bold]co gmail sent[/bold]\n")

--- a/connectonion/cli/commands/gmail_draft_review.py
+++ b/connectonion/cli/commands/gmail_draft_review.py
@@ -1,0 +1,173 @@
+"""Operator review of frozen MIME and durable, non-retrying send attempts."""
+
+import base64
+from dataclasses import dataclass
+from email import policy
+from email.utils import getaddresses
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import tempfile
+
+from ...environment import global_config_dir
+from ...env_file import env_lock
+
+from ...useful_tools.gmail_draft_mime import MIME_LIMIT, ATTACHMENT_LIMIT, validate_message
+
+
+class DraftReviewError(ValueError):
+    """Safe review/recovery guidance without message or provider error bodies."""
+
+    def __init__(self, code: str, message: str, next_command: str | None = None):
+        super().__init__(message)
+        self.code = code
+        self.next_command = next_command
+
+
+@dataclass(frozen=True)
+class DraftReview:
+    token: str
+    raw: str
+    thread_id: str | None
+    message_id: str
+    manifest: dict
+
+
+def prepare_review(gmail, draft_id: str) -> DraftReview:
+    """Read one provider draft and derive its deterministic review and send bytes."""
+    draft, message = gmail._draft_message(draft_id)
+    account = gmail.get_account_email()
+    thread_id = draft.get('message', {}).get('threadId')
+    source = validate_message(gmail, message)
+    context = json.dumps([1, account, draft_id, thread_id], separators=(',', ':')).encode()
+    token = hashlib.sha256(context + b'\0' + source).hexdigest()
+    # This stable attempt ID permits inspection after a lost response. It is not
+    # an idempotency promise from Gmail; the local ledger prevents resubmission.
+    message_id = f'<co-{token}@connectonion.local>'
+    manifest = gmail._draft_dict(draft_id, message)
+    from ...useful_tools.gmail_draft_sources import SOURCE_HEADER, LINK_HEADER
+    for part in message.walk():
+        del part[SOURCE_HEADER]
+        del part[LINK_HEADER]
+    del message['Message-ID']
+    message['Message-ID'] = message_id
+    raw = validate_message(gmail, message)
+    recipients = getaddresses(message.get_all('To', []) + message.get_all('Cc', []) + message.get_all('Bcc', []))
+    if not recipients or any(not address or '@' not in address for _,address in recipients):
+        raise DraftReviewError('invalid_recipients', 'Draft recipients are missing or invalid; edit and review again.')
+    body_parts = [(part.get_content_type(), part.get_content()) for part in message.walk()
+                  if part.get_content_maintype() == 'text' and not part.get_filename()]
+    names = [item['name'] for item in manifest['items']]
+    warnings = ['Duplicate attachment display names.'] if len(names) != len(set(names)) else []
+    if any(item.get('source') == 'drive_link' for item in manifest['items']):
+        warnings.append('Drive link sharing is unchanged; recipient access has not been verified.')
+    if any(item.get('size') is None for item in manifest['items']):
+        warnings.append('Some Drive item sizes are unknown; links contribute no MIME file bytes.')
+    if any(item.get('export_type') for item in manifest['items']):
+        warnings.append('Google-native files are attached as the export formats shown in the manifest.')
+    manifest.update(account=account, **{'from':str(message.get('From', account))},
+        thread_id=thread_id, message_id=message_id, review_token=token,
+        attachment_limit=ATTACHMENT_LIMIT, mime_size=len(raw), mime_limit=MIME_LIMIT,
+        encoded_size=len(base64.urlsafe_b64encode(raw)),
+        body_sha256=hashlib.sha256(json.dumps(body_parts, ensure_ascii=False).encode()).hexdigest(),
+        warnings=warnings)
+    return DraftReview(token, base64.urlsafe_b64encode(raw).decode(), thread_id, message_id, manifest)
+
+
+def _write_attempt(path: Path, data: dict) -> None:
+    fd, name = tempfile.mkstemp(prefix='.send-', dir=path.parent)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as stream:
+            json.dump(data, stream)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(name, path)
+    finally:
+        Path(name).unlink(missing_ok=True)
+
+
+def _read_attempt(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        with path.open('rb') as stream:
+            raw = stream.read(65537)
+        if len(raw) > 65536:
+            raise ValueError
+        data = json.loads(raw)
+        if (data['schema_version'] != 1 or data['status'] not in {'submitted','sent','rejected'} or
+                not re.fullmatch(r'[a-f0-9]{64}', data['token'])):
+            raise ValueError
+        if data['status'] == 'sent' and (not isinstance(data.get('sent_id'), str) or not data['sent_id']):
+            raise ValueError
+        return data
+    except (ValueError, TypeError, KeyError):
+        raise DraftReviewError('invalid_send_record', 'Saved send outcome is unreadable; inspect sent mail before retrying.', 'co gmail sent --json') from None
+
+
+def _recover(gmail, attempt: dict, path: Path, token: str) -> dict | None:
+    if attempt['status'] == 'rejected':
+        return None
+    if attempt['status'] == 'submitted':
+        message_id = attempt.get('message_id', '')
+        if not re.fullmatch(r'<co-[a-f0-9]{64}@connectonion\.local>', message_id):
+            raise DraftReviewError('invalid_send_record', 'Saved send identity is invalid; inspect sent mail.', 'co gmail sent --json')
+        query = f'in:sent rfc822msgid:{message_id}'
+        response = gmail._get_service().users().messages().list(userId='me', q=query, maxResults=2).execute()
+        found = response.get('messages', [])
+        if len(found) == 1:
+            attempt.update(status='sent', sent_id=found[0]['id'])
+            _write_attempt(path, attempt)
+        else:
+            import shlex
+            raise DraftReviewError('delivery_uncertain', 'Delivery remains uncertain; no second send was attempted.',
+                                   f'co gmail search {shlex.quote(query)} --json')
+    if attempt['token'] != token:
+        raise DraftReviewError('already_sent', 'This draft already has a sent receipt for another review; inspect sent mail.', 'co gmail sent --json')
+    return {'id':attempt['sent_id'], 'recovered':True}
+
+
+def send_reviewed(gmail, draft_id: str, token: str, *, directory: Path | None = None) -> dict:
+    """Recheck review, freeze raw MIME, and submit at most once per send attempt."""
+    from googleapiclient.errors import HttpError
+    if not re.fullmatch(r'[a-f0-9]{64}', token):
+        raise DraftReviewError('invalid_review', 'Invalid review token; run draft review again.', f'co gmail draft review {shlex.quote(draft_id)} --json')
+    account = gmail.get_account_email()
+    directory = directory or global_config_dir() / 'gmail-send-attempts'
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    key = hashlib.sha256(json.dumps([account, draft_id]).encode()).hexdigest()
+    path = directory / f'{key}.json'
+    with env_lock(path):
+        attempt = _read_attempt(path)
+        if attempt:
+            recovered = _recover(gmail, attempt, path, token)
+            if recovered:
+                return recovered
+        review = prepare_review(gmail, draft_id)
+        if review.token != token:
+            raise DraftReviewError('stale_review', 'Draft changed since review; review the current content before sending.', f'co gmail draft review {shlex.quote(draft_id)} --json')
+        gmail._require_draft_write_scope()
+        attempt = {'schema_version':1, 'status':'submitted', 'token':token, 'message_id':review.message_id}
+        _write_attempt(path, attempt)
+        try:
+            result = gmail._send_draft(draft_id, raw=review.raw, thread_id=review.thread_id)
+            if not isinstance(result.get('id'), str) or not result['id']:
+                raise ValueError
+        except HttpError as error:
+            status = getattr(error.resp, 'status', 0)
+            if 400 <= status < 500 and status != 408:
+                attempt['status'] = 'rejected'
+                _write_attempt(path, attempt)
+                raise DraftReviewError('send_rejected', f'Gmail rejected this send request (HTTP {status}); inspect draft and sent state before retrying.',
+                    'co auth google' if status in {401,403} else 'co gmail draft list') from None
+            raise DraftReviewError('delivery_uncertain', 'Delivery is uncertain; inspect sent mail before any further send.', 'co gmail sent --json') from None
+        except Exception:
+            # Keep the submitted marker even when the response or receipt write
+            # is lost. No exception from the provider may authorize a retry.
+            raise DraftReviewError('delivery_uncertain', 'Delivery is uncertain; inspect sent mail before any further send.', 'co gmail sent --json') from None
+        attempt.update(status='sent', sent_id=result['id'])
+        _write_attempt(path, attempt)
+        return result

--- a/connectonion/cli/commands/gmail_listings.py
+++ b/connectonion/cli/commands/gmail_listings.py
@@ -1,4 +1,4 @@
-"""Immutable, short-lived row references for one authenticated Gmail account."""
+"""Immutable, short-lived row references for one authenticated Google provider account."""
 
 import hashlib
 import json
@@ -19,7 +19,7 @@ class ListingError(ValueError):
 
 def _account(value: str) -> str:
     if not isinstance(value, str) or not value.strip():
-        raise ListingError('Cannot establish the authenticated Gmail account. Run co gmail inbox again.')
+        raise ListingError('Cannot establish the authenticated account. List again.')
     return hashlib.sha256(value.strip().casefold().encode()).hexdigest()
 
 
@@ -32,13 +32,13 @@ def _modified(path: Path) -> float:
         return 0
 
 
-def save_listing(directory: Path, account: str, family: str, ids: list[str], *, now: float | None = None) -> str:
+def save_listing(directory: Path, account: str, family: str, ids: list[str], *, now: float | None = None, provider: str = 'gmail') -> str:
     """Persist IDs only; never cache message bodies, subjects, recipients or tokens."""
-    if family not in {'messages', 'drafts'} or len(ids) > 500 or any(not isinstance(i, str) or not i or len(i) > 256 for i in ids):
-        raise ListingError('Invalid Gmail listing. Run co gmail inbox again.')
+    if (provider, family) not in {('gmail','messages'), ('gmail','drafts'), ('gdrive','files')} or len(ids) > 500 or any(not isinstance(i, str) or not i or len(i) > 256 for i in ids):
+        raise ListingError('Invalid provider listing. List again.')
     created = time.time() if now is None else now
     token = uuid4().hex
-    payload = {'schema_version': 1, 'provider': 'gmail', 'account': _account(account),
+    payload = {'schema_version': 1, 'provider': provider, 'account': _account(account),
                'family': family, 'listing_id': token, 'created_at': created,
                'expires_at': created + LIFETIME_SECONDS, 'ids': ids}
     directory.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -59,15 +59,15 @@ def save_listing(directory: Path, account: str, family: str, ids: list[str], *, 
 
 
 def resolve_reference(directory: Path, value: str, account: str, family: str,
-                      listing: str | None = None, *, now: float | None = None) -> str:
+                      listing: str | None = None, *, now: float | None = None, provider: str = 'gmail') -> str:
     """Full IDs bypass disk; numeric references require the exact displayed token."""
     number = value.removeprefix('#')
     if not (number.isascii() and number.isdigit() and len(number) < 5):
         return value
     if not listing:
-        raise ListingError('A row number requires --listing ID from its listing, or use the full Gmail ID.')
+        raise ListingError('A row number requires --listing ID from its listing, or use the full provider ID.')
     if not re.fullmatch(r'[a-f0-9]{32}', listing):
-        raise ListingError('Invalid listing ID. Run co gmail inbox or co gmail draft list again.')
+        raise ListingError('Invalid listing ID. List again with the corresponding provider command.')
     current = time.time() if now is None else now
     try:
         path = directory / f'{listing}.json'
@@ -77,7 +77,7 @@ def resolve_reference(directory: Path, value: str, account: str, family: str,
         if len(raw) > MAX_FILE_BYTES:
             raise ValueError
         data = json.loads(raw)
-        if (data['schema_version'] != 1 or data['provider'] != 'gmail' or
+        if (data['schema_version'] != 1 or data['provider'] != provider or
                 data['account'] != _account(account) or data['family'] != family or
                 data['listing_id'] != listing or
                 not data['created_at'] <= current < data['expires_at'] or
@@ -91,4 +91,4 @@ def resolve_reference(directory: Path, value: str, account: str, family: str,
             raise ValueError
         return result
     except (OSError, ValueError, KeyError, TypeError, OverflowError):
-        raise ListingError('Listing unavailable, expired, or for another account. Relist or use the full Gmail ID.') from None
+        raise ListingError('Listing unavailable, expired, or for another account. Relist or use the full provider ID.') from None

--- a/connectonion/cli/commands/gmail_mailbox_commands.py
+++ b/connectonion/cli/commands/gmail_mailbox_commands.py
@@ -40,7 +40,17 @@ def _perform(client, operation: str, args: dict) -> tuple[dict, str]:
     reference = args.pop('email_id', None)
     if operation == 'draft.preview':
         id = gm._resolve_draft_id(client, args.pop('draft_id'), args.pop('listing', None))
-        return {**client.get_draft(id), 'complete':True}, f'co gmail draft send {shlex.quote(id)}'
+        return {**client.get_draft(id), 'complete':True}, f'co gmail draft review {shlex.quote(id)} --json'
+    if operation in {'draft.review', 'draft.send'}:
+        from .gmail_draft_review import prepare_review, send_reviewed, DraftReviewError
+        id = gm._resolve_draft_id(client, args.pop('draft_id'), args.pop('listing', None))
+        if operation == 'draft.review':
+            review = prepare_review(client, id)
+            return {**review.manifest, 'complete':True}, f'co gmail draft send {shlex.quote(id)} --confirm {review.token}'
+        token = args.pop('confirm', None)
+        if not token:
+            raise DraftReviewError('confirmation_required', 'JSON send requires --confirm from a current review.', f'co gmail draft review {shlex.quote(id)} --json')
+        return {**send_reviewed(client, id, token), 'complete':True}, 'co gmail sent --json'
     id = gm._resolve_email_id(client, reference, args.pop('listing', None))
     tip = f'co gmail read {shlex.quote(id)} --json'
     mutation = operation in {'mark.read','mark.unread','archive','star','unstar','label.add','label.remove'}
@@ -71,6 +81,8 @@ def handle_mailbox(operation: str, *, json_output: bool = False, **args) -> None
     from httplib2 import HttpLib2Error
     from requests import RequestException
     from .gmail_commands import _gmail
+    from .gmail_draft_review import DraftReviewError
+    from ...useful_tools.gmail_draft_mime import DraftFormatError
     result = {'schema_version':1, 'provider':'gmail', 'operation':operation,
               'account':None, 'status':'error', 'complete':False, 'data':None, 'error':None}
     next_command = 'co gmail inbox'
@@ -94,6 +106,12 @@ def handle_mailbox(operation: str, *, json_output: bool = False, **args) -> None
             next_command = 'co auth google'
     except ListingError as error:
         result['error'] = {'code':'invalid_listing', 'message':str(error)}
+    except DraftReviewError as error:
+        result['error'] = {'code':error.code, 'message':str(error)}
+        next_command = error.next_command or 'co gmail draft list'
+    except DraftFormatError as error:
+        result['error'] = {'code':'invalid_draft', 'message':str(error)}
+        next_command = 'co gmail draft list'
     except (HttpError, GoogleAuthError) as error:
         status = getattr(getattr(error, 'resp', None), 'status', None)
         code = {401:'auth_required', 403:'permission_denied', 404:'not_found'}.get(status, 'provider_error')

--- a/connectonion/cli/commands/gmail_mailbox_registration.py
+++ b/connectonion/cli/commands/gmail_mailbox_registration.py
@@ -19,17 +19,19 @@ def handle_mailbox(*args, **kwargs):
     return run(*args, **kwargs)
 
 
-def usage_error(message: str, command: str, json_output: bool) -> None:
+def usage_error(message: str, command: str, json_output: bool, provider: str = 'gmail') -> None:
     if not json_output:
         raise typer.BadParameter(message)
-    print(json.dumps({'schema_version':1, 'provider':'gmail', 'operation':command,
+    print(json.dumps({'schema_version':1, 'provider':provider, 'operation':command,
         'account':None, 'status':'error', 'complete':False, 'data':None,
         'error':{'code':'usage_error', 'message':message},
-        'next_command':selected_command(f'co gmail {command} --help')}))
+        'next_command':selected_command(f'co {provider} {command} --help')}))
     raise typer.Exit(2)
 
 
 class MailboxCommand(TyperCommand):
+    provider = 'gmail'
+
     def make_context(self, info_name, args, parent=None, **extra):
         json_output = '--json' in args
         try:
@@ -37,10 +39,14 @@ class MailboxCommand(TyperCommand):
         except click.ClickException:
             if json_output:
                 # Do not echo arbitrary argument values or provider material.
-                prefix = parent.command_path.split('gmail', 1)[-1].strip() if parent else ''
+                prefix = parent.command_path.split(self.provider, 1)[-1].strip() if parent else ''
                 command = f'{prefix} {info_name}'.strip()
-                usage_error('Invalid or missing command arguments.', command, True)
+                usage_error('Invalid or missing command arguments.', command, True, self.provider)
             raise
+
+
+class DriveInfoCommand(MailboxCommand):
+    provider = 'gdrive'
 
 
 def register_mailbox_commands(app: typer.Typer, group_class: type) -> None:

--- a/connectonion/cli/commands/google_errors.py
+++ b/connectonion/cli/commands/google_errors.py
@@ -24,7 +24,9 @@ def google_errors(next_command: str):
             from ...provider_credentials import ProviderCredentialError
             from ...credentials import AmbientCredentialError
             from .gmail_listings import ListingError
+            from .gmail_draft_review import DraftReviewError
 
+            from ...useful_tools.gmail_draft_mime import DraftFormatError
             recovery = next_command
             try:
                 return handler(*args, **kwargs)
@@ -36,6 +38,12 @@ def google_errors(next_command: str):
                 recovery = "co auth"
             except ListingError as exc:
                 cause = str(exc)
+            except DraftReviewError as exc:
+                cause = str(exc)
+                recovery = exc.next_command or 'co gmail draft list'
+            except DraftFormatError as exc:
+                cause = str(exc)
+                recovery = 'co gmail draft list'
             except json.JSONDecodeError:
                 cause = "Saved listing numbers are unreadable; refresh the listing."
             except HttpError as exc:

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -1158,11 +1158,12 @@ def gmail_draft_attach(
     source: str = typer.Argument(..., help="Local path, or Drive file #/id with --drive"),
     drive: bool = typer.Option(False, "--drive", help="Read the source from the last Drive listing or a Drive id"),
     link: bool = typer.Option(False, "--link", help="With --drive, append its web link instead of attaching bytes"),
+    drive_listing: Optional[str] = typer.Option(None, "--drive-listing", help="Drive listing token required for a Drive row number"),
     listing: Optional[str] = typer.Option(None, "--listing", help="Listing ID printed beside row numbers; required when using a number"),
 ):
     """Stage a local/Drive file, or append a Drive link, without sending."""
     from .commands.gmail_commands import handle_gmail_draft_attach
-    handle_gmail_draft_attach(draft_id, source, drive=drive, link=link, listing=listing)
+    handle_gmail_draft_attach(draft_id, source, drive=drive, link=link, listing=listing, drive_listing=drive_listing)
 
 
 @gmail_draft_app.command("remove")
@@ -1182,11 +1183,13 @@ def gmail_draft_replace(
     attachment: int = typer.Argument(..., min=1, help="Attachment # from draft preview"),
     source: str = typer.Argument(..., help="Local path, or Drive file #/id with --drive"),
     drive: bool = typer.Option(False, "--drive", help="Read the replacement from Drive"),
+    link: bool = typer.Option(False, "--link", help="Replace with a managed Drive link; requires --drive"),
+    drive_listing: Optional[str] = typer.Option(None, "--drive-listing", help="Drive listing token required for a Drive row number"),
     listing: Optional[str] = typer.Option(None, "--listing", help="Listing ID printed beside row numbers; required when using a number"),
 ):
     """Atomically replace one staged attachment without sending."""
     from .commands.gmail_commands import handle_gmail_draft_replace
-    handle_gmail_draft_replace(draft_id, attachment, source, drive=drive, listing=listing)
+    handle_gmail_draft_replace(draft_id, attachment, source, drive=drive, link=link, listing=listing, drive_listing=drive_listing)
 
 
 @gmail_draft_app.command("preview", cls=MailboxCommand)
@@ -1203,14 +1206,36 @@ def gmail_draft_preview(
     handle_gmail_draft_preview(draft_id, listing=listing)
 
 
-@gmail_draft_app.command("send")
+@gmail_draft_app.command("review", cls=MailboxCommand)
+def gmail_draft_review(
+    draft_id: str = typer.Argument(..., help="Full draft ID, or row with --listing"),
+    listing: Optional[str] = typer.Option(None, "--listing"),
+    json_output: bool = typer.Option(False, "--json"),
+):
+    """Review the complete outgoing content and produce its confirmation token."""
+    if json_output:
+        from .commands.gmail_mailbox_commands import handle_mailbox
+        return handle_mailbox("draft.review", draft_id=draft_id, listing=listing, json_output=True)
+    from .commands.gmail_commands import handle_gmail_draft_review
+    handle_gmail_draft_review(draft_id, listing=listing)
+
+
+@gmail_draft_app.command("send", cls=MailboxCommand)
 def gmail_draft_send(
     draft_id: str = typer.Argument(..., help="Full draft ID, or row # together with --listing ID"),
     listing: Optional[str] = typer.Option(None, "--listing", help="Listing ID printed beside row numbers; required when using a number"),
+    confirm: Optional[str] = typer.Option(None, "--confirm", help="Token from draft review; required without a real TTY"),
+    json_output: bool = typer.Option(False, "--json"),
 ):
-    """Preview a draft and send it only after interactive confirmation."""
+    """Send reviewed MIME; require a token or default-No interactive confirmation."""
+    if json_output:
+        from .commands.gmail_mailbox_commands import handle_mailbox
+        return handle_mailbox("draft.send", draft_id=draft_id, listing=listing, confirm=confirm, json_output=True)
     from .commands.gmail_commands import handle_gmail_draft_send
-    handle_gmail_draft_send(draft_id, listing=listing)
+    if confirm is None:
+        handle_gmail_draft_send(draft_id, listing=listing)
+    else:
+        handle_gmail_draft_send(draft_id, listing=listing, confirm=confirm)
 
 
 register_mailbox_commands(gmail_app, _OneSuggestion)
@@ -1249,14 +1274,29 @@ def gdrive_search(
     handle_gdrive_search(query, last=last)
 
 
+from .commands.gmail_mailbox_registration import DriveInfoCommand
+
+
+@gdrive_app.command("info", cls=DriveInfoCommand)
+def gdrive_info(
+    listing: Optional[str] = typer.Option(None, "--listing", help="Frozen Drive listing token required for a row number"),
+    file_id: str = typer.Argument(..., help="Full Drive ID, or row with --listing"),
+    json_output: bool = typer.Option(False, "--json", help="Versioned inspection result"),
+):
+    """Inspect metadata and export format without downloading or changing sharing."""
+    from .commands.gdrive_commands import handle_gdrive_info
+    handle_gdrive_info(file_id, listing=listing, json_output=json_output)
+
+
 @gdrive_app.command("get")
 def gdrive_get(
-    file_id: str = typer.Argument(..., help="File # from the last listing, or a full file id"),
+    listing: Optional[str] = typer.Option(None, "--listing", help="Frozen Drive listing token required for a row number"),
+    file_id: str = typer.Argument(..., help="Full Drive ID, or row with --listing"),
     dest: str = typer.Option(".", "--to", help="Destination directory or file path"),
 ):
     """Download a file (Google Docs/Sheets/Slides are exported)."""
     from .commands.gdrive_commands import handle_gdrive_get
-    handle_gdrive_get(file_id, dest=dest)
+    handle_gdrive_get(file_id, dest=dest, listing=listing)
 
 
 @gdrive_app.command("put")
@@ -1271,11 +1311,12 @@ def gdrive_put(
 
 @gdrive_app.command("rm")
 def gdrive_rm(
-    file_id: str = typer.Argument(..., help="File # from the last listing, or a full file id"),
+    listing: Optional[str] = typer.Option(None, "--listing", help="Frozen Drive listing token required for a row number"),
+    file_id: str = typer.Argument(..., help="Full Drive ID, or row with --listing"),
 ):
     """Move a file to the Drive trash (recoverable)."""
     from .commands.gdrive_commands import handle_gdrive_rm
-    handle_gdrive_rm(file_id)
+    handle_gdrive_rm(file_id, listing=listing)
 
 
 # Synology command group. `co syno` (no args) lists your shared folders.

--- a/connectonion/useful_skills/co-mail-and-drive/SKILL.md
+++ b/connectonion/useful_skills/co-mail-and-drive/SKILL.md
@@ -64,7 +64,7 @@ do not describe a failed mark-read action as completed.
 
 For Gmail attachments, or whenever a person should review the final message,
 use the provider-native draft workflow. Only the last command can send, and it
-always previews and asks for interactive confirmation:
+requires either a current review token or a real terminal's default-No confirmation:
 
 | Intent | Command |
 |---|---|
@@ -76,7 +76,8 @@ always previews and asks for interactive confirmation:
 | Remove a staged file | `co gmail draft remove <draft> <attachment#>` |
 | Replace a staged file | `co gmail draft replace <draft> <attachment#> <source> [--drive]` |
 | Inspect recipients, body, and manifest | `co gmail draft preview <draft>` |
-| Preview, confirm, and send | `co gmail draft send <draft>` |
+| Review exact content and obtain a token | `co gmail draft review <draft> --json` |
+| Send that approved content | `co gmail draft send <draft> --confirm <review-token> --json` |
 
 ```bash
 co gmail draft list
@@ -84,31 +85,49 @@ co gmail draft create bob@example.com "Subject" "Body text"
 co gmail draft list           # create prints an ID; it does not assign row 1
 co gmail draft attach <draft-id> report.pdf
 co gdrive list
-co gmail draft attach <draft-id> 3 --drive
-co gmail draft attach <draft-id> 3 --drive --link
+co gmail draft attach <draft-id> 3 --drive --drive-listing <Drive-listing-id>
+co gmail draft attach <draft-id> 3 --drive --drive-listing <Drive-listing-id> --link
 co gmail draft remove <draft-id> 2
 co gmail draft replace <draft-id> 1 corrected.pdf
 co gmail draft preview <draft-id>
-co gmail draft send <draft-id>
+co gmail draft review <draft-id> --json
+co gmail draft send <draft-id> --confirm <review-token> --json
 ```
 
-`draft create`, `attach`, `remove`, `replace`, and `preview` never send. `draft
-send` has no `--yes` or other confirmation bypass. A declined confirmation
-leaves the draft intact and exits `1`. EOF or interruption at the confirmation
-prompt does the same and prints the preview command again.
+`draft create`, `attach`, `remove`, `replace`, `preview`, and `review` never
+send. Show the review to the user before sending. `--confirm` binds approval to
+the account, draft, thread and current MIME content; it is not a blanket `--yes`.
+Without a token, send requires a real terminal and defaults to No. Piped input
+cannot approve. Declining, EOF or interruption leaves the draft intact, exits
+1, and prints the review command. A stale token requires a new review.
+
+Send submits the reviewed MIME in the same request that consumes the draft.
+A concurrent Gmail edit cannot substitute different outgoing content, but may
+be discarded when Gmail consumes that draft. Avoid editing it during send.
+An uncertain result is recorded before submission; repeat attempts inspect a
+unique Message-ID in sent mail and never blindly submit again. Keep the global
+`gmail-send-attempts/` records when investigating an uncertain result.
 
 Gmail message and draft row numbers require `--listing <listing-id>` from
 the corresponding listing. Tokens bind to the provider-confirmed account and
 expire after 15 minutes; only the newest 128 are retained. Full IDs work without
 tokens. Other listings never retarget an older row. Bare numbers and legacy
 last-listing caches are rejected. Attachment numbers come from the current
-`draft preview`; Drive file numbers still come from the last `co gdrive` listing.
+`draft preview`; Drive file numbers require `--drive-listing <Drive-listing-id>` when passed to
+Gmail attach/replace, or `--listing <listing-id>` with Drive get/info/rm.
 After creating a draft, prefer its printed full ID.
 
 `--drive` attaches bytes without making a local copy. Native Docs, Sheets,
 Slides, and Drawings are exported using the same formats as `co gdrive get`.
 `--drive --link` appends the web URL but does not grant the recipient access or
-change Drive sharing.
+change Drive sharing. Managed link source records live inside the Gmail draft,
+survive restart, and are stripped from outgoing MIME. Ordinary body URLs are
+never managed items. `co gmail draft replace <draft> <item#> <Drive-file-id>
+--drive --link` can replace a file or link in one update. Preview/review numbers
+cover files first, then links; use the current manifest after every edit.
+Review shows source, export type, byte count, link access warnings, and duplicate
+names. Unknown Drive sizes remain unknown. The limits are 25,000,000 decoded
+file bytes and 35,000,000 final MIME bytes (decimal MB).
 
 Each success and guarded failure prints a literal next command. Read it even
 when output is piped; it is part of the CLI contract.
@@ -161,7 +180,7 @@ message is incoming; user-started threads are included. `--exclude-automated`
 opts into header-based filtering. Support/billing/invoice senders are included
 by default. The result is a page, never an exact total of replies owed.
 
-Inbox, sent, search, read, draft list/preview and every new mailbox leaf accept
+Inbox, sent, search, read, draft list/preview/review/send and every new mailbox leaf accept
 `--json`. Bare `co gmail --json` is inbox JSON. Put the flag after a subcommand
 when using one. Schema 1 includes `provider`, `account`, `operation`, `status`,
 `complete`, `data`, `error`, and a literal `next_command`; stdout is one JSON
@@ -199,9 +218,10 @@ co outlook contact search yifei
 co gdrive                          # bare command = 20 most recently modified
 co gdrive list                     # explicit form of the same listing
 co gdrive search report -n 50
-co gdrive get 3 --to ~/Downloads   # download row 3
+co gdrive info <full-file-id> --json # metadata, unknown sizes and export format; no download
+co gdrive get 3 --listing <listing-id> --to ~/Downloads   # download row 3
 co gdrive put report.pdf --name "Q3 report.pdf"
-co gdrive rm 3                     # move to trash (recoverable)
+co gdrive rm 3 --listing <listing-id>                     # move to trash (recoverable)
 ```
 
 ## The two gotchas that make you report something false
@@ -210,8 +230,7 @@ co gdrive rm 3                     # move to trash (recoverable)
 possible. Inbox, search, sent, and draft lists each print a token; pass it as
 `--listing <listing-id>` when using a row. Wrong accounts, expired/evicted or
 corrupt listings fail with exit 1 and require relisting. Do not retry a bare
-number or silently select a different row. Outlook and Drive retain their
-existing last-listing numbering: re-list before using their numbers.
+number or silently select a different row. Drive uses the same frozen-token rule; Outlook retains last-listing numbering.
 
 **2. Piping changes the output — and you are always piping.** In a terminal these
 commands print a Rich table with truncated columns and a next-step tip. Piped, they
@@ -290,7 +309,7 @@ For Gmail and Drive, these are the concrete recovery routes:
 | Result | Next command |
 |---|---|
 | Gmail listing succeeded | `co gmail read <full-message-id>` |
-| Drive listing succeeded | `co gdrive get <# from column 5 when piped>` |
+| Drive listing succeeded | `co gdrive get <full-file-id>` |
 | Empty Gmail inbox | `co gmail search <query>` |
 | Empty Gmail search | `co gmail inbox` |
 | Empty Drive listing | `co gdrive search <name prefix>` |
@@ -301,6 +320,9 @@ For Gmail and Drive, these are the concrete recovery routes:
 | Drive connection or local I/O failure (exit 1) | `co gdrive list` |
 | Missing upload path (exit 1) | `co gdrive put <path to an existing file>` |
 | Missing Gmail read argument (exit 2) | `co gmail read --help` |
+| Stale draft review (exit 1) | `co gmail draft review <draft-id> --json` |
+| Uncertain draft delivery (exit 1) | `co gmail sent --json` |
+| Missing Drive info argument (exit 2) | `co gdrive info --help` |
 | Missing Drive get argument (exit 2) | `co gdrive get --help` |
 
 A connection failure does not prove a write failed: inspect the provider state
@@ -332,7 +354,7 @@ it themselves**, do not try to drive that flow.
 - [ ] Right mailbox chosen (asked, if both were connected)
 - [ ] Exact text shown to the user before any send
 - [ ] Final Gmail attachment manifest shown before any draft send
-- [ ] Gmail numbers paired with their listing token; Outlook/Drive numbers from the latest listing
+- [ ] Gmail and Drive numbers paired with their listing token; Outlook numbers from the latest listing
 - [ ] IDs taken from piped output, never from a truncated table column
 - [ ] `--from` address taken from `co email addresses`, never guessed
 - [ ] Empty search reported as "no match", not as "does not exist"

--- a/connectonion/useful_tools/gdrive.py
+++ b/connectonion/useful_tools/gdrive.py
@@ -247,19 +247,44 @@ class GDrive:
 
     # === Transfer ===
 
-    def _get_meta(self, file_id: str) -> dict:
-        """Fetch one file's metadata, resolving shortcuts to their target."""
-        service = self._get_service()
-        item = service.files().get(
-            fileId=file_id,
-            fields=f"{FILE_FIELDS}, shortcutDetails",
-            supportsAllDrives=True,
-        ).execute()
+    def get_account_email(self) -> str:
+        """Return the account confirmed by the selected Drive credentials."""
+        cached = getattr(self, "_account_email", None)
+        if cached:
+            return cached
+        result = self._get_service().about().get(fields="user(emailAddress)").execute()
+        address = result.get("user", {}).get("emailAddress")
+        if not isinstance(address, str) or not address.strip():
+            raise ValueError("Drive did not confirm the authenticated account; run co auth google.")
+        self._account_email = address.strip().casefold()
+        return self._account_email
 
-        shortcut = item.get("shortcutDetails")
-        if shortcut:
-            return self._get_meta(shortcut["targetId"])
-        return item
+    def _get_meta(self, file_id: str) -> dict:
+        """Resolve at most 20 shortcuts, rejecting cycles and trashed targets."""
+        seen = set()
+        service = self._get_service()
+        for _ in range(20):
+            if file_id in seen:
+                raise ValueError("Drive shortcut cycle; select the target file directly.")
+            seen.add(file_id)
+            item = service.files().get(fileId=file_id, fields=f"{FILE_FIELDS}, shortcutDetails, trashed",
+                                       supportsAllDrives=True).execute()
+            if item.get("trashed"):
+                raise ValueError("Drive file or shortcut is in the trash; restore it before attaching.")
+            if "shortcutDetails" not in item:
+                return item
+            file_id = item["shortcutDetails"].get("targetId")
+            if not isinstance(file_id, str) or not file_id:
+                raise ValueError("Drive shortcut target is missing or inaccessible.")
+        raise ValueError("Drive shortcut chain exceeds 20 entries; select the target directly.")
+
+    def get_info(self, file_id: str) -> dict:
+        """Inspect a resolved file without downloading it or changing sharing."""
+        item = self._get_meta(file_id)
+        export = EXPORT_FORMATS.get(item.get("mimeType"))
+        return {**self._file_dict(item), "raw_size":int(item["size"]) if item.get("size") is not None else None,
+                "export_type":export[0] if export else None, "export_suffix":export[1] if export else None,
+                "export_size":None, "sharing":"unchanged; recipient access unverified"}
 
     def _get_file(self, file_id: str) -> dict:
         """Get one Drive file's normalized metadata without downloading it."""
@@ -309,6 +334,8 @@ class GDrive:
             "size": len(buffer.getvalue()),
             "link": item.get("webViewLink", ""),
             "data": buffer.getvalue(),
+            "original_type": item["mimeType"],
+            "export_type": mime if item["mimeType"].startswith(NATIVE_PREFIX) else None,
         }
 
     def download(self, file_id: str, dest: str = ".") -> str:

--- a/connectonion/useful_tools/gmail.py
+++ b/connectonion/useful_tools/gmail.py
@@ -534,7 +534,11 @@ class Gmail(GmailMailbox):
         return draft, self._decode_message(draft["message"]["raw"])
 
     def _draft_dict(self, draft_id: str, message) -> dict:
-        attachments = [self._attachment_dict(part) for _, part in self._attachment_parts(message)]
+        from .gmail_draft_sources import file_source, read_links
+        parts = self._attachment_parts(message)
+        attachments = [self._attachment_dict(part) for _, part in parts]
+        items = [{**item, **file_source(part)} for item, (_, part) in zip(attachments, parts)]
+        items.extend({key:value for key,value in row.items() if key != "text"} for row in read_links(message))
         return {
             "id": draft_id,
             "to": str(message.get("To", "")),
@@ -543,6 +547,7 @@ class Gmail(GmailMailbox):
             "subject": str(message.get("Subject", "")),
             "body": self._message_body(message),
             "attachments": attachments,
+            "items": items,
             "attachment_size": sum(item["size"] for item in attachments),
         }
 
@@ -595,6 +600,8 @@ class Gmail(GmailMailbox):
             message["Cc"] = cc
         if bcc:
             message["Bcc"] = bcc
+        from .gmail_draft_mime import validate_message
+        validate_message(self, message)
         created = self._get_service().users().drafts().create(
             userId="me", body={"message": {"raw": self._encode_message(message)}}
         ).execute()
@@ -606,16 +613,29 @@ class Gmail(GmailMailbox):
         return self._draft_dict(draft_id, message)
 
     def _update_draft(self, draft_id: str, message) -> dict:
+        from .gmail_draft_mime import validate_message
         self._require_draft_write_scope()
+        result = self._draft_dict(draft_id, message)
+        validate_message(self, message)
         self._get_service().users().drafts().update(
             userId="me",
             id=draft_id,
             body={"message": {"raw": self._encode_message(message)}},
         ).execute()
-        return self._draft_dict(draft_id, message)
+        return result
+
+    def _draft_attachment_budget(self, draft_id: str, replacing: int | None = None) -> int:
+        """Bound an incoming Drive stream against the current remaining file budget."""
+        _, message = self._draft_message(draft_id)
+        if replacing is not None:
+            self._remove_draft_item(message, replacing)
+        used = sum(self._attachment_dict(part)["size"] for _, part in self._attachment_parts(message))
+        if used > GMAIL_ATTACHMENT_LIMIT:
+            raise ValueError("Existing attachments exceed the 25MB limit; remove an item first.")
+        return GMAIL_ATTACHMENT_LIMIT - used
 
     def _add_draft_attachment(self, draft_id: str, name: str, mime_type: str,
-                              data: bytes) -> dict:
+                              data: bytes, *, source: dict | None = None) -> dict:
         _, message = self._draft_message(draft_id)
         existing = sum(
             item["size"]
@@ -625,6 +645,8 @@ class Gmail(GmailMailbox):
             raise ValueError("Attachments exceed Gmail's 25MB send limit.")
         main, _, sub = (mime_type or "application/octet-stream").partition("/")
         message.add_attachment(data, maintype=main, subtype=sub or "octet-stream", filename=name)
+        from .gmail_draft_sources import tag_file
+        tag_file(list(message.iter_parts())[-1], data, source)
         return self._update_draft(draft_id, message)
 
     def add_draft_attachment(self, draft_id: str, path: str) -> dict:
@@ -636,7 +658,7 @@ class Gmail(GmailMailbox):
             name, handle = self._open_attachments([path], stack)[0]
             data = handle.read(GMAIL_ATTACHMENT_LIMIT + 1)
         mime_type = mimetypes.guess_type(name)[0] or "application/octet-stream"
-        return self._add_draft_attachment(draft_id, name, mime_type, data)
+        return self._add_draft_attachment(draft_id, name, mime_type, data, source={"source":"local"})
 
     def add_draft_link(self, draft_id: str, name: str, url: str) -> dict:
         """Append a Drive link to a plain-text draft without changing sharing."""
@@ -649,39 +671,66 @@ class Gmail(GmailMailbox):
         part.set_content(f"{body}{separator}{name}: {url}\n")
         return self._update_draft(draft_id, message)
 
-    def remove_draft_attachment(self, draft_id: str, attachment: int) -> dict:
-        """Remove one attachment by its one-based preview number."""
+    def _add_managed_draft_link(self, draft_id: str, item: dict) -> dict:
+        from .gmail_draft_sources import add_link
         _, message = self._draft_message(draft_id)
+        add_link(message, item)
+        return self._update_draft(draft_id, message)
+
+    def _remove_draft_item(self, message, attachment: int) -> None:
+        from .gmail_draft_sources import remove_link
         parts = self._attachment_parts(message)
-        if attachment < 1 or attachment > len(parts):
+        if attachment < 1:
             raise ValueError(f"Draft has no attachment #{attachment}.")
+        if attachment > len(parts):
+            try:
+                remove_link(message, attachment - len(parts) - 1)
+            except ValueError as error:
+                raise ValueError(f"Cannot remove attachment #{attachment}: {error}") from None
+            return
         parent, selected = parts[attachment - 1]
         parent.set_payload([part for part in parent.iter_parts() if part is not selected])
+
+    def remove_draft_attachment(self, draft_id: str, attachment: int) -> dict:
+        """Remove one file or managed link by its current review number."""
+        _, message = self._draft_message(draft_id)
+        self._remove_draft_item(message, attachment)
         return self._update_draft(draft_id, message)
 
     def _replace_draft_attachment(self, draft_id: str, attachment: int, name: str,
-                                  mime_type: str, data: bytes) -> dict:
+                                  mime_type: str, data: bytes, *, source: dict | None = None) -> dict:
+        from email.message import EmailMessage
+        from .gmail_draft_sources import tag_file
         _, message = self._draft_message(draft_id)
         parts = self._attachment_parts(message)
-        if attachment < 1 or attachment > len(parts):
-            raise ValueError(f"Draft has no attachment #{attachment}.")
-        total_without_selected = sum(
-            self._attachment_dict(part)["size"]
-            for index, (_, part) in enumerate(parts, 1)
-            if index != attachment
-        )
-        if total_without_selected + len(data) > GMAIL_ATTACHMENT_LIMIT:
+        selected = parts[attachment - 1] if 1 <= attachment <= len(parts) else None
+        if selected:
+            parent, old = selected
+            position = list(parent.iter_parts()).index(old)
+        self._remove_draft_item(message, attachment)
+        total = sum(self._attachment_dict(part)["size"] for _, part in self._attachment_parts(message))
+        if total + len(data) > GMAIL_ATTACHMENT_LIMIT:
             raise ValueError("Attachments exceed Gmail's 25MB send limit.")
-        parent, selected = parts[attachment - 1]
-        payload = list(parent.iter_parts())
-        position = payload.index(selected)
-        from email.message import EmailMessage
         replacement = EmailMessage()
         main, _, sub = (mime_type or "application/octet-stream").partition("/")
         replacement.set_content(data, maintype=main, subtype=sub or "octet-stream")
         replacement.add_header("Content-Disposition", "attachment", filename=name)
-        payload[position] = replacement
-        parent.set_payload(payload)
+        tag_file(replacement, data, source)
+        if selected:
+            payload = list(parent.iter_parts())
+            payload.insert(position, replacement)
+            parent.set_payload(payload)
+        else:
+            if message.get_content_subtype() != "mixed":
+                message.make_mixed()
+            message.attach(replacement)
+        return self._update_draft(draft_id, message)
+
+    def _replace_draft_link(self, draft_id: str, attachment: int, item: dict) -> dict:
+        from .gmail_draft_sources import add_link
+        _, message = self._draft_message(draft_id)
+        self._remove_draft_item(message, attachment)
+        add_link(message, item)
         return self._update_draft(draft_id, message)
 
     def replace_draft_attachment(self, draft_id: str, attachment: int, path: str) -> dict:
@@ -693,13 +742,18 @@ class Gmail(GmailMailbox):
             name, handle = self._open_attachments([path], stack)[0]
             data = handle.read(GMAIL_ATTACHMENT_LIMIT + 1)
         mime_type = mimetypes.guess_type(name)[0] or "application/octet-stream"
-        return self._replace_draft_attachment(draft_id, attachment, name, mime_type, data)
+        return self._replace_draft_attachment(draft_id, attachment, name, mime_type, data, source={"source":"local"})
 
-    def _send_draft(self, draft_id: str) -> dict:
-        """Send an existing draft after the CLI has obtained confirmation."""
+    def _send_draft(self, draft_id: str, *, raw: str | None = None, thread_id: str | None = None) -> dict:
+        """Send the CLI-reviewed payload in the same operation that consumes the draft."""
+        if not raw:
+            raise ValueError("A reviewed raw payload is required; use co gmail draft review.")
         self._require_draft_write_scope()
+        message = {"raw": raw}
+        if thread_id:
+            message["threadId"] = thread_id
         return self._get_service().users().drafts().send(
-            userId="me", body={"id": draft_id}
+            userId="me", body={"id": draft_id, "message": message}
         ).execute()
 
     def _open_attachments(self, attachments: list, stack) -> list[tuple[str, object]]:

--- a/connectonion/useful_tools/gmail_draft_mime.py
+++ b/connectonion/useful_tools/gmail_draft_mime.py
@@ -1,0 +1,19 @@
+"""Bound the complete draft before a provider write or reviewed send."""
+from email import policy
+
+MIME_LIMIT = 35_000_000
+ATTACHMENT_LIMIT = 25_000_000
+
+
+class DraftFormatError(ValueError):
+    """A locally generated, safe draft validation error."""
+
+
+def validate_message(gmail, message) -> bytes:
+    attachments = [gmail._attachment_dict(part) for _, part in gmail._attachment_parts(message)]
+    if sum(item['size'] for item in attachments) > ATTACHMENT_LIMIT:
+        raise DraftFormatError('Attachments exceed the 25,000,000-byte limit.')
+    raw = message.as_bytes(policy=policy.SMTP)
+    if len(raw) > MIME_LIMIT:
+        raise DraftFormatError('Final MIME exceeds the 35,000,000-byte limit.')
+    return raw

--- a/connectonion/useful_tools/gmail_draft_sources.py
+++ b/connectonion/useful_tools/gmail_draft_sources.py
@@ -1,0 +1,124 @@
+"""Explicit provider-backed source records; body URLs alone never create items."""
+
+import base64
+import hashlib
+import json
+from urllib.parse import urlsplit
+from uuid import uuid4
+
+from .gmail_draft_mime import DraftFormatError
+
+SOURCE_HEADER = 'X-ConnectOnion-Source'
+LINK_HEADER = 'X-ConnectOnion-Drive-Links'
+
+
+def _encode(value: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(value, ensure_ascii=False, separators=(',', ':')).encode()).decode()
+
+
+def _decode(value: str, limit: int) -> dict:
+    try:
+        # Header folding adds whitespace around the encoded value.
+        value = ''.join(value.split())
+        if len(value) > limit:
+            raise ValueError
+        result = json.loads(base64.b64decode(value, altchars=b'-_', validate=True))
+        if not isinstance(result, dict) or result.get('version') != 1:
+            raise ValueError
+        return result
+    except (ValueError, TypeError, UnicodeError):
+        raise DraftFormatError('Managed draft source metadata is invalid; inspect the draft before editing.') from None
+
+
+def tag_file(part, data: bytes, source: dict | None = None) -> None:
+    source = source or {'source':'external'}
+    record = {key:source[key] for key in ('source','drive_file_id','link','export_type','original_type') if key in source}
+    record.update(version=1, item_id=uuid4().hex, sha256=hashlib.sha256(data).hexdigest())
+    if record['source'] not in {'local','external','drive_attachment'}:
+        raise DraftFormatError('Unsupported draft attachment source.')
+    del part[SOURCE_HEADER]
+    part[SOURCE_HEADER] = _encode(record)
+
+
+def file_source(part) -> dict:
+    if SOURCE_HEADER not in part:
+        return {'source':'external'}
+    record = _decode(str(part[SOURCE_HEADER]), 8192)
+    data = part.get_payload(decode=True)
+    if data is None:
+        data = part.as_bytes()
+    if (record.get('source') not in {'local','external','drive_attachment'} or
+            record.get('sha256') != hashlib.sha256(data).hexdigest()):
+        raise DraftFormatError('Managed attachment bytes changed; replace the item before reviewing.')
+    return {key:value for key,value in record.items() if key != 'version'}
+
+
+def _plain_part(message):
+    part = message.get_body(preferencelist=('plain',)) if message.is_multipart() else message
+    if part is None or part.get_content_type() != 'text/plain' or part.get_content_disposition() == 'attachment':
+        raise DraftFormatError('Managed Drive links require a plain-text body; attach the bytes instead.')
+    return part
+
+
+def read_links(message, *, strict: bool = True) -> list[dict]:
+    if LINK_HEADER not in message:
+        return []
+    record = _decode(str(message[LINK_HEADER]), 65536)
+    rows = record.get('items')
+    if not isinstance(rows, list) or len(rows) > 100:
+        raise DraftFormatError('Managed Drive-link manifest is invalid.')
+    body = _plain_part(message).get_content().replace('\r\n', '\n')
+    for row in rows:
+        if not isinstance(row, dict) or any(not isinstance(row.get(key), str) or not row[key]
+                for key in ('item_id','name','drive_file_id','link','text')):
+            raise DraftFormatError('Managed Drive-link record is invalid.')
+        if strict and body.count(row['text']) != 1:
+            raise DraftFormatError('Managed Drive-link text changed or became ambiguous; remove or replace the item before reviewing.')
+    if len({row['item_id'] for row in rows}) != len(rows):
+        raise DraftFormatError('Managed Drive-link identifiers are duplicated.')
+    return rows
+
+
+def _write_links(message, rows: list) -> None:
+    del message[LINK_HEADER]
+    if rows:
+        encoded = _encode({'version':1, 'items':rows})
+        if len(encoded) > 65536:
+            raise DraftFormatError('Managed Drive-link manifest is too large.')
+        message[LINK_HEADER] = encoded
+
+
+def add_link(message, item: dict) -> None:
+    url, name, file_id = item['link'], item['name'], item['id']
+    parsed = urlsplit(url)
+    if parsed.scheme != 'https' or parsed.hostname not in {'drive.google.com','docs.google.com'} or parsed.username or parsed.password:
+        raise DraftFormatError('Drive did not return a supported HTTPS file link.')
+    if not file_id or any(char in name + url for char in '\r\n\0'):
+        raise DraftFormatError('Drive link metadata contains invalid fields.')
+    rows = read_links(message)
+    if len(rows) >= 100:
+        raise DraftFormatError('A draft supports at most 100 managed Drive links.')
+    part = _plain_part(message)
+    body = part.get_content().replace('\r\n', '\n')
+    text = f'{name}: {url}\n'
+    if text in body:
+        raise DraftFormatError('This exact Drive-link text already exists in the body; it was not added as another managed item.')
+    separator = '' if body.endswith('\n\n') else ('\n' if body.endswith('\n') else '\n\n')
+    part.set_content(body + separator + text)
+    rows.append({'item_id':uuid4().hex, 'source':'drive_link', 'name':name, 'type':item.get('type',''),
+                 'size':item.get('raw_size'), 'drive_file_id':file_id, 'link':url, 'text':text,
+                 'sharing':'unchanged; recipient access unverified'})
+    _write_links(message, rows)
+
+
+def remove_link(message, index: int) -> None:
+    rows = read_links(message, strict=False)
+    if not 0 <= index < len(rows):
+        raise DraftFormatError('Managed Drive-link number is out of range.')
+    row = rows.pop(index)
+    part = _plain_part(message)
+    body = part.get_content().replace('\r\n', '\n')
+    if body.count(row['text']) > 1:
+        raise DraftFormatError('Managed link text is ambiguous; edit the duplicate text before removing it.')
+    part.set_content(body.replace(row['text'], '', 1))
+    _write_links(message, rows)

--- a/docs/acceptance/1.8.4-gmail-draft-review.md
+++ b/docs/acceptance/1.8.4-gmail-draft-review.md
@@ -1,0 +1,88 @@
+# Gmail draft review — 1.8.4 implementation evidence
+
+Checked 7 September 2026. Branch: fix/1.8.4-gmail-review. Base:
+cdd1c0bac61b800f2b2f4e51bbe0196a9f8dc1cb, the mailbox slice (#1452),
+which depends on #1451 and #1450. Refs #1424; no completion, merge or release
+claim. Version metadata deliberately remains 1.8.3 until release preparation.
+
+Implemented: canonical review and explicit content token; real-TTY default-No
+fallback; frozen raw MIME in drafts.send; durable uncertain-send recovery;
+provider-backed local/Drive source records and managed links; one-update
+file/link replacement; decoded/MIME/remaining-export budgets; gdrive info;
+shortcut/trash checks; provider-confirmed account matching; immutable Drive
+listing tokens and --drive-listing source selection.
+
+The initial focused command passed 306 tests. Added Drive-context and budget
+regressions passed afterward. Full selection: 8,313 passed, 23 skipped,
+184 live tests deselected, seven warnings, with one failing legacy test fixture
+that called the old Drive printer signature (279.75 seconds). The fixture is
+updated; 31 piping/listing regressions pass. Final full rerun at 6ab91e64 passed
+8,314 tests, with 23 skipped, 184 live tests deselected and seven warnings
+(274.81 seconds).
+
+Build: python -m build --no-isolation, wheel plus sdist; twine check passed.
+Candidate wheel SHA-256:
+086dce739cd8d01d2cd896d8a18ec8fe14e256dec2c162e8f5630a3d2b3a9f18.
+Installed into a fresh temporary target outside the checkout. Read-only checks
+used the installed package, keys.env and a separate restarted process/directory:
+Gmail draft list JSON, Drive list, then Drive info by frozen row token. All
+passed, including exact file identity, schema 1 and the same account. Sanitized
+Google account fingerprint: abe6ff1509726914. No provider names, content,
+credentials, draft/file IDs or addresses were retained in this evidence.
+
+Pinned output-only audit: co/gemini-3.7-flash, 22/22 passed. Inputs were captured
+CLI output with synthetic providers; the model's returned commands were scored,
+never executed. The cases include all Gmail draft leaves and all Drive leaves.
+Parser-generated help and packaged skill match in both directions.
+
+Reproduced exit cases include missing arguments (2), missing provider scope (1),
+non-TTY send without a token (1), stale token (1), uncertain send (1), malformed
+managed records (1), wrong account/listing (1), and successful review/info (0).
+JSON usage failures stay one document. Local tests prove the frozen bytes survive
+an edit during the final permission check and an uncertain send never blindly
+resubmits. MIME tests retain recipients, Unicode, ordinary body URLs and other
+items during removal/replacement, including CRLF provider round trips.
+
+Remaining provider acceptance: create a disposable draft with local, Drive
+binary, exported-native and managed-link items; replace/remove and reload across
+processes; independently edit to reject a stale token; send once to the same
+approved account; verify delivered bytes/export/link and draft consumption.
+These live writes require explicit approval. No Gmail message was sent and no
+Drive content/sharing was changed by this slice. The earlier mailbox fixture's
+approval does not by itself authorize Drive fixture uploads or draft sending.
+
+The new Design Journal article is prepared and locally reviewed. Its external
+model story check was rejected by automatic approval review pending explicit
+permission to send that article to the configured model. Do not report that gate
+as passed or trigger it indirectly while approval is pending.
+
+Provider limits: no compare-and-swap for concurrent draft edits; consuming a
+draft can lose a simultaneous edit. The ledger protects this local installation,
+not all clients/machines. Link access stays unchanged/unverified. Current item
+numbers must be re-read after draft edits. Native exports retain documented
+Markdown/CSV/PDF behavior; Sheets export only the first sheet.
+
+## Repeatable live acceptance
+
+`scripts/acceptance/gmail_release.py` prepares only synthetic fixtures and requires
+explicit authorization for its self-addressed send and Google fixture writes:
+
+```bash
+PYTHONPATH=/path/to/installed/candidate python scripts/acceptance/gmail_release.py \
+  --allow-self-send-and-fixture-writes
+```
+
+The selected global Google record must have Gmail modify/compose and Drive write
+scopes. Run the script with the candidate's Python environment. It starts each
+CLI operation in a fresh process and unrelated directory, checks local/Drive
+binary/native/link records after reload, rejects missing confirmation and a stale
+review, then sends the reviewed message only to the provider-confirmed account.
+It verifies attachment hashes, body and Message-ID, draft consumption and a
+second command recovering the saved receipt without sending again. Frozen-row
+lookup, mark/star/IMPORTANT/archive and private collision-safe downloads follow.
+
+Only the run's exact newly created message and Drive fixtures move to Trash;
+existing mail/files and sharing remain untouched. An unsent fixture draft is
+deleted unless delivery is uncertain. Output contains only phase names, check
+results and error types. A prepared script or passing offline suite does not
+claim that this live journey has run.

--- a/docs/acceptance/1.8.4-gmail-draft-review.md
+++ b/docs/acceptance/1.8.4-gmail-draft-review.md
@@ -1,8 +1,8 @@
 # Gmail draft review — 1.8.4 implementation evidence
 
 Checked 7 September 2026. Branch: fix/1.8.4-gmail-review. Base:
-cdd1c0bac61b800f2b2f4e51bbe0196a9f8dc1cb, the mailbox slice (#1452),
-which depends on #1451 and #1450. Refs #1424; no completion, merge or release
+8dbe7d0d, the mailbox slice (#1452),
+with #1451 and #1450 already merged. Review PR #1455. Refs #1424; no completion, merge or release
 claim. Version metadata deliberately remains 1.8.3 until release preparation.
 
 Implemented: canonical review and explicit content token; real-TTY default-No
@@ -48,8 +48,11 @@ binary, exported-native and managed-link items; replace/remove and reload across
 processes; independently edit to reject a stale token; send once to the same
 approved account; verify delivered bytes/export/link and draft consumption.
 These live writes require explicit approval. No Gmail message was sent and no
-Drive content/sharing was changed by this slice. The earlier mailbox fixture's
-approval does not by itself authorize Drive fixture uploads or draft sending.
+Drive content/sharing was changed by this slice. The live acceptance script below remains pending its specific authorization.
+
+The current code-only PR at `c0527645` passes 357 Gmail/Drive/CLI tests and has
+no docs/blog diff or new private journal objects. The combined Core candidate
+passes 8,562 tests, with 23 skipped and 184 live tests deselected.
 
 The new Design Journal article is prepared and locally reviewed. Its external
 model story check was rejected by automatic approval review pending explicit

--- a/docs/blog/2026-09-07-the-gap-after-review.md
+++ b/docs/blog/2026-09-07-the-gap-after-review.md
@@ -1,0 +1,49 @@
+# The Gap After Review
+
+Draft for 1.8.4; publish after release acceptance.
+
+The draft send handler looked careful. It fetched a Gmail draft, printed its
+recipients and attachments, then asked for confirmation. After the operator
+answered, it called Gmail with the draft ID. The ID was the problem: it named
+an editable object, not the message the operator had just read.
+
+The first repair seemed straightforward. Fetch the draft again after
+confirmation and compare a content hash. That catches an edit made while the
+prompt is open. It still leaves an interval between the comparison and the
+send request, when another Gmail client can replace the content behind the ID.
+Adding another comparison only moves the interval.
+
+Google's draft guide supplied the useful distinction. The send request can
+include an updated raw message alongside the draft ID. We can compare the
+review and submit the reviewed bytes in that same request. The regression now
+edits the simulated provider draft during the final permission check. The send
+payload still contains the original reviewed body. The late edit cannot become
+the outgoing message.
+
+This choice has a cost we need to state. Gmail consumes the draft when it sends.
+A concurrent edit may be discarded. The implementation protects which bytes
+leave the account; it cannot promise to preserve another client's simultaneous
+work on an object that the provider removes.
+
+Then the test lost the send response. Retrying the command would be tempting:
+there is no receipt on screen, and the draft might still appear briefly. But a
+timeout says nothing about whether Gmail delivered the message. The client now
+writes an attempt record before submission and gives the outgoing message a
+stable Message-ID. A repeated command looks for that message in sent mail. One
+match recovers a receipt; no match leaves the outcome uncertain and does not
+send again. The record contains hashes and IDs, not the message body.
+
+Working through attachment review exposed a related identity problem. A managed
+Drive link has to survive a new CLI process, but an arbitrary URL in the body
+must not become an attachment merely because it looks like Drive. The draft
+therefore carries explicit source records inside its MIME. A reload test passed,
+then a CRLF round-trip test failed because provider line endings changed the
+stored link's text comparison. Normalizing that comparison preserved the record
+without adopting unrelated URLs. The send path removes internal source headers
+after including them in the review.
+
+Review now identifies content at the point where the operator can inspect it,
+and the final request carries that content across the boundary. The remaining
+live test has to prove Google preserves those records and delivers the declared
+exports. Mocked races establish the client behavior; they do not stand in for
+that provider acceptance.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -295,7 +295,7 @@ saved as `GOOGLE_*` in `.env` / `~/.co/keys.env`).
 ```bash
 co gdrive                             # 20 most recently modified files
 co gdrive search report                # find by name (word prefixes)
-co gdrive get 3 --to ~/Downloads       # download #3 from the listing
+co gdrive get 3 --listing <listing-id> --to ~/Downloads       # download #3 from the listing
 co gdrive put report.pdf               # upload
 ```
 
@@ -312,6 +312,7 @@ The CLI wraps the same `Gmail` tool your agents use. See
 [gmail.md](gmail.md) for details.
 - `co gdrive` / `co gdrive list` - recent files (`--last/-n`)
 - `co gdrive search <query>` - find by file name
+- `co gdrive info <full-file-id> --json` - read-only metadata and export format
 - `co gdrive get <#>` - download (`--to`); Docs/Sheets/Slides are exported to md/csv/pdf
 - `co gdrive put <path>` - upload (`--name`)
 - `co gdrive rm <#>` - move to trash (recoverable)
@@ -1202,3 +1203,7 @@ See [server.md](server.md).
 - [Interactive Debugging](../debug/auto_debug.md) - `@xray` debugger
 - [Trust System](../features/trust.md) - Multi-agent trust
 - [Getting Started](../quickstart.md) - Full tutorial
+
+The 1.8.4 Gmail candidate adds `co gmail draft review <draft-id> --json` and
+`co gmail draft send <draft-id> --confirm <review-token> --json`. See
+[gmail.md](gmail.md) for the MIME-bound send and uncertain-outcome contract.

--- a/docs/cli/gdrive.md
+++ b/docs/cli/gdrive.md
@@ -17,7 +17,7 @@ co auth google
 co gdrive
 
 # Download file #3 from the listing
-co gdrive get 3
+co gdrive get 3 --listing <listing-id>
 
 # Upload something
 co gdrive put report.pdf
@@ -47,11 +47,11 @@ co gdrive                # 20 most recently modified
 co gdrive list -n 50
 ```
 
-Files are numbered. **Numbers mean your last listing** — `co gdrive get 3`
-downloads the third row of the table you just saw. Running `co gdrive` again
-renumbers.
-List and search share their numbering cache. An empty result clears the old
-numbers; it does not leave an earlier row available for `get` or `rm`.
+Each list/search prints a frozen token. Numbers require `--listing <listing-id>`
+for get, info or rm; full IDs bypass caches. Tokens bind the Drive-confirmed
+account and files family, expire after 15 minutes, and retain at most 128 lists.
+Concurrent or empty listings cannot change older rows. Legacy last-list caches
+and bare numbers now fail instead of selecting a potentially different file.
 
 Trashed files are excluded.
 
@@ -66,12 +66,29 @@ One caveat worth knowing: Drive matches **word prefixes, not any substring**.
 On a file named `HelloWorld`, searching `Hello` matches and `World` does not.
 That is the API's behavior, not ours.
 
+### `co gdrive info <full-file-id>` — Inspect without downloading
+
+```bash
+co gdrive info <full-file-id>
+co gdrive info <full-file-id> --json
+```
+
+Returns provider-confirmed account, resolved file ID, name, MIME type, modified
+time, web link, `raw_size` (null when unknown), export type/suffix and unknown
+export size. Use a full ID or a row with `--listing <listing-id>` from list/search. JSON uses
+schema 1 with status, complete, data, error and next_command. Exit 0 means the
+inspection completed, 1 is an operational failure, 2 is invalid syntax.
+Shortcut resolution is limited to 20 entries; cycles, missing targets and trash
+fail. Inspection neither downloads bytes nor changes sharing. Recipient link
+access remains unverified. The Gmail integration checks that Drive and Gmail
+confirm the same account before reading an attachment source.
+
 ### `co gdrive get <#>` — Download
 
 ```bash
-co gdrive get 3                       # into the current directory
-co gdrive get 3 --to ~/Downloads      # into a directory
-co gdrive get 3 --to notes.md         # to an exact path
+co gdrive get 3 --listing <listing-id>                       # into the current directory
+co gdrive get 3 --listing <listing-id> --to ~/Downloads      # into a directory
+co gdrive get 3 --listing <listing-id> --to notes.md         # to an exact path
 co gdrive get 1A2b3C4d5E6f7G8h        # by full file id
 ```
 
@@ -95,8 +112,8 @@ Drive listing and use its row number:
 ```bash
 co gmail draft list               # select an existing draft independently
 co gdrive list -n 20
-co gmail draft attach 1 3 --drive
-co gmail draft attach 1 3 --drive --link
+co gmail draft attach <draft-id> <Drive-file-id> --drive
+co gmail draft attach <draft-id> <Drive-file-id> --drive --link
 ```
 
 The first form reads the file into the Gmail draft without writing a local
@@ -114,7 +131,7 @@ Uploads to the root of your Drive and prints the link.
 ### `co gdrive rm <#>` — Trash
 
 ```bash
-co gdrive rm 3
+co gdrive rm 3 --listing <listing-id>
 ```
 
 Moves the file to the Drive trash. It is **not** permanently deleted — restore
@@ -139,7 +156,8 @@ rows, filter for five tab-separated fields first:
 co gdrive list | awk -F '\t' 'NF == 5 { print $4 }'
 ```
 
-The tip names the fifth column as the source of the number for `co gdrive get`.
+The tip names a full ID. Row numbers remain column five and require the printed
+listing token. Filter metadata and tip lines when parsing tab-separated rows.
 
 ## Using it from an agent
 
@@ -164,7 +182,7 @@ drive.upload("report.pdf")
 
 | Exit / result | Recovery command |
 |---|---|
-| 0, listing or search results | `co gdrive get <# from this listing>` |
+| 0, listing or search results | `co gdrive get <full-file-id>` |
 | 0, empty search | `co gdrive list` |
 | 1, missing permission | `co auth google` |
 | 1, unknown row or unreadable cache | `co gdrive list` |

--- a/docs/cli/gmail.md
+++ b/docs/cli/gmail.md
@@ -20,7 +20,8 @@ co gmail read 3 --listing <listing-id>
 co gmail draft create alice@example.com "Hello" "Thanks for the meeting today!"
 co gmail draft list               # choose the new draft's row from this listing
 co gmail draft preview <draft-id>
-co gmail draft send <draft-id>
+co gmail draft review <draft-id> --json
+co gmail draft send <draft-id> --confirm <review-token> --json
 ```
 
 Use the row that matches your draft; `create` prints its full ID but does not
@@ -93,8 +94,9 @@ reads the body from stdin.
 
 The draft workflow is the safe path when attachments or Drive files are
 involved. Creating, attaching, removing, replacing, and previewing do not send
-mail. Only `draft send` can send, and it always prints the final preview and
-asks for interactive confirmation. There is no confirmation-bypass flag.
+mail. `draft review` is the canonical final review; `preview` remains an
+inspection command for existing callers. Send requires a token from that exact
+review, or a real terminal's default-No confirmation. Piped `yes` cannot approve.
 
 ```bash
 co gmail draft list
@@ -102,7 +104,8 @@ co gmail draft create alice@example.com "Report" "Please review."
 co gmail draft list               # select the matching row before using a number
 co gmail draft attach <draft-id> report.pdf
 co gmail draft preview <draft-id>
-co gmail draft send <draft-id>
+co gmail draft review <draft-id> --json
+co gmail draft send <draft-id> --confirm <review-token> --json
 ```
 
 Draft numbers use `--listing <listing-id>` from `co gmail draft list` and
@@ -113,23 +116,53 @@ Creating a draft prints its ID and does not change any frozen listing.
 The ID-only cache lives in the global config directory's `gmail-listings/`;
 it stores an account digest, not the account address or message contents.
 Answering no, ending input, or interrupting the confirmation prompt keeps the
-draft, exits 1, and prints its preview command again.
+draft, exits 1, and prints its review command again.
 
 Use local or Drive files without first copying Drive content to disk:
 
 ```bash
 co gdrive list -n 20
-co gmail draft attach <draft-id> 3 --drive          # attach Drive row 3 as bytes
-co gmail draft attach <draft-id> 3 --drive --link   # append its Drive URL instead
+co gmail draft attach <draft-id> 3 --drive --drive-listing <Drive-listing-id>          # attach Drive row 3 as bytes
+co gmail draft attach <draft-id> 3 --drive --drive-listing <Drive-listing-id> --link   # append its Drive URL instead
 co gmail draft remove <draft-id> 2
 co gmail draft replace <draft-id> 1 corrected.pdf
-co gmail draft replace <draft-id> 1 3 --drive
+co gmail draft replace <draft-id> 1 3 --drive --drive-listing <Drive-listing-id>
+co gmail draft replace <draft-id> 1 <Drive-file-id> --drive --link
 ```
 
 Google Docs, Sheets, Slides, and Drawings are exported with the same formats as
 `co gdrive get`. A Drive link does not change the file's sharing permissions;
 the recipient still needs access. The combined decoded attachment size must be
-at most 25 MB.
+at most 25,000,000 bytes; final MIME must fit 35,000,000 bytes. These are decimal
+MB, preserving the existing SDK constant. `review --json` includes the account,
+From, To/Cc/Bcc, body and digest, draft/thread IDs, source manifest, per-file and
+aggregate sizes, final MIME and base64 sizes, limits, warnings and review token.
+The `items` field combines files first and managed links second. Legacy
+`attachments` retains its file-only shape. Unknown link sizes are `null`.
+
+Managed Drive records round-trip inside provider MIME; arbitrary body URLs never
+become managed items. Links retain unchanged sharing and unverified recipient
+access. Editing a managed link's text independently requires removing/replacing
+that item. Ordinary edits change the review token. Source metadata is removed
+from the outgoing message after it is included in the review hash.
+
+Send re-fetches and rejects any changed token, then supplies the exact reviewed
+MIME with the draft ID in one Gmail `drafts.send` request. A late provider edit
+cannot substitute outgoing bytes, though consuming the draft can discard that
+edit. Gmail provides no draft edit compare-and-swap; avoid concurrent edits.
+Create/update preflight rejects invalid sources or oversized MIME before the
+provider write. A lost provider update response may still mean the update
+completed; inspect the draft before retrying.
+
+A private account/draft-scoped send marker is persisted under the global
+`gmail-send-attempts/` directory before submission. It stores hashes and receipt
+IDs, never message content. On an ambiguous response, another send command
+checks a deterministic Message-ID in sent mail and returns the single matching
+receipt or stays uncertain; it does not resend. Do not remove that record to
+force a retry. A confirmed receipt can be returned even after Gmail has removed
+the draft. Explicit HTTP rejections allow a later deliberate attempt. This is a
+local retry guard, not a Gmail exactly-once guarantee across other clients or
+machines. Existing one-shot send/reply behavior remains separate.
 
 ### `co gmail send <to> <subject> <message>` — Send immediately
 
@@ -198,7 +231,7 @@ co gmail unanswered --within-days 30 --last 20 --json
 ```
 
 Every new mailbox command supports `--json`, as do inbox, sent, search, read,
-draft list and draft preview. `co gmail --json` is the default inbox. JSON uses
+draft list, preview, review and send. `co gmail --json` is the default inbox. JSON uses
 one schema-1 envelope: `provider`, `account`, `operation`, `status`, `complete`,
 `data`, `error`, `next_command`. It prints no prompts or extra stdout text.
 New commands put human hints on stderr. Operational/partial failures exit 1;
@@ -284,7 +317,8 @@ gmail.get_draft(draft["id"])
 | 1, missing permission | `co auth google` |
 | 1, unknown message number or unreadable numbering cache | `co gmail inbox` |
 | 1, send/reply connection failure | `co gmail sent` |
-| 1, declined draft confirmation | `co gmail draft preview <draft ID>` |
+| 1, declined or stale draft confirmation | `co gmail draft review <draft-id> --json` |
+| 1, uncertain draft send | `co gmail sent --json` |
 | 2, missing read argument | `co gmail read --help` |
 
 Read the printed cause and next command even when piping output. Provider error

--- a/docs/design-decisions/069-reviewed-draft-send-and-source-records.md
+++ b/docs/design-decisions/069-reviewed-draft-send-and-source-records.md
@@ -1,0 +1,62 @@
+# DD-069: Reviewed draft bytes and provider-backed source records
+
+Date: 2026-09-07. Status: implementation candidate. Related: #1424, #1444, #1446.
+
+`draft review [--json]` is the canonical pre-send review. Existing preview stays
+available for inspection. No redundant show/attachments/attach-drive leaves are
+introduced. Attach uses `--drive [--link]`; replace adds the same link option.
+
+A review hashes account, draft ID, thread ID and SMTP-serialized provider MIME.
+It includes all recipients, From, body/digest, source items, file totals, final
+MIME/base64 sizes and warnings. A caller supplies the token to send or uses a
+real terminal's default-No prompt. Piped input cannot approve. Send re-fetches
+and rejects changed content, then sends those frozen bytes and draft ID in one
+provider request. Gmail's [draft guide](https://developers.google.com/workspace/gmail/api/guides/drafts)
+explicitly supports this payload. Re-fetch followed by ID-only send was rejected
+because another client can edit the draft between those operations. Gmail has
+no edit compare-and-swap: consuming a draft can discard a concurrent late edit,
+but that edit cannot replace the outbound bytes.
+
+Before submission, a locked, private global send ledger records an account/draft
+hash, review hash and deterministic RFC Message-ID. It never stores draft bytes
+or recipients. A successful receipt is persisted. An ambiguous response leaves
+the submitted marker; subsequent calls search sent mail for that Message-ID and
+return one matching receipt or remain uncertain without resending. Explicit HTTP
+4xx rejection (except request timeout) permits a deliberate new attempt. This
+is local retry safety, not a provider exactly-once claim across machines or
+unrelated clients. Records are not automatically expired or deleted: silently
+forgetting an uncertain send would re-enable duplication. Inspect before any
+manual recovery, and preserve the ledger with the global configuration.
+
+Private source headers contain explicit local/Drive byte provenance and hashes.
+Managed Drive links have structured records on the root MIME message and exact
+plain-text body lines. Records survive provider reloads, including CRLF line
+endings. Independent managed-text changes fail review until removed/replaced;
+ordinary body URLs never acquire managed status. Review shows records, then
+strips those internal headers from the outgoing MIME. File-only attachments
+remain compatible; the additive items manifest lists files then links. Numbers
+refer to the current draft manifest, so inspect it after edits. Source records
+are descriptive provenance, not a provider-signed attestation.
+
+Replacement builds and validates one new MIME message before one update. A
+preflight failure leaves the provider untouched; a lost update response still
+requires inspection. Preserve the existing 25,000,000-byte decoded file limit
+and enforce a 35,000,000-byte final MIME cap. Drive export streams use the current
+remaining file budget, then the update validates again against the latest draft.
+Metadata inspection returns unknown sizes as null, resolves at most 20 shortcut
+entries, rejects cycles/trash and never grants recipient access. Native exports
+remain Markdown/CSV/PDF as documented by the existing Drive adapter.
+
+Drive now shares the immutable listing mechanism with Gmail, using a distinct
+provider/files context. Get/info/rm numbers require --listing; Gmail's Drive
+source numbers require --drive-listing, independent of its draft --listing.
+Full IDs work throughout. Tokens expire after 15 minutes, retain at most 128
+lists and store IDs plus account hashes only. Legacy last-listing files are
+ignored. Both provider clients confirm the same Google account before crossing
+from Drive into Gmail. This migration prevents another process or account from
+retargeting a previously displayed Drive row.
+
+The existing Google local credential/refresh contract remains authoritative.
+No broker content endpoint or new OAuth scope is introduced. Google accepts
+compose/modify/full-mail grants for draft operations; unknown local grants let
+the provider decide. No agent-callable draft send or approval bypass is added.

--- a/docs/useful_tools/gdrive.md
+++ b/docs/useful_tools/gdrive.md
@@ -130,7 +130,7 @@ The same tool backs [`co gdrive`](../cli/gdrive.md):
 ```bash
 co gdrive                          # 20 most recently modified
 co gdrive search report
-co gdrive get 3 --to ~/Downloads
+co gdrive get 3 --listing <listing-id> --to ~/Downloads
 co gdrive put report.pdf
 ```
 
@@ -139,3 +139,11 @@ co gdrive put report.pdf
 - [`co gdrive`](../cli/gdrive.md) — the CLI wrapper
 - [Gmail](gmail.md) — the same shape for mail
 - [Google Integration](../integrations/google.md) — OAuth scopes requested
+
+### Read-only metadata in the 1.8.4 candidate
+
+`get_info(file_id)` resolves shortcuts and returns metadata, `raw_size` (None
+when absent), `export_type`, `export_suffix` and unknown `export_size` without
+reading file bytes. `get_account_email()` asks Drive for the authenticated
+account. Shortcut cycles, chains beyond 20 entries and trashed targets fail.
+The CLI exposes this through `co gdrive info <full-file-id> --json`.

--- a/docs/useful_tools/gmail.md
+++ b/docs/useful_tools/gmail.md
@@ -91,8 +91,8 @@ Your agent can now read and manage Gmail.
 ### Drafts
 
 Draft methods edit provider-native Gmail drafts and never send them. The
-terminal's separate `co gmail draft send` command performs the final preview
-and confirmation; draft sending is intentionally not exposed as a public agent
+terminal's `co gmail draft review` and `send --confirm` commands bind the final
+send to reviewed content; draft sending is intentionally not exposed as a public agent
 method.
 
 **`list_drafts(last=20)`**
@@ -112,7 +112,7 @@ method.
 - Append a link to a plain-text body; this does not change sharing permissions
 
 **`remove_draft_attachment(draft_id, attachment)`**
-- Remove the one-based attachment number from `get_draft()`
+- Remove the current one-based item number from `get_draft()["items"]` (files then managed links)
 
 **`replace_draft_attachment(draft_id, attachment, path)`**
 - Replace one attachment with a local project file in one draft update
@@ -203,9 +203,9 @@ co gmail send bob@example.com "Hi" "Body text"
 co gmail search "from:alice@example.com is:unread"
 co gmail draft create bob@example.com "Report" "Please review."
 co gmail draft list               # choose the matching row; create prints an ID
-co gmail draft attach 1 report.pdf
-co gmail draft preview 1
-co gmail draft send 1          # previews and asks; there is no --yes
+co gmail draft attach <draft-id> report.pdf
+co gmail draft review <draft-id> --json
+co gmail draft send <draft-id> --confirm <review-token> --json
 ```
 
 ## See Also
@@ -219,3 +219,10 @@ co gmail draft send 1          # previews and asks; there is no --yes
 **Missing gmail.readonly scope**: Run `co auth google`
 
 **Credentials not found**: Run `co auth google`
+
+In the 1.8.4 candidate, `get_draft()` adds an `items` source manifest while
+preserving file-only `attachments`. Local files are tagged as local; existing
+untagged files are external. The CLI records Drive exports and managed links
+inside provider MIME. The older `add_draft_link(name, url)` remains an ordinary
+body append and does not claim verified Drive provenance. No draft send method
+is exposed as an agent tool. See [draft review behavior](../cli/gmail.md).

--- a/scripts/acceptance/gmail_release.py
+++ b/scripts/acceptance/gmail_release.py
@@ -1,0 +1,214 @@
+"""Opt-in live Gmail/Drive acceptance; touches only this run's synthetic fixtures.
+
+Run with an installed candidate on PYTHONPATH and the explicit consent flag.
+One message is sent only to the provider-confirmed account. Two private Drive
+fixtures and the sent message move to Trash afterward; no sharing is changed.
+Output contains phase names and checks, never addresses, IDs, tokens or content.
+"""
+
+import argparse
+import base64
+from collections import Counter
+import contextlib
+from email import policy
+from email.parser import BytesParser
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+
+
+def attachment_hashes(message) -> Counter:
+    return Counter(hashlib.sha256(part.get_payload(decode=True)).hexdigest()
+                   for part in message.walk() if part.get_filename())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--allow-self-send-and-fixture-writes', action='store_true')
+    args = parser.parse_args()
+    if not args.allow_self_send_and_fixture_writes:
+        parser.error('Explicit consent is required for one self-send and fixture writes.')
+
+    report = {'passed': False, 'checks': [], 'cleanup': []}
+    phase = 'initialize'
+    draft_id = sent_id = None
+    drive_ids = []
+    gmail_service = drive_service = None
+    # Capture provider diagnostics as well as CLI output: the report is safe to
+    # retain, while provider resources and the reviewed MIME stay in memory.
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+        try:
+            from googleapiclient.errors import HttpError
+            from googleapiclient.http import MediaIoBaseUpload
+            from connectonion.useful_tools.gmail import Gmail
+            from connectonion.useful_tools.gdrive import GDrive
+            from connectonion.cli.commands.gmail_draft_review import prepare_review
+
+            gmail, drive = Gmail(), GDrive()
+            account = gmail.get_account_email()
+            assert drive.get_account_email().casefold() == account.casefold()
+            gmail._require_draft_write_scope()
+            gmail_service, drive_service = gmail._get_service(), drive._get_service()
+            run_name = 'ConnectOnion release acceptance ' + uuid.uuid4().hex
+            with tempfile.TemporaryDirectory(prefix='co-gmail-acceptance-') as temporary:
+                root = Path(temporary)
+                other = root / 'unrelated-directory'
+                other.mkdir(mode=0o700)
+
+                def cli(*arguments, error=None, machine=False):
+                    child = subprocess.run(
+                        [sys.executable, '-m', 'connectonion.cli.main', *arguments],
+                        cwd=other, capture_output=True, text=True, timeout=120,
+                        env={**os.environ, 'NO_COLOR': '1'},
+                    )
+                    if machine:
+                        data = json.loads(child.stdout)
+                        assert data['schema_version'] == 1
+                        assert data['account'].casefold() == account.casefold()
+                        if error:
+                            assert child.returncode == 1 and data['error']['code'] == error
+                        else:
+                            assert child.returncode == 0 and data['complete']
+                        return data['data']
+                    assert child.returncode == 0
+
+                phase = 'create_private_fixtures'
+                for mime, name in [('text/plain', 'binary.txt'),
+                                   ('application/vnd.google-apps.document', 'native')]:
+                    data = (run_name + '\nSynthetic fixture only.\n').encode()
+                    created = drive_service.files().create(
+                        body={'name': run_name + ' ' + name, 'mimeType': mime},
+                        media_body=MediaIoBaseUpload(io.BytesIO(data), mimetype='text/plain'),
+                        fields='id',
+                    ).execute()
+                    drive_ids.append(created['id'])
+                local = root / 'local.txt'
+                local.write_text('Synthetic local attachment.\n')
+                replacement = root / 'replacement.txt'
+                replacement.write_text('Synthetic replacement attachment.\n')
+                draft_id = gmail.create_draft(account, run_name, 'Synthetic release acceptance.\n')['id']
+                cli('gmail', 'draft', 'attach', draft_id, str(local))
+                cli('gmail', 'draft', 'attach', draft_id, drive_ids[0], '--drive')
+                cli('gmail', 'draft', 'attach', draft_id, drive_ids[1], '--drive')
+                cli('gmail', 'draft', 'attach', draft_id, drive_ids[0], '--drive', '--link')
+                preview = cli('gmail', 'draft', 'preview', draft_id, '--json', machine=True)
+                assert len(preview['items']) == 4
+                assert {item['source'] for item in preview['items']} == {
+                    'local', 'drive_attachment', 'drive_link'}
+                assert any(item.get('export_type') for item in preview['items'])
+                report['checks'].append('local_binary_native_link_survive_process_restart')
+
+                phase = 'edit_and_review'
+                cli('gmail', 'draft', 'replace', draft_id, '1', str(replacement))
+                cli('gmail', 'draft', 'remove', draft_id, '2')
+                cli('gmail', 'draft', 'attach', draft_id, drive_ids[0], '--drive')
+                cli('gmail', 'draft', 'send', draft_id, '--json',
+                    machine=True, error='confirmation_required')
+                previous = cli('gmail', 'draft', 'review', draft_id, '--json', machine=True)
+                # An independent provider update must invalidate the CLI's token.
+                _, message = gmail._draft_message(draft_id)
+                message.replace_header('Subject', run_name + ' reviewed edit')
+                gmail._update_draft(draft_id, message)
+                cli('gmail', 'draft', 'send', draft_id, '--confirm', previous['review_token'],
+                    '--json', machine=True, error='stale_review')
+                reviewed = cli('gmail', 'draft', 'review', draft_id, '--json', machine=True)
+                frozen = prepare_review(gmail, draft_id)
+                assert frozen.token == reviewed['review_token']
+                assert reviewed['to'] == account and not reviewed['cc'] and not reviewed['bcc']
+                report['checks'].append('noninteractive_confirmation_and_stale_review_rejected')
+
+                phase = 'send_once_to_same_account'
+                sent = cli('gmail', 'draft', 'send', draft_id, '--confirm', frozen.token,
+                           '--json', machine=True)
+                sent_id = sent['id']
+                receipt = cli('gmail', 'draft', 'send', draft_id, '--confirm', frozen.token,
+                              '--json', machine=True)
+                assert receipt['id'] == sent_id and receipt['recovered'] is True
+                try:
+                    gmail_service.users().drafts().get(userId='me', id=draft_id).execute()
+                except HttpError as error:
+                    assert error.resp.status == 404
+                else:
+                    raise AssertionError('Sent draft still exists')
+                draft_id = None
+                deadline = time.monotonic() + 90
+                while True:
+                    delivered = gmail_service.users().messages().get(
+                        userId='me', id=sent_id, format='raw').execute()
+                    if 'INBOX' in delivered.get('labelIds', []):
+                        break
+                    assert time.monotonic() < deadline
+                    time.sleep(3)
+                parsed = BytesParser(policy=policy.SMTP).parsebytes(base64.urlsafe_b64decode(delivered['raw']))
+                expected = BytesParser(policy=policy.SMTP).parsebytes(base64.urlsafe_b64decode(frozen.raw))
+                assert attachment_hashes(parsed) == attachment_hashes(expected)
+                assert parsed['Message-ID'] == frozen.message_id
+                assert parsed.get_body(preferencelist=('plain',)).get_content() == expected.get_body(preferencelist=('plain',)).get_content()
+                report['checks'].append('delivered_reviewed_content_draft_consumed_no_duplicate_send')
+
+                phase = 'mailbox_commands_and_attachment_downloads'
+                result = cli('gmail', 'search', 'rfc822msgid:' + frozen.message_id,
+                             '--last', '10', '--json', machine=True)
+                assert len(result['items']) == 1 and result['items'][0]['id'] == sent_id
+                assert cli('gmail', 'read', '1', '--listing', result['listing_id'],
+                           '--json', machine=True)['id'] == sent_id
+                labels = [('mark', '--unread', 'UNREAD', True), ('mark', '--read', 'UNREAD', False),
+                          ('star', None, 'STARRED', True), ('star', '--remove', 'STARRED', False)]
+                for operation, option, label, present in labels:
+                    cli('gmail', operation, sent_id, *([option] if option else []), '--json', machine=True)
+                    current = gmail_service.users().messages().get(userId='me', id=sent_id, format='minimal').execute()
+                    assert (label in current.get('labelIds', [])) is present
+                for operation in ['add', 'remove']:
+                    cli('gmail', 'label', operation, sent_id, 'IMPORTANT', '--json', machine=True)
+                    current = gmail_service.users().messages().get(userId='me', id=sent_id, format='minimal').execute()
+                    assert ('IMPORTANT' in current.get('labelIds', [])) == (operation == 'add')
+                downloads = root / 'downloads'
+                downloads.mkdir(mode=0o700)
+                paths = set()
+                for _ in range(2):
+                    saved = cli('gmail', 'download', sent_id, '--all', '--to', str(downloads), '--json', machine=True)
+                    assert Counter(row['sha256'] for row in saved['items']) == attachment_hashes(expected)
+                    for row in saved['items']:
+                        path = Path(row['path'])
+                        assert path not in paths and path.is_relative_to(downloads)
+                        assert hashlib.sha256(path.read_bytes()).hexdigest() == row['sha256']
+                        if os.name == 'posix':
+                            assert path.stat().st_mode & 0o777 == 0o600
+                        paths.add(path)
+                cli('gmail', 'archive', sent_id, '--json', machine=True)
+                archived = gmail_service.users().messages().get(userId='me', id=sent_id, format='minimal').execute()
+                assert 'INBOX' not in archived.get('labelIds', [])
+                report['checks'].append('frozen_listing_labels_archive_and_private_collision_safe_downloads')
+                report['passed'] = True
+        except Exception as error:
+            report.update(failed_phase=phase, error_type=type(error).__name__)
+        finally:
+            # Never delete or search-and-clean resources outside the exact IDs
+            # created by this invocation. Leave uncertain sends for inspection.
+            cleanup_actions = []
+            if draft_id and gmail_service and phase != 'send_once_to_same_account':
+                cleanup_actions.append(('draft_deleted', lambda: gmail_service.users().drafts().delete(userId='me', id=draft_id).execute()))
+            if sent_id and gmail_service:
+                cleanup_actions.append(('message_trashed', lambda: gmail_service.users().messages().trash(userId='me', id=sent_id).execute()))
+            for file_id in drive_ids:
+                cleanup_actions.append(('drive_fixture_trashed', lambda id=file_id: drive_service.files().update(fileId=id, body={'trashed': True}).execute()))
+            for name, action in cleanup_actions:
+                try:
+                    action()
+                    report['cleanup'].append(name)
+                except Exception as error:
+                    report['passed'] = False
+                    report['cleanup'].append(name + '_failed_' + type(error).__name__)
+    print(json.dumps(report, sort_keys=True))
+    return 0 if report['passed'] else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/cli/test_tips_survive_piping.py
+++ b/tests/cli/test_tips_survive_piping.py
@@ -66,8 +66,10 @@ def test_outlook_piped_scheduled_still_names_the_next_step(tmp_path, capsys):
 def test_gdrive_piped_listing_still_names_the_next_step(tmp_path, capsys):
     files = [{"id": "f1", "name": "report.pdf", "type": "application/pdf", "size": "10", "modified": ""}]
     with patch.object(gdrive_commands, "LIST_CACHE", tmp_path / "gdrive.json"):
-        gdrive_commands._print_listing(files, "drive")
-    assert "Download one with: co gdrive get <# from column 5>" in capsys.readouterr().out
+        drive = Mock()
+        drive.get_account_email.return_value = 'owner@example.test'
+        gdrive_commands._print_listing(drive, files, "drive")
+    assert "Download one with: co gdrive get f1" in capsys.readouterr().out
 
 
 def test_retry_hint_restates_the_full_command(capsys):

--- a/tests/e2e/cli/test_cli_gdrive.py
+++ b/tests/e2e/cli/test_cli_gdrive.py
@@ -46,7 +46,7 @@ def test_gdrive_get_routes_id_and_destination():
         result = runner.invoke(app, ["gdrive", "get", "3", "--to", "/tmp"])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("3", dest="/tmp")
+    handler.assert_called_once_with("3", dest="/tmp", listing=None)
 
 
 def test_gdrive_get_defaults_to_cwd():
@@ -54,7 +54,7 @@ def test_gdrive_get_defaults_to_cwd():
         result = runner.invoke(app, ["gdrive", "get", "3"])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("3", dest=".")
+    handler.assert_called_once_with("3", dest=".", listing=None)
 
 
 def test_gdrive_put_routes_path_and_name():
@@ -70,7 +70,7 @@ def test_gdrive_rm_routes_id():
         result = runner.invoke(app, ["gdrive", "rm", "2"])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("2")
+    handler.assert_called_once_with("2", listing=None)
 
 
 def test_gdrive_requires_an_id_to_get():

--- a/tests/e2e/cli/test_cli_gmail.py
+++ b/tests/e2e/cli/test_cli_gmail.py
@@ -188,7 +188,7 @@ def test_gmail_draft_attach_routes_drive_link():
         ])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("2", "3", drive=True, link=True, listing=None)
+    handler.assert_called_once_with("2", "3", drive=True, link=True, listing=None, drive_listing=None)
 
 
 def test_gmail_draft_remove_routes_attachment_number():
@@ -206,7 +206,7 @@ def test_gmail_draft_replace_routes_drive_source():
         ])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("2", 1, "drive-file", drive=True, listing=None)
+    handler.assert_called_once_with("2", 1, "drive-file", drive=True, link=False, listing=None, drive_listing=None)
 
 
 def test_gmail_draft_preview_routes_id():

--- a/tests/unit/test_gdrive.py
+++ b/tests/unit/test_gdrive.py
@@ -360,7 +360,7 @@ class TestReadFileForAttachment:
             "type": "application/pdf",
             "size": 4,
             "link": "https://drive.google.com/file/d/file-1/view",
-            "data": b"%PDF",
+            "data": b"%PDF", "original_type":"application/pdf", "export_type":None,
         }
         service.files.return_value.get_media.assert_called_once()
 
@@ -465,3 +465,27 @@ class TestUploadAndDelete:
 
         service.files.return_value.delete.assert_not_called()
         assert service.files.return_value.update.call_args.kwargs["body"] == {"trashed": True}
+
+@pytest.mark.parametrize('resources,reason', [
+    ([file_resource(id='a', shortcutDetails={'targetId':'b'}), file_resource(id='b', shortcutDetails={'targetId':'a'})], 'cycle'),
+    ([file_resource(trashed=True)], 'trash'),
+    ([file_resource(shortcutDetails={})], 'target'),
+])
+def test_metadata_rejects_unusable_targets_without_unbounded_recursion(resources, reason):
+    service = MagicMock()
+    service.files().get().execute.side_effect = resources
+    with patch.dict(os.environ, ENV, clear=False):
+        with pytest.raises(ValueError, match=reason):
+            drive_with_service(service)._get_meta('a')
+    assert service.files().get().execute.call_count <= 2
+
+
+def test_info_reports_unknown_native_size_and_export_without_download():
+    service = MagicMock()
+    service.files().get().execute.return_value = file_resource(size=None, mimeType='application/vnd.google-apps.document')
+    with patch.dict(os.environ, ENV, clear=False):
+        info = drive_with_service(service).get_info('file-1')
+    assert info['raw_size'] is None
+    assert info['export_type'] == 'text/markdown'
+    assert info['export_size'] is None
+    service.files().export_media.assert_not_called()

--- a/tests/unit/test_gdrive_commands.py
+++ b/tests/unit/test_gdrive_commands.py
@@ -124,6 +124,7 @@ class TestHandleList:
 
     def test_empty_listing_message(self, capsys):
         drive = MagicMock()
+        drive.get_account_email.return_value = 'owner@example.test'
         drive.list_files.return_value = []
 
         with patch.object(gdrive_commands, "_gdrive", return_value=drive):
@@ -134,16 +135,20 @@ class TestHandleList:
     def test_empty_listing_clears_numbers(self):
         """An empty listing must not clobber the numbering from the last one."""
         drive = MagicMock()
+        drive.get_account_email.return_value = 'owner@example.test'
         drive.list_files.return_value = []
 
         with patch.object(gdrive_commands, "_gdrive", return_value=drive):
             handle_gdrive_list()
 
-        assert json.loads(gdrive_commands.LIST_CACHE.read_text()) == {}
+        assert not gdrive_commands.LIST_CACHE.exists()
+        record = json.loads(next((gdrive_commands.LIST_CACHE.parent / 'gdrive-listings').glob('*.json')).read_text())
+        assert record['ids'] == []
 
     def test_table_and_cache(self, monkeypatch, capsys):
         monkeypatch.setattr(gdrive_commands, "console", Console(force_terminal=True, width=120))
         drive = MagicMock()
+        drive.get_account_email.return_value = 'owner@example.test'
         drive.list_files.return_value = sample_files(3)
 
         with patch.object(gdrive_commands, "_gdrive", return_value=drive):
@@ -152,13 +157,14 @@ class TestHandleList:
         output = plain(capsys.readouterr().out)
         assert "Document 1.pdf" in output
         assert "co gdrive get" in output
-        assert json.loads(gdrive_commands.LIST_CACHE.read_text()) == {
-            "1": "file-1", "2": "file-2", "3": "file-3",
-        }
+        record = json.loads(next((gdrive_commands.LIST_CACHE.parent / 'gdrive-listings').glob('*.json')).read_text())
+        assert record['ids'] == ['file-1','file-2','file-3']
+        assert record['provider'] == 'gdrive'
 
     def test_piped_output_carries_full_ids(self, monkeypatch, capsys):
         monkeypatch.setattr(gdrive_commands, "console", Console(force_terminal=False, width=120))
         drive = MagicMock()
+        drive.get_account_email.return_value = 'owner@example.test'
         drive.list_files.return_value = sample_files(2)
 
         with patch.object(gdrive_commands, "_gdrive", return_value=drive):
@@ -173,6 +179,7 @@ class TestHandleList:
 
     def test_limit_reaches_the_tool(self):
         drive = MagicMock()
+        drive.get_account_email.return_value = 'owner@example.test'
         drive.list_files.return_value = []
 
         with patch.object(gdrive_commands, "_gdrive", return_value=drive):
@@ -186,6 +193,7 @@ class TestHandleSearch:
     def test_no_matches_explains_prefix_matching(self, capsys):
         """Drive matches word prefixes, so a 'no results' needs that caveat."""
         drive = MagicMock()
+        drive.get_account_email.return_value = 'owner@example.test'
         drive.search_files.return_value = []
 
         with patch.object(gdrive_commands, "_gdrive", return_value=drive):
@@ -203,7 +211,12 @@ class TestResolveFileId:
         gdrive_commands.LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
         gdrive_commands.LIST_CACHE.write_text(json.dumps({"1": "file-a", "2": "file-b"}))
 
-        assert _resolve_file_id("2") == "file-b"
+        from connectonion.cli.commands.gmail_listings import save_listing
+        token = save_listing(gdrive_commands.LIST_CACHE.parent / 'gdrive-listings', 'owner@example.test',
+                             'files', ['file-a','file-b'], provider='gdrive')
+        drive = MagicMock()
+        drive.get_account_email.return_value = 'owner@example.test'
+        assert _resolve_file_id("2", drive, token) == "file-b"
 
     def test_full_id_passes_through(self):
         assert _resolve_file_id("1A2b3C4d5E6f7G8h") == "1A2b3C4d5E6f7G8h"
@@ -212,7 +225,9 @@ class TestResolveFileId:
         gdrive_commands.LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
         gdrive_commands.LIST_CACHE.write_text(json.dumps({"1": "file-a"}))
 
-        assert _resolve_file_id("7") == ""
+        from connectonion.cli.commands.gmail_listings import ListingError
+        with pytest.raises(ListingError, match='--listing'):
+            _resolve_file_id("7")
 
 
 class TestGetPutRm:
@@ -221,28 +236,34 @@ class TestGetPutRm:
         gdrive_commands.LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
         gdrive_commands.LIST_CACHE.write_text(json.dumps({"1": "file-a"}))
         drive = MagicMock()
+        drive.get_account_email.return_value = 'owner@example.test'
         drive.download.return_value = "Downloaded to /tmp/Report.pdf"
 
         with patch.object(gdrive_commands, "_gdrive", return_value=drive):
-            handle_gdrive_get("1", dest="/tmp")
+            from connectonion.cli.commands.gmail_listings import save_listing
+            token = save_listing(gdrive_commands.LIST_CACHE.parent / 'gdrive-listings', 'owner@example.test',
+                                 'files', ['file-a'], provider='gdrive')
+            handle_gdrive_get("1", dest="/tmp", listing=token)
 
         drive.download.assert_called_once_with("file-a", dest="/tmp")
         assert "Report.pdf" in plain(capsys.readouterr().out)
 
     def test_get_unknown_number_exits(self, capsys):
         drive = MagicMock()
+        drive.get_account_email.return_value = 'owner@example.test'
 
         with patch.object(gdrive_commands, "_gdrive", return_value=drive):
             with pytest.raises(typer.Exit):
                 handle_gdrive_get("9")
 
         drive.download.assert_not_called()
-        assert "No file #9" in capsys.readouterr().out
+        assert "--listing" in capsys.readouterr().out
 
     def test_put_uploads_and_shows_the_link(self, tmp_path, capsys):
         local = tmp_path / "report.pdf"
         local.write_bytes(b"data")
         drive = MagicMock()
+        drive.get_account_email.return_value = 'owner@example.test'
         drive.upload.return_value = {
             "id": "file-1", "name": "report.pdf", "type": "application/pdf",
             "modified": "", "size": 4, "link": "https://drive.google.com/file/d/file-1/view",
@@ -268,9 +289,45 @@ class TestGetPutRm:
         gdrive_commands.LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
         gdrive_commands.LIST_CACHE.write_text(json.dumps({"1": "file-a"}))
         drive = MagicMock()
+        drive.get_account_email.return_value = 'owner@example.test'
 
         with patch.object(gdrive_commands, "_gdrive", return_value=drive):
-            handle_gdrive_rm("1")
+            from connectonion.cli.commands.gmail_listings import save_listing
+            token = save_listing(gdrive_commands.LIST_CACHE.parent / 'gdrive-listings', 'owner@example.test',
+                                 'files', ['file-a'], provider='gdrive')
+            handle_gdrive_rm("1", listing=token)
 
         drive.delete.assert_called_once_with("file-a")
         assert "trash" in plain(capsys.readouterr().out)
+
+
+def test_info_json_uses_confirmed_account_and_full_file_id(monkeypatch):
+    from typer.testing import CliRunner
+    from connectonion.cli.main import app
+    drive = MagicMock()
+    drive.get_account_email.return_value = 'owner@example.test'
+    drive.get_info.return_value = {**sample_files(1)[0], 'raw_size':None, 'export_type':'text/markdown'}
+    monkeypatch.setattr(gdrive_commands, '_gdrive', lambda:drive)
+    result = CliRunner().invoke(app, ['gdrive','info','file-1','--json'])
+    data = json.loads(result.stdout)
+    assert result.exit_code == 0, result.output
+    assert data['account'] == 'owner@example.test'
+    assert data['data']['raw_size'] is None
+    drive.get_info.assert_called_once_with('file-1')
+
+
+def test_info_json_usage_and_provider_failures_are_single_safe_documents(monkeypatch):
+    from typer.testing import CliRunner
+    from connectonion.cli.main import app
+    from googleapiclient.errors import HttpError
+    from httplib2 import Response
+    result = CliRunner().invoke(app, ['gdrive','info','--json'])
+    assert result.exit_code == 2
+    assert json.loads(result.stdout)['provider'] == 'gdrive'
+    drive = MagicMock()
+    drive.get_account_email.side_effect = HttpError(Response({'status':'403'}), b'PRIVATE_BODY')
+    monkeypatch.setattr(gdrive_commands, '_gdrive', lambda:drive)
+    result = CliRunner().invoke(app, ['gdrive','info','file-1','--json'])
+    assert result.exit_code == 1
+    assert 'PRIVATE_BODY' not in result.output
+    assert json.loads(result.stdout)['next_command'] == 'co auth google'

--- a/tests/unit/test_gdrive_listing_context.py
+++ b/tests/unit/test_gdrive_listing_context.py
@@ -1,0 +1,32 @@
+"""A Drive row cannot move between accounts or concurrent listings."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from connectonion.cli.commands import gdrive_commands as drive_cli
+from connectonion.cli.commands.gmail_listings import save_listing, ListingError
+
+
+def test_drive_rows_require_matching_account_and_frozen_provider_listing(tmp_path, monkeypatch):
+    monkeypatch.setattr(drive_cli, 'LIST_CACHE', tmp_path/'legacy.json')
+    directory = tmp_path/'gdrive-listings'
+    first = save_listing(directory, 'one@example.test', 'files', ['file-a'], provider='gdrive')
+    second = save_listing(directory, 'one@example.test', 'files', ['file-b'], provider='gdrive')
+    drive = MagicMock()
+    drive.get_account_email.return_value = 'one@example.test'
+    assert drive_cli._resolve_file_id('1', drive, first) == 'file-a'
+    assert drive_cli._resolve_file_id('1', drive, second) == 'file-b'
+    with pytest.raises(ListingError, match='--listing'):
+        drive_cli._resolve_file_id('1', drive)
+    drive.get_account_email.return_value = 'two@example.test'
+    with pytest.raises(ListingError):
+        drive_cli._resolve_file_id('1', drive, first)
+    gmail = save_listing(directory, 'two@example.test', 'messages', ['message-a'])
+    with pytest.raises(ListingError):
+        drive_cli._resolve_file_id('1', drive, gmail)
+
+
+def test_full_drive_ids_never_consult_a_legacy_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(drive_cli, 'LIST_CACHE', tmp_path/'legacy.json')
+    drive_cli.LIST_CACHE.write_text('{"file-a":"wrong"}')
+    assert drive_cli._resolve_file_id('file-a') == 'file-a'

--- a/tests/unit/test_gmail.py
+++ b/tests/unit/test_gmail.py
@@ -1755,8 +1755,8 @@ class TestGmailDraftAttachments:
         service = MagicMock()
         service.users().drafts().send().execute.return_value = {"id": "message-1"}
 
-        result = self._gmail(service)._send_draft("draft-1")
+        result = self._gmail(service)._send_draft("draft-1", raw='reviewed-raw')
 
         assert result == {"id": "message-1"}
-        assert service.users().drafts().send.call_args.kwargs["body"] == {"id": "draft-1"}
+        assert service.users().drafts().send.call_args.kwargs["body"] == {"id": "draft-1", "message": {"raw": "reviewed-raw"}}
         service.users().messages().send.assert_not_called()

--- a/tests/unit/test_gmail_commands.py
+++ b/tests/unit/test_gmail_commands.py
@@ -71,6 +71,7 @@ from connectonion.cli.commands.gmail_listings import save_listing, ListingError
 def mail_mock():
     client = MagicMock()
     client.get_account_email.return_value = 'one@example.test'
+    client._draft_attachment_budget.return_value = 25_000_000
     return client
 
 
@@ -570,6 +571,21 @@ def sample_draft(**overrides):
     return draft
 
 
+@pytest.fixture
+def reviewed_cli(monkeypatch):
+    from types import SimpleNamespace
+    from connectonion.cli.commands import gmail_draft_review as review_module
+    manifest = sample_draft(account='one@example.test', **{'from':'one@example.test'},
+        body_sha256='digest', mime_size=100, mime_limit=35_000_000, encoded_size=136,
+        attachment_limit=25_000_000, warnings=[])
+    review = SimpleNamespace(manifest=manifest, token='a'*64, raw='frozen', thread_id=None)
+    monkeypatch.setattr(review_module, 'prepare_review', lambda *args:review)
+    monkeypatch.setattr(review_module, 'send_reviewed', lambda client,id,token:client._send_draft(id, raw='frozen', thread_id=None))
+    monkeypatch.setattr(gmail_commands, 'console', Console(force_terminal=True, width=120))
+    monkeypatch.setattr(sys, 'stdin', MagicMock(isatty=lambda:True))
+    return review
+
+
 class TestGmailDraftCommands:
     """The CLI is a staged workflow and every result prints one next command."""
 
@@ -609,7 +625,7 @@ class TestGmailDraftCommands:
             gmail_commands._resolve_draft_id(gmail, "1")
 
     @pytest.mark.parametrize("interruption", [typer.Abort, KeyboardInterrupt, EOFError])
-    def test_interrupted_confirmation_keeps_draft_and_prints_tip(self, interruption, capsys):
+    def test_interrupted_confirmation_keeps_draft_and_prints_tip(self, interruption, capsys, reviewed_cli):
         gmail = mail_mock()
         gmail.get_draft.return_value = sample_draft()
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -618,7 +634,7 @@ class TestGmailDraftCommands:
                     gmail_commands.handle_gmail_draft_send("draft-1")
         assert exc.value.exit_code == 1
         gmail._send_draft.assert_not_called()
-        assert "co gmail draft preview draft-1" in plain(capsys.readouterr().out)
+        assert "co gmail draft review draft-1" in plain(capsys.readouterr().out)
 
     def test_create_stays_unsent_and_points_to_attach(self, capsys):
         gmail = mail_mock()
@@ -656,8 +672,9 @@ class TestGmailDraftCommands:
         gmail = mail_mock()
         gmail._add_draft_attachment.return_value = sample_draft()
         drive = MagicMock()
+        drive.get_account_email.return_value = 'one@example.test'
         drive._read_file.return_value = {
-            "name": "Budget.csv", "type": "text/csv", "data": b"a,b",
+            "id":"drive-file", "name": "Budget.csv", "type": "text/csv", "data": b"a,b",
         }
 
         with patch.object(gmail_commands, "_gmail", return_value=gmail):
@@ -666,15 +683,16 @@ class TestGmailDraftCommands:
 
         drive._read_file.assert_called_once()
         gmail._add_draft_attachment.assert_called_once_with(
-            "draft-1", "Budget.csv", "text/csv", b"a,b"
+            "draft-1", "Budget.csv", "text/csv", b"a,b", source={"source":"drive_attachment", "drive_file_id":"drive-file"}
         )
         assert "co gmail draft preview draft-1" in plain(capsys.readouterr().out)
 
     def test_attach_drive_link_does_not_download_or_change_sharing(self, capsys):
         gmail = mail_mock()
-        gmail.add_draft_link.return_value = sample_draft(attachments=[], attachment_size=0)
+        gmail._add_managed_draft_link.return_value = sample_draft(attachments=[], attachment_size=0)
         drive = MagicMock()
-        drive._get_file.return_value = {
+        drive.get_account_email.return_value = 'one@example.test'
+        drive.get_info.return_value = {
             "name": "Budget", "link": "https://drive.google.com/file/d/1/view",
         }
 
@@ -683,9 +701,7 @@ class TestGmailDraftCommands:
                 handle_gmail_draft_attach("draft-1", "drive-file", drive=True, link=True)
 
         drive._read_file.assert_not_called()
-        gmail.add_draft_link.assert_called_once_with(
-            "draft-1", "Budget", "https://drive.google.com/file/d/1/view"
-        )
+        gmail._add_managed_draft_link.assert_called_once_with("draft-1", drive.get_info.return_value)
         assert "Drive link added" in plain(capsys.readouterr().out)
 
     def test_link_without_drive_is_a_fix_it_error(self, capsys):
@@ -726,9 +742,9 @@ class TestGmailDraftCommands:
         output = plain(capsys.readouterr().out)
         assert "Exact body" in output
         assert "report.pdf (application/pdf, 4 bytes)" in output
-        assert "co gmail draft send draft-1" in output
+        assert "co gmail draft review draft-1" in output
 
-    def test_send_decline_keeps_draft_and_exits_nonzero(self, capsys):
+    def test_send_decline_keeps_draft_and_exits_nonzero(self, capsys, reviewed_cli):
         gmail = mail_mock()
         gmail.get_draft.return_value = sample_draft()
 
@@ -741,9 +757,9 @@ class TestGmailDraftCommands:
         gmail._send_draft.assert_not_called()
         output = plain(capsys.readouterr().out)
         assert "Not sent" in output
-        assert "co gmail draft preview draft-1" in output
+        assert "co gmail draft review draft-1" in output
 
-    def test_send_confirms_after_preview_and_points_to_sent(self, capsys):
+    def test_send_confirms_after_preview_and_points_to_sent(self, capsys, reviewed_cli):
         gmail = mail_mock()
         gmail.get_draft.return_value = sample_draft()
         gmail._send_draft.return_value = {"id": "message-1"}
@@ -754,7 +770,7 @@ class TestGmailDraftCommands:
 
         output = plain(capsys.readouterr().out)
         assert "Exact body" in output
-        gmail._send_draft.assert_called_once_with("draft-1")
+        gmail._send_draft.assert_called_once_with("draft-1", raw='frozen', thread_id=None)
         assert "co gmail sent" in output
 
     def test_unknown_cached_number_points_to_list(self, capsys):

--- a/tests/unit/test_gmail_draft_review.py
+++ b/tests/unit/test_gmail_draft_review.py
@@ -1,0 +1,151 @@
+"""A review controls the exact send payload, even with concurrent provider edits."""
+import base64
+from email.message import EmailMessage
+from unittest.mock import MagicMock
+
+import pytest
+
+from connectonion.useful_tools.gmail import Gmail
+
+
+def raw_message(body='Reviewed body'):
+    message = EmailMessage()
+    message['To'] = 'recipient@example.test'
+    message['Cc'] = 'copy@example.test'
+    message['Bcc'] = 'blind@example.test'
+    message['Subject'] = 'Review fixture'
+    message.set_content(body)
+    return base64.urlsafe_b64encode(message.as_bytes()).decode()
+
+
+@pytest.fixture
+def gmail(monkeypatch):
+    client = Gmail.__new__(Gmail)
+    service = MagicMock()
+    service.users().drafts().get().execute.return_value = {
+        'id':'draft-a', 'message':{'raw':raw_message(), 'threadId':'thread-a'}}
+    service.users().drafts().send().execute.return_value = {'id':'sent-a'}
+    monkeypatch.setattr(client, '_get_service', lambda:service)
+    monkeypatch.setattr(client, 'get_account_email', lambda:'owner@example.test')
+    monkeypatch.setattr(client, '_require_draft_write_scope', lambda:None)
+    return client, service
+
+
+def test_review_binds_account_draft_thread_and_full_content(gmail):
+    from connectonion.cli.commands.gmail_draft_review import prepare_review
+    client, service = gmail
+    first = prepare_review(client, 'draft-a')
+    assert first.manifest['bcc'] == 'blind@example.test'
+    assert first.manifest['account'] == 'owner@example.test'
+    assert first.manifest['encoded_size'] > 0
+    assert first.token == prepare_review(client, 'draft-a').token
+    service.users().drafts().get().execute.return_value['message']['raw'] = raw_message('Changed body')
+    assert first.token != prepare_review(client, 'draft-a').token
+
+
+def test_changed_draft_cannot_send_with_old_review(gmail, tmp_path):
+    from connectonion.cli.commands.gmail_draft_review import prepare_review, send_reviewed, DraftReviewError
+    client, service = gmail
+    review = prepare_review(client, 'draft-a')
+    service.users().drafts().get().execute.return_value['message']['raw'] = raw_message('Changed independently')
+    with pytest.raises(DraftReviewError, match='changed'):
+        send_reviewed(client, 'draft-a', review.token, directory=tmp_path)
+    service.users().drafts().send.assert_called_once_with()  # mock fixture initialization only
+
+
+def test_send_carries_frozen_bytes_in_same_provider_request(gmail, tmp_path):
+    from connectonion.cli.commands.gmail_draft_review import prepare_review, send_reviewed
+    client, service = gmail
+    review = prepare_review(client, 'draft-a')
+    result = send_reviewed(client, 'draft-a', review.token, directory=tmp_path)
+    assert result['id'] == 'sent-a'
+    body = service.users().drafts().send.call_args.kwargs['body']
+    assert body == {'id':'draft-a', 'message':{'raw':review.raw, 'threadId':'thread-a'}}
+    assert b'Reviewed body' in base64.urlsafe_b64decode(body['message']['raw'])
+
+
+def test_lost_send_response_blocks_resubmission(gmail, tmp_path):
+    from connectonion.cli.commands.gmail_draft_review import prepare_review, send_reviewed, DraftReviewError
+    from requests import ConnectionError
+    client, service = gmail
+    review = prepare_review(client, 'draft-a')
+    service.users().drafts().send().execute.side_effect = ConnectionError('provider secret body')
+    service.users().messages().list().execute.return_value = {'messages':[]}
+    with pytest.raises(DraftReviewError, match='uncertain'):
+        send_reviewed(client, 'draft-a', review.token, directory=tmp_path)
+    before = service.users().drafts().send().execute.call_count
+    with pytest.raises(DraftReviewError, match='uncertain'):
+        send_reviewed(client, 'draft-a', review.token, directory=tmp_path)
+    assert service.users().drafts().send().execute.call_count == before
+    assert 'Reviewed body' not in ''.join(path.read_text() for path in tmp_path.glob('*.json'))
+
+
+def test_repeating_confirmed_send_returns_receipt_without_resending(gmail, tmp_path):
+    from connectonion.cli.commands.gmail_draft_review import prepare_review, send_reviewed
+    client, service = gmail
+    review = prepare_review(client, 'draft-a')
+    first = send_reviewed(client, 'draft-a', review.token, directory=tmp_path)
+    before = service.users().drafts().send().execute.call_count
+    assert send_reviewed(client, 'draft-a', review.token, directory=tmp_path)['id'] == first['id']
+    assert service.users().drafts().send().execute.call_count == before
+
+
+def test_non_tty_send_cannot_be_approved_by_piped_yes(gmail, monkeypatch):
+    from typer.testing import CliRunner
+    from connectonion.cli.main import app
+    from connectonion.cli.commands import gmail_commands as gm
+    client, service = gmail
+    monkeypatch.setattr(gm, '_gmail', lambda:client)
+    result = CliRunner().invoke(app, ['gmail','draft','send','draft-a'], input='y\n')
+    assert result.exit_code == 1
+    assert 'Non-interactive send requires' in result.output
+    assert service.users().drafts().send().execute.call_count == 0
+
+
+def test_json_review_then_confirm_routes_complete_frozen_payload(gmail, monkeypatch):
+    import json
+    from typer.testing import CliRunner
+    from connectonion.cli.main import app
+    from connectonion.cli.commands import gmail_commands as gm
+    client, service = gmail
+    monkeypatch.setattr(gm, '_gmail', lambda:client)
+    reviewed = CliRunner().invoke(app, ['gmail','draft','review','draft-a','--json'])
+    assert reviewed.exit_code == 0, reviewed.output
+    token = json.loads(reviewed.stdout)['data']['review_token']
+    sent = CliRunner().invoke(app, ['gmail','draft','send','draft-a','--confirm',token,'--json'])
+    assert sent.exit_code == 0, sent.output
+    assert json.loads(sent.stdout)['data']['id'] == 'sent-a'
+    assert 'raw' in service.users().drafts().send.call_args.kwargs['body']['message']
+
+
+def test_id_only_sdk_send_is_refused(gmail):
+    client, service = gmail
+    with pytest.raises(ValueError, match='reviewed raw'):
+        client._send_draft('draft-a')
+    assert service.users().drafts().send().execute.call_count == 0
+
+
+def test_edit_after_final_check_cannot_substitute_outgoing_content(gmail, monkeypatch, tmp_path):
+    from connectonion.cli.commands.gmail_draft_review import prepare_review, send_reviewed
+    client, service = gmail
+    review = prepare_review(client, 'draft-a')
+    def concurrent_edit():
+        service.users().drafts().get().execute.return_value['message']['raw'] = raw_message('Independent late edit')
+    monkeypatch.setattr(client, '_require_draft_write_scope', concurrent_edit)
+    send_reviewed(client, 'draft-a', review.token, directory=tmp_path)
+    outgoing = service.users().drafts().send.call_args.kwargs['body']['message']['raw']
+    assert outgoing == review.raw
+    assert b'Independent late edit' not in base64.urlsafe_b64decode(outgoing)
+
+
+def test_unknown_send_recovers_one_sent_receipt_without_resubmission(gmail, tmp_path):
+    from connectonion.cli.commands.gmail_draft_review import prepare_review, send_reviewed, DraftReviewError
+    client, service = gmail
+    review = prepare_review(client, 'draft-a')
+    service.users().drafts().send().execute.side_effect = TimeoutError()
+    with pytest.raises(DraftReviewError):
+        send_reviewed(client, 'draft-a', review.token, directory=tmp_path)
+    before = service.users().drafts().send().execute.call_count
+    service.users().messages().list().execute.return_value = {'messages':[{'id':'recovered-a'}]}
+    assert send_reviewed(client, 'draft-a', review.token, directory=tmp_path) == {'id':'recovered-a', 'recovered':True}
+    assert service.users().drafts().send().execute.call_count == before

--- a/tests/unit/test_gmail_draft_sources.py
+++ b/tests/unit/test_gmail_draft_sources.py
@@ -1,0 +1,159 @@
+"""Managed source metadata survives provider MIME round trips and restart."""
+from email.message import EmailMessage
+
+import pytest
+
+from connectonion.useful_tools.gmail import Gmail
+from connectonion.useful_tools import gmail_draft_sources as sources
+
+
+def message():
+    result = EmailMessage()
+    result['To'] = 'recipient@example.test'
+    result['Cc'] = 'copy@example.test'
+    result['Bcc'] = 'blind@example.test'
+    result['Subject'] = 'Unicode résumé'
+    result.set_content('Body with an ordinary URL: https://drive.google.com/file/d/ordinary/view\n')
+    return result
+
+
+def item(id='file-a'):
+    return {'id':id, 'name':'Budget', 'type':'application/pdf', 'raw_size':5,
+            'link':f'https://drive.google.com/file/d/{id}/view'}
+
+
+def test_arbitrary_body_url_is_never_a_managed_item():
+    assert sources.read_links(message()) == []
+
+
+def test_link_round_trip_keeps_account_recipients_and_explicit_record():
+    original = message()
+    sources.add_link(original, item())
+    restored = Gmail._decode_message(Gmail._encode_message(original))
+    rows = sources.read_links(restored)
+    assert len(rows) == 1 and rows[0]['drive_file_id'] == 'file-a'
+    assert rows[0]['sharing'] == 'unchanged; recipient access unverified'
+    assert str(restored['Bcc']) == 'blind@example.test'
+    assert str(restored['Subject']) == 'Unicode résumé'
+    assert item()['link'] in restored.get_content()
+
+
+def test_remove_link_leaves_arbitrary_body_url_untouched():
+    original = message()
+    sources.add_link(original, item())
+    sources.remove_link(original, 0)
+    assert sources.read_links(original) == []
+    assert '/ordinary/view' in original.get_content()
+    assert '/file-a/view' not in original.get_content()
+
+
+def test_independent_link_edit_cannot_keep_stale_managed_record():
+    original = message()
+    sources.add_link(original, item())
+    original.set_content(original.get_content().replace('/file-a/', '/different/'))
+    with pytest.raises(ValueError, match='changed'):
+        sources.read_links(original)
+
+
+def test_file_source_survives_mime_round_trip_and_detects_changed_bytes():
+    original = message()
+    original.add_attachment(b'original', maintype='application', subtype='pdf', filename='résumé.pdf')
+    part = list(original.iter_attachments())[0]
+    sources.tag_file(part, b'original', {'source':'drive_attachment','drive_file_id':'file-a','export_type':'application/pdf'})
+    restored = Gmail._decode_message(Gmail._encode_message(original))
+    part = list(restored.iter_attachments())[0]
+    assert sources.file_source(part)['drive_file_id'] == 'file-a'
+    part.set_payload('altered')
+    with pytest.raises(ValueError, match='changed'):
+        sources.file_source(part)
+
+@pytest.fixture
+def provider(monkeypatch):
+    from unittest.mock import MagicMock
+    client = Gmail.__new__(Gmail)
+    service = MagicMock()
+    current = {'message': message()}
+    def fetch(**kwargs):
+        request = MagicMock()
+        request.execute.return_value = {'message':{'raw':Gmail._encode_message(current['message'])}}
+        return request
+    def update(**kwargs):
+        current['message'] = Gmail._decode_message(kwargs['body']['message']['raw'])
+        return MagicMock()
+    service.users().drafts().get.side_effect = fetch
+    service.users().drafts().update.side_effect = update
+    monkeypatch.setattr(client, '_get_service', lambda:service)
+    monkeypatch.setattr(client, '_require_draft_write_scope', lambda:None)
+    monkeypatch.setattr(client, 'get_account_email', lambda:'owner@example.test')
+    return client, service, current
+
+
+def test_unified_items_survive_fetch_remove_and_replace_in_one_update(provider):
+    client, service, current = provider
+    client._add_draft_attachment('draft-a', 'local.txt', 'text/plain', b'local', source={'source':'local'})
+    client._add_managed_draft_link('draft-a', item())
+    restored = client.get_draft('draft-a')
+    assert [row['source'] for row in restored['items']] == ['local', 'drive_link']
+    assert restored['attachment_size'] == 5
+    before = service.users().drafts().update.call_count
+    client._replace_draft_attachment('draft-a', 2, 'new.txt', 'text/plain', b'new', source={'source':'local'})
+    assert service.users().drafts().update.call_count == before + 1
+    assert '/file-a/view' not in client.get_draft('draft-a')['body']
+    client._replace_draft_link('draft-a', 1, item('file-b'))
+    restored = client.get_draft('draft-a')
+    assert [row['source'] for row in restored['items']] == ['local', 'drive_link']
+    client.remove_draft_attachment('draft-a', 2)
+    assert len(client.get_draft('draft-a')['items']) == 1
+    assert '/ordinary/view' in client.get_draft('draft-a')['body']
+
+
+def test_failed_link_replacement_keeps_old_provider_item(provider):
+    client, service, current = provider
+    client._add_managed_draft_link('draft-a', item())
+    before = Gmail._encode_message(current['message'])
+    with pytest.raises(ValueError, match='HTTPS'):
+        client._replace_draft_link('draft-a', 1, {**item(), 'link':'http://untrusted.test'})
+    assert Gmail._encode_message(current['message']) == before
+
+
+def test_send_strips_internal_records_but_review_shows_sources(provider):
+    from connectonion.cli.commands.gmail_draft_review import prepare_review
+    client, service, current = provider
+    client._add_draft_attachment('draft-a', 'a.txt', 'text/plain', b'a', source={'source':'local'})
+    client._add_managed_draft_link('draft-a', item())
+    reviewed = prepare_review(client, 'draft-a')
+    outgoing = Gmail._decode_message(reviewed.raw)
+    assert [row['source'] for row in reviewed.manifest['items']] == ['local','drive_link']
+    assert all(sources.SOURCE_HEADER not in part and sources.LINK_HEADER not in part for part in outgoing.walk())
+    assert item()['link'] in client._message_body(outgoing)
+
+
+def test_mime_limit_rejects_update_before_provider_mutation(provider, monkeypatch):
+    from connectonion.useful_tools import gmail_draft_mime
+    client, service, current = provider
+    monkeypatch.setattr(gmail_draft_mime, 'MIME_LIMIT', 100)
+    with pytest.raises(ValueError, match='MIME'):
+        client._add_draft_attachment('draft-a', 'a.txt', 'text/plain', b'a')
+    service.users().drafts().update.assert_not_called()
+
+
+def test_managed_link_handles_provider_crlf_round_trip():
+    from email import policy
+    from email.parser import BytesParser
+    original = message()
+    sources.add_link(original, item())
+    restored = BytesParser(policy=policy.default).parsebytes(original.as_bytes(policy=policy.SMTP))
+    assert sources.read_links(restored)[0]['drive_file_id'] == 'file-a'
+    sources.remove_link(restored, 0)
+    assert '/file-a/view' not in restored.get_content()
+
+
+def test_drive_stream_budget_excludes_only_replaced_file(provider, monkeypatch):
+    import connectonion.useful_tools.gmail as gmail_module
+    client, service, current = provider
+    client._add_draft_attachment('draft-a', 'a.txt', 'text/plain', b'1234')
+    client._add_managed_draft_link('draft-a', item())
+    monkeypatch.setattr(gmail_module, 'GMAIL_ATTACHMENT_LIMIT', 10)
+    assert client._draft_attachment_budget('draft-a') == 6
+    assert client._draft_attachment_budget('draft-a', replacing=1) == 10
+    assert client._draft_attachment_budget('draft-a', replacing=2) == 6

--- a/tests/unit/test_google_cli_design.py
+++ b/tests/unit/test_google_cli_design.py
@@ -36,11 +36,13 @@ CASES = [
     (['gmail', 'draft', 'attach', 'draft-a', 'report.pdf'], 'Preview the staged draft', 'co gmail draft preview draft-a'),
     (['gmail', 'draft', 'remove', 'draft-a', '1'], 'Preview the updated draft', 'co gmail draft preview draft-a'),
     (['gmail', 'draft', 'replace', 'draft-a', '1', 'report.pdf'], 'Preview the updated draft', 'co gmail draft preview draft-a'),
-    (['gmail', 'draft', 'preview', 'draft-a'], 'Proceed to the confirmation gate', 'co gmail draft send draft-a'),
-    (['gmail', 'draft', 'send', 'draft-a'], 'Inspect the kept draft', 'co gmail draft preview draft-a'),
-    (['gdrive'], 'Download the first listed file', 'co gdrive get 1'),
-    (['gdrive', 'list'], 'Download the first listed file', 'co gdrive get 1'),
-    (['gdrive', 'search', 'Report'], 'Download the first matching file', 'co gdrive get 1'),
+    (['gmail', 'draft', 'preview', 'draft-a'], 'Obtain a content-bound review', 'co gmail draft review draft-a'),
+    (['gmail', 'draft', 'send', 'draft-a'], 'Review the kept draft', 'co gmail draft review draft-a'),
+    (['gmail', 'draft', 'review', 'draft-a'], 'Send this exact reviewed content', 'co gmail draft send draft-a --confirm ' + 'a' * 64),
+    (['gdrive', 'info', 'file-a'], 'Download the inspected file', 'co gdrive get file-a'),
+    (['gdrive'], 'Download the first listed file', 'co gdrive get file-a'),
+    (['gdrive', 'list'], 'Download the first listed file', 'co gdrive get file-a'),
+    (['gdrive', 'search', 'Report'], 'Download the first matching file', 'co gdrive get file-a'),
     (['gdrive', 'get', 'file-a'], 'Show more files', 'co gdrive list'),
     (['gdrive', 'put', 'report.pdf'], 'Check uploaded files', 'co gdrive list'),
     (['gdrive', 'rm', 'file-a'], 'Show remaining files', 'co gdrive list'),
@@ -79,12 +81,20 @@ def capture(args, root, failure=None):
         getattr(gmail, name).return_value = draft
     drive.list_files.return_value = drive.search_files.return_value = [
         dict(id='file-a', name='Report.pdf', type='application/pdf', size=5, modified='')]
+    drive.get_account_email.return_value = 'sender@example.invalid'
+    drive.get_info.return_value = dict(id='file-a', name='Report.pdf', type='application/pdf', raw_size=5)
     drive.download.return_value = 'Downloaded to report.pdf'
     drive.upload.return_value = dict(name='Report.pdf', link='')
     if failure is not None:
         gmail.list_inbox.side_effect = drive.list_files.side_effect = failure
         gmail.send.side_effect = gmail.reply.side_effect = drive.upload.side_effect = failure
+    from connectonion.cli.commands import gmail_draft_review as review_module
+    from types import SimpleNamespace
+    reviewed = SimpleNamespace(token='a'*64, manifest={**draft, 'account':'sender@example.invalid',
+        'from':'sender@example.invalid', 'body_sha256':'b'*64, 'mime_size':100, 'encoded_size':136,
+        'attachment_limit':25_000_000, 'mime_limit':35_000_000, 'warnings':[], 'review_token':'a'*64})
     with ExitStack() as stack:
+        stack.enter_context(patch.object(review_module, 'prepare_review', return_value=reviewed))
         stack.enter_context(patch.dict(os.environ, {'GOOGLE_EMAIL': 'sender@example.invalid'}))
         for module, name, value in ((gm, '_gmail', lambda **kw: gmail),
                                     (gd, '_gdrive', lambda: drive),
@@ -155,7 +165,9 @@ def test_empty_listing_cannot_reuse_old_row(module, cache, handler, args, method
             with pytest.raises(ListingError):
                 gm._resolve_email_id(client, '1')
         else:
-            assert gd._resolve_file_id('1') == ''
+            from connectonion.cli.commands.gmail_listings import ListingError
+            with pytest.raises(ListingError):
+                gd._resolve_file_id('1', client)
 
 
 @pytest.mark.parametrize('surface,subcommand', [('gmail', 'read'), ('gdrive', 'get')])


### PR DESCRIPTION
## Preview publication decision — 8 September 2026

The owner explicitly authorized technical-article model review and Gmail/Drive fixture writes, then requested publishing **1.8.4a1 preview first**, followed by local installed-package acceptance. The approved journal is now included. Final 1.8.4 stable still needs the live Gmail/Drive and physical NAS journeys; they do not block this explicitly requested opt-in preview. The earlier pending-export statements below are historical. All required current-head checks must pass before merge; none is waived.

A Gmail draft could change after its preview but before ID-only sending. This change binds review to the account, draft, thread and complete MIME, then supplies the reviewed raw payload in the same request that consumes the draft. It also records uncertain send attempts before submission, so a lost response cannot silently become a duplicate retry.

Refs #1424 and #1445. Depends on #1452; #1451 and #1450 are merged. Base: `feat/1.8.4-gmail-mailbox` at `8dbe7d0d`.

- **Proposed target version:** 1.8.4a1 preview; 1.8.4 stable after acceptance
- **Estimated release window:** after coordinated acceptance; no publication date promised
- **Suggested labels:** enhancement
- **Forward-port tracking issue (stable patches only):** N/A — stacked mainline work; policy correction #1449

`draft review [--json]` is canonical; preview remains available. Send needs the exact token or a real terminal's default-No confirmation. Internal source records preserve local/Drive files and managed links across Gmail reloads, then are stripped from outgoing MIME. Replacement validates before one update. New `gdrive info` exposes metadata and unknown/export sizes without downloading. Drive streams respect remaining draft budget, and shortcut cycles/trash fail.

Drive row numbers now require frozen account-bound listing tokens (`--listing` on get/info/rm, `--drive-listing` for Gmail source rows). Full IDs remain available. Old mutable caches are ignored. Limits remain 25,000,000 decoded file bytes, plus 35,000,000 final MIME bytes. Drive sharing is unchanged.

Verification and migration are recorded in `docs/acceptance/1.8.4-gmail-draft-review.md`, CLI/tool docs, the packaged skill, DD 069 and the Design Journal draft. Initial focused run: 306 passed; subsequent listing/piping cases: 31 passed. Pinned output-only audit: 22/22. Wheel/sdist build, twine and installed read-only Gmail/Drive inspection across restart/directory changes passed. Final full suite at `6ab91e64`: **8,314 passed**, 23 skipped, 184 live tests deselected and seven warnings (274.81 seconds), after fixing one obsolete printer fixture.

Live draft/Drive fixture writes and self-send acceptance remain unperformed. The external article quality gate also awaits explicit approval after automatic approval review rejected exporting that new article. No merge, version bump, publication or live send is claimed. Mostly AI-generated with Codex (GPT-6).

| Command | Printed tip | Goal | Model reply | Pass |
|---|---|---|---|---|
| co gmail | Read one with: co gmail read msg-a | Read the first listed email | co gmail read msg-a | True |
| co gmail inbox | Read one with: co gmail read msg-a | Read the first listed email | co gmail read msg-a | True |
| co gmail search test | Read one with: co gmail read msg-a | Read the first matching email | co gmail read msg-a | True |
| co gmail read msg-a | Unread state unchanged. Reply with: co gmail reply msg-a <message> | Reply with body Thanks | co gmail reply msg-a "Thanks" | True |
| co gmail reply msg-a Thanks | Check sent mail: co gmail sent | Check sent mail | co gmail sent | True |
| co gmail send a@example.invalid Test Hello | Check sent mail: co gmail sent | Check sent mail | co gmail sent | True |
| co gmail sent | Read one with: co gmail read msg-a | Read the first listed sent email | co gmail read msg-a | True |
| co gmail draft list | Preview one with: co gmail draft preview draft-a | Preview the first listed draft | co gmail draft preview draft-a | True |
| co gmail draft create a@example.invalid Test Hello | Attach a local file: co gmail draft attach draft-a <path> | Attach report.pdf | co gmail draft attach draft-a report.pdf | True |
| co gmail draft attach draft-a report.pdf | Preview it: co gmail draft preview draft-a | Preview the staged draft | co gmail draft preview draft-a | True |
| co gmail draft remove draft-a 1 | Preview it: co gmail draft preview draft-a | Preview the updated draft | co gmail draft preview draft-a | True |
| co gmail draft replace draft-a 1 report.pdf | Preview it: co gmail draft preview draft-a | Preview the updated draft | co gmail draft preview draft-a | True |
| co gmail draft preview draft-a | Review before sending: co gmail draft review draft-a | Obtain a content-bound review | co gmail draft review draft-a | True |
| co gmail draft send draft-a | Next: co gmail draft review draft-a | Review the kept draft | co gmail draft review draft-a | True |
| co gmail draft review draft-a | Next: co gmail draft send draft-a --confirm aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | Send this exact reviewed content | co gmail draft send draft-a --confirm aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | True |
| co gdrive info file-a | Next: co gdrive get file-a | Download the inspected file | co gdrive get file-a | True |
| co gdrive | Download one with: co gdrive get file-a | Download the first listed file | co gdrive get file-a | True |
| co gdrive list | Download one with: co gdrive get file-a | Download the first listed file | co gdrive get file-a | True |
| co gdrive search Report | Download one with: co gdrive get file-a | Download the first matching file | co gdrive get file-a | True |
| co gdrive get file-a | Show more files: co gdrive list | Show more files | co gdrive list | True |
| co gdrive put report.pdf | Check uploaded files: co gdrive list | Check uploaded files | co gdrive list | True |
| co gdrive rm file-a | Show remaining files: co gdrive list | Show remaining files | co gdrive list | True |

## Current review candidate

Head `c05276451ddf282cede8429b0f635ac414b22e3f` includes the prepared live acceptance script, mailbox stack and ANSI-help regression. This exact code-only head passes **357 Gmail/Drive/CLI tests**. The combined Core candidate passed **8,562 tests, 23 skipped, 184 deselected**; local 1.8.4 wheel installation and CLI smoke checks pass.

The Design Journal remains local pending approval for its model-backed review/export. This PR has no docs/blog diff and introduces no private journal objects; the required story gate remains pending and is not waived. The explicit real draft/Drive/self-send journey is prepared in `scripts/acceptance/gmail_release.py` but has not run. No Core release or live send is claimed.

Current PR head: `7b5101faa8942d94b614e0b099944d2b5712f430`; the final follow-up changes acceptance documentation only. Runtime test counts above apply unchanged.

