### PR TITLE
VERSIONING.md stops calling 1.8.3 unpublished

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -63,7 +63,7 @@ or advertise this candidate as published until the remaining gates pass.
 ## Current Version: 1.8.3
 
 ### Version History
-- 1.8.3 (**prepared, not published — Google tools with local credentials:**
+- 1.8.3 (**Google tools with local credentials:**
   unify Gmail, Drive, Calendar and YouTube authorization and command discovery;
   add Gmail draft attachments, Calendar CLI and preview-confirmed YouTube
   uploads/metadata updates. Preserve local token ownership, refresh rotation


### PR DESCRIPTION
1.8.3 is on PyPI (uploaded 2026-09-06) and is the Latest GitHub release (`v1.8.3`, 2026-09-06T15:54Z), but its VERSIONING.md entry still opens with "prepared, not published". Checked against PyPI's release index and `gh release list`, not inferred from the tag.

One-line change: drop the stale qualifier from the entry heading. Nothing else in the entry changes.

Release-entry and version-agreement tests: 19 passed.

**Proposed target version:** docs only / no release
**Estimated release window:** none; corrects the record for an already-published version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmCtowqB3DqGVPpTb1VU3S
