### PR TITLE
Release 1.8.4b1: Outlook fixes (#1312 #1313 #1314 #1247) and co outlook calendar

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -43,7 +43,28 @@ The published stable line is 1.8.x. Maintenance fixes for `release/1.7`
 must still be forward-ported to `main`. Pre-releases are opt-in and must be
 marked as pre-releases on PyPI and GitHub.
 
-## Release candidate: 1.8.4a2 (preview, prepared for publication)
+## Release candidate: 1.8.4b1 (beta preview, prepared for publication)
+
+The first 1.8.4 beta closes the open Outlook complaints from one working day
+and gives the Microsoft calendar a terminal. A valid Microsoft token is used
+until five minutes before its expiry, so an oo-api outage no longer makes a
+reachable mailbox look expired (#1312). Each credential failure names the
+layer that broke — `co auth` for a missing or dead OpenOnion key, `co auth
+microsoft` for a revoked or incomplete Microsoft record — instead of blaming
+Microsoft for both (#1313). A scheduled send or reply ends by naming the
+cancel path, and `co outlook --help` groups Mail, Send, Scheduled sends,
+Contacts and Calendar (#1314). `co outlook reply --cc/--bcc` copies a third
+person without leaving the thread (#1247). `co outlook calendar` mirrors
+`co gcalendar` leaf for leaf over the existing MicrosoftCalendar tool, with
+writes that preview by default and print the exact `--yes` command (#816).
+
+Beta means the 1.8.4 surface is now frozen for exercise: no new command groups
+after this, only fixes found by running it. Every Outlook command ends with one
+next command that survives piping; the exit-code and tip evidence is in the
+release PR. Stable remains 1.8.3; physical Synology acceptance and the final
+1.8.4 decision are unchanged from 1.8.4a2. See [1.8.4b1 notes](docs/releases/1.8.4b1.md).
+
+## Release candidate: 1.8.4a2 (preview, published)
 
 This preview fixes Gmail send-receipt recovery when Google rewrites Message-ID.
 Reviewed MIME carries a provider-preserved attempt marker; recovery requires a
@@ -58,9 +79,24 @@ Stable remains 1.8.3; this does not authorize final 1.8.4 or cloud provisioning.
 See [1.8.4a2 notes](docs/releases/1.8.4a2.md) and the
 [local acceptance record](docs/acceptance/1.8.4-live-followup/README.md).
 
-## Current Version: 1.8.4a2
+## Current Version: 1.8.4b1
 
 ### Version History
+- 1.8.4b1 (**the first 1.8.4 beta: Outlook stops blaming the wrong credential, says how
+  to cancel, copies a third person without leaving the thread, and gets a calendar.**
+  A valid Microsoft token is used until five minutes before expiry rather than
+  discarded on every command (#1312, a regression test now pins it). Broker 401s and
+  a missing `OPENONION_API_KEY` point to `co auth`; a revoked or refresh-less
+  Microsoft record points to `co auth microsoft` (#1313). Scheduled sends and
+  replies end with `co outlook scheduled` and name `co outlook cancel <#>`; the
+  group help reads as Mail / Send / Scheduled sends / Contacts / Calendar (#1314).
+  `co outlook reply --cc/--bcc` sets recipients on Graph's reply action or on the
+  deferred reply draft, so the reply stays threaded (#1247). New `co outlook
+  calendar` group — list, today, read, meetings, free, create, teams, update,
+  delete — over the existing MicrosoftCalendar tool, previews by default, ISO
+  offsets converted to UTC, Graph error bodies never printed (#816). Every Outlook
+  command ends with one next command that survives piping. Beta: the 1.8.4 surface
+  is frozen for exercise. Stable remains 1.8.3.)
 - 1.8.4a2 (**preview recovery fix:** Gmail-preserved attempt markers recover a
   lost send receipt despite rewritten Message-ID; bounded unique lookup remains
   fail-closed. Full real Gmail/Drive acceptance passed; physical NAS pending.)

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.8.4a2"
+__version__ = "1.8.4b1"

--- a/connectonion/cli/commands/outlook_calendar_commands.py
+++ b/connectonion/cli/commands/outlook_calendar_commands.py
@@ -1,0 +1,155 @@
+"""`co outlook calendar`: the terminal surface of MicrosoftCalendar (#816).
+
+Outlook is one product with three panes — Mail, Calendar, People — so the
+calendar sits under `co outlook` beside `contact`, not as a fourth top-level
+name an agent would have to guess. Each leaf maps to exactly one
+MicrosoftCalendar method, mirroring `co gcalendar` leaf for leaf (`teams`
+where Google has `meet`). Reads run at once; every write previews by default
+and the preview prints the complete command that performs it, so the agent's
+next call is a copy, not a reconstruction.
+"""
+
+from typing import Optional
+import re
+import shlex
+
+import typer
+from rich.console import Console
+
+from .microsoft_errors import microsoft_errors
+from .command_tips import print_tip
+from ..typer_groups import _OneSuggestion
+
+outlook_calendar_app = typer.Typer(
+    cls=_OneSuggestion,  # a typo is answered once, like every other group
+    help="Your Outlook calendar: events, Teams meetings, free slots. Bare 'co outlook calendar' lists events.",
+    no_args_is_help=False,
+)
+
+TIME_HELP = "ISO time; an offset is converted to UTC, a naive time means UTC (2026-09-10T10:00:00Z)"
+
+
+def _client():
+    """The Calendars scope check shares its words and next command with mail and contacts."""
+    from .outlook_commands import _microsoft_record
+    _microsoft_record("Calendars")
+    from ...useful_tools.microsoft_calendar import MicrosoftCalendar
+    return MicrosoftCalendar()
+
+
+@microsoft_errors("co outlook calendar list")
+def _run(method: str, *args, **kwargs):
+    result = getattr(_client(), method)(*args, **kwargs)
+    Console().print(result, markup=False, highlight=False)
+    first = re.search(r"\bID: (\S+)", result) if method == "list_events" else None
+    print_tip(f"Next: co outlook calendar read {first[1]}" if first else "Next: co outlook calendar list")
+
+
+def _performing_command(operation: str, positional: list, options: dict) -> str:
+    parts = ["co", "outlook", "calendar", operation, *(shlex.quote(str(value)) for value in positional)]
+    for name, value in options.items():
+        if value:
+            parts += [f"--{name}", shlex.quote(str(value))]
+    return " ".join(parts + ["--yes"])
+
+
+def _confirm(yes: bool, operation: str, positional: list, options: dict) -> bool:
+    if not yes:
+        Console().print({"mode": "preview", "operation": operation,
+                         **{f"arg{i}": v for i, v in enumerate(positional, 1)},
+                         **{k: v for k, v in options.items() if v}}, markup=False)
+        Console().print("No changes made.", markup=False)
+        print_tip(f"Next: {_performing_command(operation, positional, options)}")
+    return yes
+
+
+@outlook_calendar_app.callback(invoke_without_command=True)
+def calendar(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        _run("list_events")
+
+
+@outlook_calendar_app.command("list")
+def list_events(days: int = typer.Option(7, "--days", min=1),
+                last: int = typer.Option(20, "--last", "-n", min=1, max=250)):
+    """List upcoming events with stable event IDs (not row numbers)."""
+    _run("list_events", days_ahead=days, max_results=last)
+
+
+@outlook_calendar_app.command("today")
+def today():
+    """Read today's events."""
+    _run("get_today_events")
+
+
+@outlook_calendar_app.command("read")
+def read(event_id: str = typer.Argument(..., help="Exact event ID from co outlook calendar list")):
+    """Read one event by ID."""
+    _run("get_event", event_id)
+
+
+@outlook_calendar_app.command("meetings")
+def meetings(days: int = typer.Option(7, "--days", min=1)):
+    """Read upcoming events that have attendees."""
+    _run("get_upcoming_meetings", days_ahead=days)
+
+
+@outlook_calendar_app.command("free")
+def free(date: str = typer.Argument(..., help="YYYY-MM-DD; business hours in UTC"),
+         minutes: int = typer.Option(60, "--minutes", min=1, max=480)):
+    """Find free slots between 09:00 and 17:00 UTC on one day."""
+    _run("find_free_slots", date, duration_minutes=minutes)
+
+
+@outlook_calendar_app.command("create")
+def create(title: str = typer.Argument(..., help="Event title"),
+           start: str = typer.Argument(..., help=TIME_HELP),
+           end: str = typer.Argument(..., help=TIME_HELP),
+           description: Optional[str] = typer.Option(None, "--description"),
+           attendees: Optional[str] = typer.Option(None, "--attendees", help="Comma-separated emails"),
+           location: Optional[str] = typer.Option(None, "--location"),
+           yes: bool = typer.Option(False, "--yes", help="Create this event; default is a local preview")):
+    """Create an event. Previews until --yes."""
+    options = dict(description=description, attendees=attendees, location=location)
+    if _confirm(yes, "create", [title, start, end], options):
+        _run("create_event", title, start, end, **options)
+
+
+@outlook_calendar_app.command("teams")
+def teams(title: str = typer.Argument(..., help="Meeting title"),
+          start: str = typer.Argument(..., help=TIME_HELP),
+          end: str = typer.Argument(..., help=TIME_HELP),
+          attendees: str = typer.Option(..., "--attendees", help="Comma-separated emails"),
+          description: Optional[str] = typer.Option(None, "--description"),
+          yes: bool = typer.Option(False, "--yes", help="Create the event and its Teams link; default previews")):
+    """Create an event with a Microsoft Teams meeting link. Previews until --yes."""
+    options = dict(attendees=attendees, description=description)
+    if _confirm(yes, "teams", [title, start, end], options):
+        _run("create_teams_meeting", title, start, end, attendees, description=description)
+
+
+@outlook_calendar_app.command("update")
+def update(event_id: str = typer.Argument(..., help="Exact event ID from co outlook calendar list"),
+           title: Optional[str] = typer.Option(None, "--title"),
+           start: Optional[str] = typer.Option(None, "--start", help=TIME_HELP),
+           end: Optional[str] = typer.Option(None, "--end", help=TIME_HELP),
+           description: Optional[str] = typer.Option(None, "--description"),
+           attendees: Optional[str] = typer.Option(None, "--attendees", help="Comma-separated emails"),
+           location: Optional[str] = typer.Option(None, "--location"),
+           yes: bool = typer.Option(False, "--yes", help="Apply the supplied fields to this exact event; default previews")):
+    """Update the supplied fields; omitted fields are preserved. Previews until --yes."""
+    options = dict(title=title, start=start, end=end, description=description, attendees=attendees, location=location)
+    if not any(options.values()):
+        print_tip("No changes supplied. Next: co outlook calendar update --help")
+        raise typer.Exit(2)
+    if _confirm(yes, "update", [event_id], options):
+        _run("update_event", event_id, title=title, start_time=start, end_time=end,
+             description=description, attendees=attendees, location=location)
+
+
+@outlook_calendar_app.command("delete")
+def delete(event_id: str = typer.Argument(..., help="Exact event ID from co outlook calendar list"),
+           yes: bool = typer.Option(False, "--yes", help="Delete the exact event; default previews")):
+    """Delete an event by its stable ID, never by a listing number. Previews until --yes."""
+    if _confirm(yes, "delete", [event_id], {}):
+        _run("delete_event", event_id)

--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -2,7 +2,7 @@
 Purpose: CLI surface for Outlook email and contacts — send/read/search mail and add/list/search contacts from the terminal
 LLM-Note:
   Dependencies: imports from [os, sys, json, pathlib, datetime, typer, dotenv, rich.console, rich.panel, rich.table, ...useful_tools.outlook.Outlook] | imported by [cli/main.py via handle_outlook_*()] | hits Microsoft Graph API through the Outlook tool
-  Data flow: _outlook() loads MICROSOFT_* from the global default or explicit --env-file and checks the operation scope → Outlook() instance | mail commands use list/read/send/reply methods and the numbered inbox cache | send and reply share _check_attachments() to reject missing or oversize --attach files before megabytes are base64-encoded | handle_outlook_reply(email_id, message, at, *, attachments) keeps `at` third positional for pre-attachment callers, so attachments is keyword-only | contact commands use add_contact()/list_contacts()/search_contacts() and render Rich tables or tab-separated plain output
+  Data flow: _microsoft_record() loads MICROSOFT_* from the global default or explicit --env-file and checks the operation scope (shared with outlook_calendar_commands) → _outlook() wraps it in an Outlook() instance | mail commands use list/read/send/reply methods and the numbered inbox cache | send and reply share _check_attachments() to reject missing or oversize --attach files before megabytes are base64-encoded | handle_outlook_reply(email_id, message, at, *, attachments, cc, bcc) keeps `at` third positional for pre-attachment callers, so attachments/cc/bcc are keyword-only | every handler ends with one print_tip() next command that survives piping; a scheduled send or reply names the cancel path (#1314) | contact commands use add_contact()/list_contacts()/search_contacts() and render Rich tables or tab-separated plain output
   State/Effects: writes ~/.co/outlook_last_inbox.json for mail numbering | read changes mailbox state only with --mark-read; send/reply/contact commands mutate their named data | Outlook auto-refreshes expired tokens via oo-api and saves the selected credential record
   Integration: exposes handle_outlook_* functions for cli/main.py, including handle_outlook_contact_add/list/search | presentation mirrors existing mail tables | Graph logic lives in useful_tools/outlook.py | requires prior 'co auth microsoft'
   Errors: guarded failures print a hint and exit 1 (typer.Exit) — missing auth/Mail/Contacts.ReadWrite scopes, invalid files/times/ids | Graph API errors propagate from Outlook
@@ -26,8 +26,12 @@ console = Console()
 
 INBOX_CACHE = Path.home() / ".co" / "outlook_last_inbox.json"
 
-def _outlook(required_scope: str = "Mail"):
-    """Load Microsoft credentials and require the Graph scope this command needs."""
+def _microsoft_record(required_scope: str = "Mail"):
+    """Load the selected Microsoft record and require the Graph scope this command needs.
+
+    Shared by mail, contacts and calendar so all three answer "not connected"
+    and "permission missing" with the same words and the same next command.
+    """
     from ...environment import load_environment
     load_environment()
     from ...provider_credentials import resolve_provider_credentials
@@ -41,14 +45,18 @@ def _outlook(required_scope: str = "Mail"):
         raise typer.Exit(1)
 
     # "Mail" matches any Mail.* grant; "Contacts.ReadWrite" matches only itself.
-    from ...provider_credentials import resolve_provider_credentials
-    scopes = resolve_provider_credentials("microsoft").scopes
+    scopes = record.scopes
     if scopes and not any(s == required_scope or s.startswith(f"{required_scope}.") for s in scopes):
         console.print(f"\n❌ [bold red]Microsoft {required_scope} permission missing[/bold red]")
         console.print("\n[cyan]Reconnect Microsoft to grant it:[/cyan]")
         print(f"Next: {auth_tip}")
         raise typer.Exit(1)
+    return record
 
+
+def _outlook(required_scope: str = "Mail"):
+    """Load Microsoft credentials and require the Graph scope this command needs."""
+    _microsoft_record(required_scope)
     from ...useful_tools.outlook import Outlook
     return Outlook(allow_external_attachments=True)
 
@@ -100,6 +108,7 @@ def _parse_send_at(at: str) -> str:
     def bad():
         console.print(f"\n❌ [bold red]Invalid --at value:[/bold red] {at}")
         console.print("   Use [bold]+30m[/bold], [bold]+2h[/bold], or UTC ISO like [bold]2026-07-06T15:30:00Z[/bold]\n")
+        print_tip("Next: co outlook send --help")
         raise typer.Exit(1)
 
     if at.startswith("+"):
@@ -152,10 +161,30 @@ def handle_outlook_send(to: str, subject: str, message: str, cc: str = None, bcc
     else:
         console.print(f"\n[green]✓ Sent[/green] to [cyan]{to}[/cyan]")
     console.print(f"  From: {resolve_provider_credentials('microsoft').get('EMAIL') or ''}")
+    if cc:
+        console.print(f"  Cc: {cc}")
+    if bcc:
+        console.print(f"  Bcc: {bcc}")
     if attachments:
         names = ", ".join(Path(p).name for p in attachments)
         console.print(f"  Attached: {names}")
-    console.print()
+    _after_send(send_at)
+
+
+def _after_send(send_at: str | None) -> None:
+    """The send most likely to be taken back is the one that says how (#1314).
+
+    Four emails queued for the next morning, wording that then had to change,
+    and the cancel path found by reading useful_tools/outlook.py rather than
+    any CLI output. So the confirmation names it, and the same tip survives
+    piping — the agent that scheduled the mail is the one that needs it.
+    """
+    if send_at:
+        console.print("  Cancel before it goes out: co outlook scheduled, then co outlook cancel <#>",
+                      markup=False, highlight=False)
+        print_tip("Next: co outlook scheduled")
+    else:
+        print_tip("Next: co outlook sent")
 
 
 @microsoft_errors("co outlook inbox")
@@ -166,6 +195,7 @@ def handle_outlook_inbox(last: int = 10, unread: bool = False):
     if not emails:
         scope = "unread " if unread else ""
         console.print(f"\n[cyan]Outlook inbox:[/cyan] no {scope}emails\n")
+        print_tip("Next: co outlook inbox -n 25" if unread else "Next: co outlook search <words>")
         return
     _print_listing(outlook, emails, f"📬 Outlook — {resolve_provider_credentials('microsoft').get('EMAIL') or ''}")
 
@@ -212,7 +242,10 @@ def handle_outlook_read(email_id: str, mark_read: bool = False):
     console.print(content.strip() or "[dim](empty body)[/dim]", markup=False, highlight=False)
 
     marked = "Unread state unchanged. "
-    if mark_read and "Mail.ReadWrite" in os.getenv("MICROSOFT_SCOPES", ""):
+    # The scope comes from the same selected record as the token — a per-field
+    # os.getenv read could answer for a different account than the one that
+    # is about to be written to.
+    if mark_read and "Mail.ReadWrite" in outlook._credentials.scopes:
         # Marking read is a mailbox write — Graph rejects it with 403 on
         # tokens that only carry Mail.Read + Mail.Send.
         outlook.mark_read(resolved)
@@ -235,20 +268,23 @@ def handle_outlook_download(email_id: str, out_dir: str = ".", include_inline: b
     if not saved:
         console.print("\n[yellow]No file attachments on that email.[/yellow]")
         console.print("[dim]Embedded signature images are skipped — --include-inline saves them too.[/dim]\n")
+        print_tip(f"Next: co outlook download {email_id} --include-inline")
         return
 
     console.print()
     for path in saved:
         console.print(f"[green]✓[/green] {path}")
-    console.print()
+    print_tip(f"Next: co outlook read {email_id}")
 
 
 @microsoft_errors("co outlook sent")
-def handle_outlook_reply(email_id: str, message: str, at: str = None, *, attachments: list = None):
+def handle_outlook_reply(email_id: str, message: str, at: str = None, *, attachments: list = None,
+                         cc: str = None, bcc: str = None):
     """Reply to an email from the last listing (threaded via Graph). A message of '-' reads stdin.
 
     `at` keeps its third-positional slot from before attachments existed;
-    attachments is keyword-only so no caller can pass a schedule as a file.
+    attachments, cc and bcc are keyword-only so no caller can pass a schedule
+    as a file or an address.
     """
     if message == "-":
         message = sys.stdin.read()
@@ -262,15 +298,19 @@ def handle_outlook_reply(email_id: str, message: str, at: str = None, *, attachm
         print_tip(f"\n[yellow]No email #{email_id} in your last listing — run co outlook, then co outlook reply <#> <message>.[/yellow]\n")
         raise typer.Exit(1)
 
-    outlook.reply(resolved, message, attachments=attachments, send_at=send_at)
+    outlook.reply(resolved, message, attachments=attachments, send_at=send_at, cc=cc, bcc=bcc)
     if send_at:
         console.print(f"\n[green]✓ Reply scheduled[/green] for [bold]{send_at}[/bold] to email {email_id}")
     else:
         console.print(f"\n[green]✓ Replied[/green] to email {email_id}")
+    if cc:
+        console.print(f"  Cc: {cc}")
+    if bcc:
+        console.print(f"  Bcc: {bcc}")
     if attachments:
         names = ", ".join(Path(p).name for p in attachments)
         console.print(f"  Attached: {names}")
-    console.print()
+    _after_send(send_at)
 
 
 @microsoft_errors("co outlook inbox")
@@ -279,7 +319,7 @@ def handle_outlook_sent(last: int = 10):
     outlook = _outlook()
     console.print(f"\n📤 [bold cyan]Outlook sent[/bold cyan] [dim]({resolve_provider_credentials('microsoft').get('EMAIL') or ''})[/dim]\n")
     console.print(outlook.get_sent_emails(max_results=last), markup=False, highlight=False)
-    console.print()
+    print_tip("Next: co outlook inbox")
 
 
 @microsoft_errors("co outlook inbox")
@@ -289,6 +329,7 @@ def handle_outlook_search(query: str, last: int = 10):
     emails = outlook.list_search(query, max_results=last)
     if not emails:
         console.print(f"\n[cyan]Search:[/cyan] no emails matching [bold]{query}[/bold]\n")
+        print_tip("Next: co outlook inbox -n 25")
         return
     _print_listing(outlook, emails, f"🔎 Outlook — {query}")
 
@@ -300,6 +341,7 @@ def _print_contacts(contacts: list, title: str):
         # silently turns tab-separated output into something cut -f can't read.
         for contact in contacts:
             print(f"{contact['name']}\t{contact['email']}\t{contact['id']}")
+        print_tip('Next: co outlook send <email from this listing> "<subject>" "<message>"')
         return
 
     table = Table(title=title, show_header=True, header_style="bold cyan")
@@ -310,7 +352,7 @@ def _print_contacts(contacts: list, title: str):
         table.add_row(str(index), contact["name"], contact["email"])
     console.print()
     console.print(table)
-    console.print()
+    print_tip('Next: co outlook send <email from this listing> "<subject>" "<message>"')
 
 
 @microsoft_errors("co outlook inbox")
@@ -322,6 +364,7 @@ def handle_outlook_contact_add(name: str, email: str):
         f"\n[green]✓ Saved contact[/green] "
         f"[bold]{contact['name']}[/bold] <[cyan]{contact['email']}[/cyan]>\n"
     )
+    print_tip("Next: co outlook contact list")
 
 
 @microsoft_errors("co outlook inbox")
@@ -331,6 +374,7 @@ def handle_outlook_contact_list(last: int = 25):
     contacts = outlook.list_contacts(max_results=last)
     if not contacts:
         console.print("\n[cyan]Outlook contacts:[/cyan] none saved\n")
+        print_tip('Next: co outlook contact add "<name>" <email>')
         return
     _print_contacts(contacts, "👥 Outlook contacts")
 
@@ -345,6 +389,7 @@ def handle_outlook_contact_search(query: str, last: int = 25):
             f"\n[cyan]Contact search:[/cyan] no contacts matching "
             f"[bold]{query}[/bold]\n"
         )
+        print_tip("Next: co outlook contact list -n 100")
         return
     _print_contacts(contacts, f"🔎 Outlook contacts — {query}")
 
@@ -356,6 +401,7 @@ def handle_outlook_scheduled():
     scheduled = outlook.get_scheduled()
     if not scheduled:
         console.print("\n[cyan]No scheduled emails.[/cyan]\n")
+        print_tip('Next: co outlook send <to> "<subject>" "<message>" --at +2h')
         return
 
     INBOX_CACHE.parent.mkdir(exist_ok=True)
@@ -394,4 +440,5 @@ def handle_outlook_cancel(email_id: str):
         raise typer.Exit(1)
 
     outlook.cancel_scheduled(resolved)
-    console.print(f"\n[green]✓ Canceled[/green] scheduled email {email_id}\n")
+    console.print(f"\n[green]✓ Canceled[/green] scheduled email {email_id}")
+    print_tip("Next: co outlook scheduled")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -1357,7 +1357,7 @@ app.add_typer(syno_app, name="syno")
 
 # Outlook command group. `co outlook` (no args) shows the Outlook inbox.
 # Uses the MICROSOFT_* OAuth tokens saved to .env by `co auth microsoft`.
-outlook_app = _typer_app(help="Send and read email from your Outlook account. Bare 'co outlook' shows the inbox.")
+outlook_app = _typer_app(help="Your Outlook account: mail, scheduled sends, contacts and calendar. Bare 'co outlook' shows the inbox.")
 app.add_typer(outlook_app, name="outlook")
 
 
@@ -1373,7 +1373,13 @@ outlook_contact_app = _typer_app(
     help="Add, list, and search Outlook contacts.",
     no_args_is_help=True,
 )
-outlook_app.add_typer(outlook_contact_app, name="contact")
+outlook_app.add_typer(outlook_contact_app, name="contact", rich_help_panel="Contacts")
+
+# Outlook is one product with three panes: Mail, Calendar, People. The
+# calendar therefore lives here beside `contact`, not as a fourth top-level
+# name an agent would have to guess (#816). Its leaves mirror `co gcalendar`.
+from .commands.outlook_calendar_commands import outlook_calendar_app
+outlook_app.add_typer(outlook_calendar_app, name="calendar", rich_help_panel="Calendar")
 
 
 @outlook_contact_app.command("add")
@@ -1405,7 +1411,7 @@ def outlook_contact_search(
     handle_outlook_contact_search(query, last=last)
 
 
-@outlook_app.command("send", epilog="Examples:  co outlook send a@b.com \"Hi\" \"Quick note\"  |  "
+@outlook_app.command("send", rich_help_panel="Send", epilog="Examples:  co outlook send a@b.com \"Hi\" \"Quick note\"  |  "
                                     "cat body.txt | co outlook send a@b.com \"Report\" -  |  "
                                     "co outlook send a@b.com \"Invoice\" \"Attached\" --attach invoice.pdf --at +2h")
 def outlook_send(
@@ -1415,14 +1421,14 @@ def outlook_send(
     cc: Optional[str] = typer.Option(None, "--cc", help="CC recipients (comma-separated)"),
     bcc: Optional[str] = typer.Option(None, "--bcc", help="BCC recipients (comma-separated)"),
     attach: Optional[List[str]] = typer.Option(None, "--attach", "-a", help="File to attach (repeat for multiple)"),
-    at: Optional[str] = typer.Option(None, "--at", help="Schedule delivery: +30m, +2h, or UTC ISO time (2026-07-06T15:30:00Z)"),
+    at: Optional[str] = typer.Option(None, "--at", help="Schedule delivery: +30m, +2h, or UTC ISO time (2026-07-06T15:30:00Z); cancel before it goes out with co outlook cancel <#>"),
 ):
     """Send an email from your Outlook account, now or scheduled with --at."""
     from .commands.outlook_commands import handle_outlook_send
     handle_outlook_send(to, subject, message, cc=cc, bcc=bcc, attachments=attach, at=at)
 
 
-@outlook_app.command("inbox")
+@outlook_app.command("inbox", rich_help_panel="Mail")
 def outlook_inbox(
     last: int = typer.Option(10, "--last", "-n", help="How many emails to show"),
     unread: bool = typer.Option(False, "--unread", "-u", help="Only unread emails"),
@@ -1432,7 +1438,7 @@ def outlook_inbox(
     handle_outlook_inbox(last=last, unread=unread)
 
 
-@outlook_app.command("read")
+@outlook_app.command("read", rich_help_panel="Mail")
 def outlook_read(
     email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing (re-run to refresh numbers)"),
     mark_read: bool = typer.Option(False, "--mark-read", help="Mark the email as read after showing it"),
@@ -1442,7 +1448,7 @@ def outlook_read(
     handle_outlook_read(email_id, mark_read=mark_read)
 
 
-@outlook_app.command("download")
+@outlook_app.command("download", rich_help_panel="Mail")
 def outlook_download(
     email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing"),
     out_dir: str = typer.Option(".", "--to", help="Directory to save attachments into"),
@@ -1456,42 +1462,45 @@ def outlook_download(
     handle_outlook_download(email_id, out_dir, include_inline=include_inline)
 
 
-@outlook_app.command("reply", epilog="Examples:  co outlook reply 3 \"Sounds good\"  |  "
+@outlook_app.command("reply", rich_help_panel="Send", epilog="Examples:  co outlook reply 3 \"Sounds good\"  |  "
                                      "cat notes.txt | co outlook reply 3 -  |  "
+                                     "co outlook reply 3 \"Looping in Sam\" --cc sam@example.com  |  "
                                      "co outlook reply 3 \"Signed copy attached\" --attach signed.pdf")
 def outlook_reply(
     email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing"),
     message: str = typer.Argument(..., help="Reply body (plain text, or '-' to read from stdin)"),
+    cc: Optional[str] = typer.Option(None, "--cc", help="CC recipients (comma-separated); the reply stays in its thread"),
+    bcc: Optional[str] = typer.Option(None, "--bcc", help="BCC recipients (comma-separated)"),
     attach: Optional[List[str]] = typer.Option(None, "--attach", "-a", help="File to attach (repeat for multiple)"),
-    at: Optional[str] = typer.Option(None, "--at", help="Schedule delivery: +30m, +2h, or UTC ISO time (2026-07-06T15:30:00Z)"),
+    at: Optional[str] = typer.Option(None, "--at", help="Schedule delivery: +30m, +2h, or UTC ISO time (2026-07-06T15:30:00Z); cancel before it goes out with co outlook cancel <#>"),
 ):
     """Reply to an email (threaded), now or scheduled with --at."""
     from .commands.outlook_commands import handle_outlook_reply
-    handle_outlook_reply(email_id, message, attachments=attach, at=at)
+    handle_outlook_reply(email_id, message, attachments=attach, at=at, cc=cc, bcc=bcc)
 
 
-@outlook_app.command("scheduled")
+@outlook_app.command("scheduled", rich_help_panel="Scheduled sends")
 def outlook_scheduled():
     """List emails waiting for scheduled delivery."""
     from .commands.outlook_commands import handle_outlook_scheduled
     handle_outlook_scheduled()
 
 
-@outlook_app.command("cancel")
+@outlook_app.command("cancel", rich_help_panel="Scheduled sends")
 def outlook_cancel(email_id: str = typer.Argument(..., help="Email # from 'co outlook scheduled' (or a full message ID)")):
     """Cancel a scheduled email before it goes out."""
     from .commands.outlook_commands import handle_outlook_cancel
     handle_outlook_cancel(email_id)
 
 
-@outlook_app.command("sent")
+@outlook_app.command("sent", rich_help_panel="Mail")
 def outlook_sent(last: int = typer.Option(10, "--last", "-n", help="How many emails to show")):
     """List recently sent Outlook emails."""
     from .commands.outlook_commands import handle_outlook_sent
     handle_outlook_sent(last=last)
 
 
-@outlook_app.command("search")
+@outlook_app.command("search", rich_help_panel="Mail")
 def outlook_search(
     query: str = typer.Argument(..., help="Search query (matches subject and body)"),
     last: int = typer.Option(10, "--last", "-n", help="How many results to show"),

--- a/connectonion/useful_skills/co-mail-and-drive/SKILL.md
+++ b/connectonion/useful_skills/co-mail-and-drive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: co-mail-and-drive
-description: Read and send mail from the user's own Gmail or Outlook account, safely stage Gmail draft attachments, send from the agent's own address, manage Outlook contacts, and work with Google Drive files — with `co gmail`, `co outlook`, `co email`, and `co gdrive`. Use when the user asks about their inbox, an email or draft they want to prepare, an attachment, a contact, or a file in Drive.
+description: Read and send mail from the user's own Gmail or Outlook account, safely stage Gmail draft attachments, send from the agent's own address, manage Outlook contacts and the Outlook calendar, and work with Google Drive files — with `co gmail`, `co outlook`, `co email`, and `co gdrive`. Use when the user asks about their inbox, an email or draft they want to prepare, an attachment, a contact, a meeting on their Outlook calendar, or a file in Drive.
 ---
 
 ## Environment selection in the 1.8.4 implementation
@@ -28,6 +28,7 @@ the `co email` exception). The output still carries the recovery step; read it.
 | `co outlook` | the user's **personal Outlook** | same, on the Microsoft account |
 | `co email` | the **agent's own** address (`*@mail.openonion.ai`) | "send from the agent", "what did the agent receive" |
 | `co gdrive` | the user's **Google Drive** | "my files", "that doc" |
+| `co outlook calendar` | the user's **Outlook calendar** | "my meetings", "am I free", "book a Teams call" (Google: `co gcalendar`) |
 
 When both mail accounts are connected and the request is ambiguous, ask which one
 rather than guessing. Sending from the wrong identity is not undoable.
@@ -143,7 +144,16 @@ co gmail send bob@example.com "Invoice" "Attached." --cc a@x.com --attach invoic
 `co outlook send`. Attachments are checked before the send: a missing file or a set
 over the size limit (Gmail 25MB, Outlook 3MB) exits `1` without sending.
 
-Outlook additionally schedules:
+`co outlook reply` takes `--cc` / `--bcc` too, and the reply stays in its thread —
+before 1.8.4b1 copying a third person meant a fresh `send` with "RE:" in the
+subject, which the recipient saw as a new conversation:
+
+```bash
+co outlook reply 3 "Looping in Sam" --cc sam@example.com
+```
+
+Outlook additionally schedules. A scheduled send or reply ends with the cancel
+path; run it as printed rather than looking for a separate command:
 
 ```bash
 co outlook send bob@example.com "Nudge" "Following up" --at +2h    # +30m, +2h, or 2026-07-06T15:30:00Z
@@ -211,6 +221,30 @@ co outlook contact add "Full Name" name@example.com
 co outlook contact list -n 50
 co outlook contact search yifei
 ```
+
+## Outlook calendar
+
+Same Microsoft account, needs the `Calendars` scope (`co auth microsoft` grants
+it). Event IDs are stable IDs, not row numbers. Reads run at once; every write
+previews by default and prints the exact `--yes` command that performs it.
+
+```bash
+co outlook calendar                               # bare = upcoming events
+co outlook calendar list --days 14 -n 50
+co outlook calendar today
+co outlook calendar read <event-id>               # ID from the listing
+co outlook calendar meetings --days 7             # events that have attendees
+co outlook calendar free 2026-09-10 --minutes 30  # 09:00–17:00 UTC, your calendar only
+co outlook calendar create "Standup" 2026-09-10T09:00:00+10:00 2026-09-10T09:15:00+10:00 --attendees a@x.com
+co outlook calendar teams "Design review" 2026-09-10T10:00:00Z 2026-09-10T11:00:00Z --attendees a@x.com,b@x.com
+co outlook calendar update <event-id> --title "Moved" --start 2026-09-11T10:00:00Z
+co outlook calendar delete <event-id>
+```
+
+Times: an ISO offset is converted to UTC; a naive time means UTC. `update`
+preserves omitted fields. `free` reads only this calendar, not attendees'.
+The preview shows arguments, not proof of account access: after an uncertain
+write, run `co outlook calendar list` before retrying.
 
 ## Drive files
 
@@ -325,6 +359,20 @@ For Gmail and Drive, these are the concrete recovery routes:
 | Missing Drive info argument (exit 2) | `co gdrive info --help` |
 | Missing Drive get argument (exit 2) | `co gdrive get --help` |
 
+For Outlook, mail and calendar share one credential layer, and the next command
+names the layer that actually failed (#1313):
+
+| Result | Next command |
+|---|---|
+| Outlook send or reply succeeded | `co outlook sent` |
+| Scheduled send or reply succeeded | `co outlook scheduled`, then `co outlook cancel <#>` to pull it back |
+| No `OPENONION_API_KEY`, or oo-api rejected it during a token refresh (exit 1) | `co auth` — not `co auth microsoft`; the Microsoft grant is fine |
+| Microsoft revoked the refresh token, or the record has no refresh token (exit 1) | `co auth microsoft` |
+| Microsoft `<scope>` permission missing (exit 1) | `co auth microsoft` (re-consent; a refresh cannot widen scopes) |
+| Graph returned an error status (exit 1; body never printed) | `co outlook inbox` / `co outlook calendar list` |
+| Calendar write preview (exit 0, `No changes made.`) | the printed `co outlook calendar <op> … --yes` |
+| `update` with no fields (exit 2) | `co outlook calendar update --help` |
+
 A connection failure does not prove a write failed: inspect the provider state
 before repeating a send, reply, upload, or draft creation. Provider error bodies
 are omitted from CLI error messages. Outlook and agent-mail recovery behavior
@@ -340,7 +388,8 @@ When a command says the account is not connected:
 ❌ Gmail draft permission missing   → co auth google      (re-consent)
 ❌ Google Drive permission missing  → co auth google      (re-consent)
 ❌ Microsoft account not connected  → co auth microsoft
-❌ Microsoft <scope> permission missing → co auth microsoft
+❌ Microsoft <scope> permission missing → co auth microsoft   (Mail, Contacts.ReadWrite, Calendars)
+Error: OpenOnion authentication failed while refreshing provider access. → co auth
 ❌ No API key found (co email)      → co auth
 ```
 

--- a/connectonion/useful_skills/co-mail-and-drive/SKILL.md
+++ b/connectonion/useful_skills/co-mail-and-drive/SKILL.md
@@ -407,3 +407,5 @@ it themselves**, do not try to drive that flow.
 - [ ] IDs taken from piped output, never from a truncated table column
 - [ ] `--from` address taken from `co email addresses`, never guessed
 - [ ] Empty search reported as "no match", not as "does not exist"
+
+If Teams creation returns an event without a usable meeting link, the command exits 1 and retains the event ID. Follow `co outlook calendar read EVENT_ID` to inspect that event; do not repeat creation. A missing event ID requires listing the calendar before another write.

--- a/connectonion/useful_tools/microsoft_calendar.py
+++ b/connectonion/useful_tools/microsoft_calendar.py
@@ -6,7 +6,7 @@ LLM-Note:
   State/Effects: reads and locally refreshes MICROSOFT_* OAuth tokens | persists rotated tokens to user keys.env and an existing project .env | makes HTTP calls to Microsoft Graph API | can create/update/delete events, create Teams meetings
   Integration: exposes MicrosoftCalendar class with list_events(), get_today_events(), get_event(), create_event(), update_event(), delete_event(), create_teams_meeting(), get_upcoming_meetings(), find_free_slots(), check_availability() | used as agent tool via Agent(tools=[MicrosoftCalendar()])
   Performance: network I/O per API call | batch fetching for list operations | date parsing for queries
-  Errors: raises ValueError if OAuth not configured | HTTP errors from Graph API propagate | returns error strings for display
+  Errors: raises ValueError if OAuth not configured | Graph 401/403 and other non-2xx responses raise ProviderCredentialError with a status code and a next command, never the response body | returns error strings for display | driven from the terminal by cli/commands/outlook_calendar_commands.py (`co outlook calendar`)
 
 Microsoft Calendar tool for managing calendar events via Microsoft Graph API.
 
@@ -43,7 +43,7 @@ Example:
 """
 
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import httpx
@@ -128,7 +128,11 @@ class MicrosoftCalendar:
                 "Microsoft permission denied." if response.status_code == 403 else "Microsoft authorization expired.",
                 self._credentials.auth_command)
         if response.status_code not in [200, 201, 202, 204]:
-            raise ValueError(f"Microsoft Graph API error: {response.status_code} - {response.text}")
+            # Same shape as Outlook: the status is the diagnosis, the body is
+            # tenant text that must not reach a terminal or an agent transcript.
+            from ..provider_credentials import ProviderCredentialError
+            raise ProviderCredentialError("provider_unavailable",
+                f"Microsoft Graph API error (HTTP {response.status_code}).", "co outlook calendar list")
 
         if response.status_code == 204:
             return {}
@@ -140,7 +144,21 @@ class MicrosoftCalendar:
         return dt.strftime('%Y-%m-%d %I:%M %p')
 
     def _parse_time(self, time_str: str) -> datetime:
-        """Parse time string to datetime object."""
+        """Parse a time as naive UTC: offsets are converted, naive means UTC.
+
+        Every event is sent to Graph with timeZone "UTC", so a value carrying
+        its own offset ("2026-09-10T20:00:00+10:00") has to be converted before
+        it is stripped — passing it through unconverted would book the meeting
+        ten hours late. Same contract as GoogleCalendar.
+        """
+        try:
+            parsed = datetime.fromisoformat(time_str.replace('Z', '+00:00'))
+        except ValueError:
+            parsed = None
+        if parsed is not None:
+            if parsed.tzinfo is not None:
+                parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+            return parsed.replace(microsecond=0)
         for fmt in ['%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S', '%Y-%m-%d %H:%M']:
             try:
                 return datetime.strptime(time_str, fmt)

--- a/connectonion/useful_tools/microsoft_calendar.py
+++ b/connectonion/useful_tools/microsoft_calendar.py
@@ -43,6 +43,8 @@ Example:
 """
 
 import os
+import shlex
+from urllib.parse import urlsplit
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -264,7 +266,7 @@ class MicrosoftCalendar:
         """
         endpoint = f"/me/calendar/events/{event_id}"
         params = {
-            "$select": "subject,start,end,body,location,attendees,onlineMeetingUrl"
+            "$select": "subject,start,end,body,location,attendees,onlineMeeting,onlineMeetingUrl"
         }
 
         event = self._request("GET", endpoint, params=params)
@@ -282,7 +284,7 @@ class MicrosoftCalendar:
             status = a.get('status', {}).get('response', 'none')
             attendee_list.append(f"{email} ({status})")
 
-        meeting_url = event.get('onlineMeetingUrl', 'No meeting link')
+        meeting_url = self._meeting_url(event) or 'No meeting link'
 
         output = [
             f"Event: {subject}",
@@ -398,9 +400,37 @@ class MicrosoftCalendar:
 
         created_event = self._request("POST", "/me/calendar/events", json=event)
 
-        meeting_url = created_event.get('onlineMeeting', {}).get('joinUrl', '') or created_event.get('onlineMeetingUrl', 'No meeting link')
+        meeting_url = self._meeting_url(created_event)
+        if not meeting_url:
+            from ..provider_credentials import ProviderCredentialError
+            event_id = created_event.get('id')
+            if isinstance(event_id, str) and event_id and not any(ord(c)<32 for c in event_id):
+                raise ProviderCredentialError('meeting_link_unconfirmed',
+                    f'Event created (ID: {event_id}), but its Teams link is not confirmed. '
+                    'Inspect this event; do not repeat creation.',
+                    shlex.join(['co','outlook','calendar','read',event_id]))
+            raise ProviderCredentialError('creation_unconfirmed',
+                'Microsoft accepted the request but returned no confirmed Teams link or usable event ID. '
+                'Inspect the calendar before retrying creation.', 'co outlook calendar list')
 
         return f"Teams meeting created: {title}\nStart: {self._format_datetime(start_dt.isoformat())}\nTeams link: {meeting_url}\nEvent ID: {created_event['id']}"
+
+    @staticmethod
+    def _meeting_url(event: dict) -> str | None:
+        """Only a usable HTTPS link confirms the requested meeting outcome."""
+        meeting = event.get('onlineMeeting')
+        candidates = [meeting.get('joinUrl') if isinstance(meeting, dict) else None,
+                      event.get('onlineMeetingUrl')]
+        for value in candidates:
+            if not isinstance(value, str) or any(c.isspace() for c in value):
+                continue
+            try:
+                parsed = urlsplit(value)
+            except ValueError:
+                continue
+            if parsed.scheme == 'https' and parsed.hostname and not parsed.username and not parsed.password:
+                return value
+        return None
 
     def update_event(self, event_id: str, title: str = None, start_time: str = None,
                      end_time: str = None, description: str = None,

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [os, html, httpx] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth microsoft' | tested by [tests/unit/test_outlook.py]
   Data flow: Agent calls Outlook methods → _get_access_token() uses a cached Microsoft access token while its expiry is valid or unknown, preemptively refreshing near expiry via oo-api and refreshing after a Graph 401 → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | download_attachments() decodes Graph fileAttachment bytes into a caller-selected project directory without overwriting existing paths | send()/reply() with attachments share _encoded_attachments() (validate, size-check, base64) and place fileAttachments on the sent message — reply() puts them on the reply action's message so Graph still threads it | send()/reply() with send_at never use the one-shot sendMail / reply actions (they delivered at once, #1198): send() creates a draft carrying PidTagDeferredSendTime (SystemTime 0x3FEF) and PidTagDeferredDeliveryTime (0x000F) and submits it; reply() does createReply → POST attachments → PATCH the same two properties → send, so Exchange holds the exact draft until then (needs Mail.ReadWrite) | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
   State/Effects: reads MICROSOFT_* env vars for OAuth tokens/scopes | makes HTTP calls to Microsoft Graph API | can modify mailbox state (mark read, archive, send emails), create contacts, and write downloaded attachments inside the project boundary | token refresh atomically saves the selected credential record
-  Integration: exposes Outlook class with email methods plus add_contact(), list_contacts(), search_contacts() | structured list methods feed cli/commands/outlook_commands.py | used as agent tool via Agent(tools=[Outlook()]) | reply(email_id, body, send_at, *, attachments) keeps send_at third positional for pre-attachment callers, so attachments is keyword-only
+  Integration: exposes Outlook class with email methods plus add_contact(), list_contacts(), search_contacts() | structured list methods feed cli/commands/outlook_commands.py | used as agent tool via Agent(tools=[Outlook()]) | reply(email_id, body, send_at, *, attachments, cc, bcc) keeps send_at third positional for pre-attachment callers, so attachments/cc/bcc are keyword-only; cc/bcc are set on the reply action's message (or PATCHed onto the deferred reply draft) so a copied third person still gets a threaded reply (#1247)
   Performance: network I/O per API call | batch fetching for list operations | email body fetched separately
   Errors: raises ValueError if OAuth not configured | HTTP errors from Graph API propagate | deferred drafts cannot be deleted via API (Exchange 403) — cancel via Outlook's own Cancel Send | returns error strings for display to user
 
@@ -22,7 +22,7 @@ Usage:
     # - search_emails(query, max_results)
     # - get_email_body(email_id)
     # - send(to, subject, body, cc, bcc, attachments, send_at)
-    # - reply(email_id, body, send_at, *, attachments)
+    # - reply(email_id, body, send_at, *, attachments, cc, bcc)
     # - get_scheduled(max_results)
     # - add_contact(name, email)
     # - list_contacts(max_results)
@@ -136,9 +136,16 @@ class Outlook:
             refresh_at = expires_at - timedelta(minutes=5)
             if datetime.now(timezone.utc) >= refresh_at:
                 if not refresh_token:
-                    raise ValueError(
-                        "Microsoft access token is expiring, but its refresh "
-                        "credential is missing.\nRun: co auth microsoft"
+                    # A plain ValueError here was rendered by the CLI as
+                    # "invalid input; check the command arguments" (#1313
+                    # family): nothing about the arguments is wrong, the saved
+                    # record is missing its refresh half. Say that, and name
+                    # the command that completes the record.
+                    from ..provider_credentials import ProviderCredentialError
+                    raise ProviderCredentialError(
+                        "incomplete_record",
+                        "Microsoft access token is expiring and the saved record has no refresh token.",
+                        self._credentials.auth_command,
                     )
                 access_token = self._refresh_via_backend(refresh_token)
 
@@ -715,8 +722,16 @@ class Outlook:
         self._request("POST", "/me/sendMail", json={"message": message})
         return f"Email sent successfully to {to}{suffix}"
 
+    @staticmethod
+    def _recipients(value: str | None) -> list[dict]:
+        """Comma-separated addresses as Graph recipient objects; empty for None."""
+        if not value:
+            return []
+        return [{"emailAddress": {"address": addr.strip()}}
+                for addr in value.split(",") if addr.strip()]
+
     def reply(self, email_id: str, body: str, send_at: str = None, *,
-              attachments: list = None) -> str:
+              attachments: list = None, cc: str = None, bcc: str = None) -> str:
         """Reply to an email, immediately or at a scheduled time.
 
         send_at stays third positional — callers written before attachments
@@ -732,6 +747,10 @@ class Outlook:
                 Exchange holds until then (needs the Mail.ReadWrite scope)
             attachments: Optional list of local file paths to attach — same
                 files and ~3MB total Graph limit as send()
+            cc: Optional CC recipients (comma-separated). Without this, copying
+                a third person meant a fresh `send` with "RE:" in the subject —
+                a new thread on the receiving end (#1247).
+            bcc: Optional BCC recipients (comma-separated)
 
         Returns:
             Confirmation message
@@ -746,20 +765,32 @@ class Outlook:
         encoded = self._encoded_attachments(attachments) if attachments else []
         suffix = self._attachment_suffix(attachments)
 
+        # `reply` (not replyAll) starts with empty CC/BCC, so setting the
+        # collections adds the named people rather than replacing anyone.
+        extra = {}
+        if cc:
+            extra["ccRecipients"] = self._recipients(cc)
+        if bcc:
+            extra["bccRecipients"] = self._recipients(bcc)
+
         if send_at:
-            self._scheduled_reply(email_id, body, encoded, send_at)
+            self._scheduled_reply(email_id, body, encoded, send_at, extra)
             return f"Reply scheduled for {send_at}{suffix}"
 
         # The reply action takes writable message properties beside the
-        # comment, so attachments ride along without giving up the threading
-        # Graph does for us (In-Reply-To, References, same conversation).
+        # comment, so attachments and recipients ride along without giving up
+        # the threading Graph does for us (In-Reply-To, References, same
+        # conversation).
         data = {"comment": body}
         if encoded:
-            data["message"] = {"attachments": encoded}
+            extra["attachments"] = encoded
+        if extra:
+            data["message"] = extra
         self._request("POST", f"/me/messages/{email_id}/reply", json=data)
         return f"Reply sent successfully{suffix}"
 
-    def _scheduled_reply(self, email_id: str, body: str, encoded: list, send_at: str) -> str:
+    def _scheduled_reply(self, email_id: str, body: str, encoded: list, send_at: str,
+                         recipients: dict | None = None) -> str:
         """Create a reply draft, set the deferred-send properties, submit it.
 
         The reply action is create-and-send in one step, like sendMail was
@@ -778,7 +809,10 @@ class Outlook:
         for attachment in encoded:
             # PATCH does not take attachments; the attachments collection does.
             self._request("POST", f"/me/messages/{draft_id}/attachments", json=attachment)
+        # Recipients and the deferred-send time go on the same PATCH, so the
+        # draft is never submitted with one and not the other.
         self._request("PATCH", f"/me/messages/{draft_id}", json={
+            **(recipients or {}),
             "singleValueExtendedProperties": [
                 {"id": "SystemTime 0x3FEF", "value": send_at},
                 {"id": "SystemTime 0x000F", "value": send_at},

--- a/docs/blog/2026-09-08-the-command-that-blamed-the-wrong-password.md
+++ b/docs/blog/2026-09-08-the-command-that-blamed-the-wrong-password.md
@@ -1,0 +1,55 @@
+# The command that blamed the wrong password
+
+On 27 August, four emails were queued in Outlook for the next morning. An hour
+later the wording had to change. `co outlook send --at` had confirmed each one
+with a timestamp and a recipient, and nothing else. The way to take them back
+was found by opening `useful_tools/outlook.py` and reading what `get_scheduled`
+did, then guessing that `cancel` existed. It did. The CLI had simply never said
+so.
+
+The same afternoon, `co outlook inbox` said the Microsoft session had expired
+and told the user to run `co auth microsoft`. They did, twice, through the
+browser consent flow, and got the same error. The token was fine. A direct
+request to Graph with the stored token returned 200. What had died was the
+OpenOnion key that the refresh broker checks first, and the 401 from our own
+backend had been reported as a Microsoft expiry. Later the same key was absent
+from the environment altogether, and that surfaced as "Microsoft Mail permission
+missing". Three causes, one wrong instruction.
+
+The third complaint was quieter and worse. A threaded reply to an external
+founder needed a colleague copied in. `co outlook reply` had no `--cc`, so the
+reply went out as a fresh `send` with "RE:" in the subject. On the founder's
+side it arrived as a new conversation with no history, the shape of a mass
+mail, and it had to be re-sent by hand.
+
+None of these were failures of the Graph integration. Every request that mattered
+had worked. They were failures of what the command said afterwards, and the
+lesson we kept relearning is that an error message naming the wrong command
+costs more than no message at all: the user does the wrong thing confidently
+and then trusts the tool less.
+
+So the fix was mostly about the last line of output. A scheduled send now ends
+with the cancel path, and the `--at` help says it too. The credential layer
+that failed is the one that gets named: `co auth` when the OpenOnion key is
+missing or rejected, `co auth microsoft` when Microsoft revoked the grant or the
+saved record has no refresh token, and the scope by name when the token predates
+it. `reply` gained `--cc` and `--bcc`, set on Graph's reply action so the
+message stays in its thread. And because the Microsoft calendar tool had
+existed for months with no way to reach it from a terminal, `co outlook
+calendar` now mirrors `co gcalendar` leaf for leaf, under `co outlook` because
+Outlook is one product with three panes, not four.
+
+Writing the tips was not the hard part. Testing that they work was. We gave a
+fresh model only the output of each command and a goal, and asked for one shell
+command back. Twenty-five of twenty-six rows passed on the first run. The one
+that failed was an invalid `--at` value: the error explained the accepted
+formats but named no command, and the model answered with a shell history
+substitution that would have done nothing. A human reading that message would
+have called it clear. The tip test is worth running precisely because it does
+not read like a human.
+
+The regression tests were run against the public 1.8.3 wheel before the fix.
+Thirteen of fifteen failed there, which is the evidence that they test the
+complaint and not the implementation. The two that passed cover the token
+reuse from #1312, which 1.8.3 had already fixed; they stay as guards. No live
+mailbox was used for any of this, and that is what the beta is for.

--- a/docs/cli/outlook.md
+++ b/docs/cli/outlook.md
@@ -347,3 +347,5 @@ Other cases:
 - **`co outlook cancel` rejected with 403** → some Exchange work/school
   tenants lock deferred messages against API deletion; use Cancel Send in
   Outlook instead. On personal outlook.com accounts cancel works normally.
+
+If Teams creation returns an event without a usable meeting link, the command exits 1 and retains the event ID. Follow `co outlook calendar read EVENT_ID` to inspect that event; do not repeat creation. A missing event ID requires listing the calendar before another write.

--- a/docs/cli/outlook.md
+++ b/docs/cli/outlook.md
@@ -1,8 +1,13 @@
 # Outlook CLI (co outlook)
 
-Manage email and contacts from your Outlook account right in the terminal —
-the same Microsoft Graph access your agents get from the
-[Outlook tool](../useful_tools/outlook.md), as a command.
+Manage email, contacts and your calendar from your Outlook account right in
+the terminal — the same Microsoft Graph access your agents get from the
+[Outlook tool](../useful_tools/outlook.md) and the
+[Microsoft Calendar tool](../useful_tools/microsoft_calendar.md), as commands.
+
+Outlook is one product with three panes — Mail, Calendar, People — and
+`co outlook --help` is grouped the same way: **Mail**, **Send**,
+**Scheduled sends**, **Contacts**, **Calendar**.
 
 ## Quick Start
 
@@ -23,9 +28,15 @@ co outlook send alice@example.com "Hello" "Thanks for the meeting today!"
 # Save and find contacts
 co outlook contact add "Zhou Yifei" zhou@example.com
 co outlook contact search yifei
+
+# Your calendar
+co outlook calendar today
+co outlook calendar teams "Design review" 2026-09-10T10:00:00Z 2026-09-10T11:00:00Z --attendees a@x.com --yes
 ```
 
-That's the whole surface. Everything below is detail.
+That's the whole surface. Everything below is detail. Every command ends by
+naming the next one — including when its output is piped — so an agent driving
+`co outlook` never has to guess a command name.
 
 ## Setup
 
@@ -36,17 +47,25 @@ co auth microsoft
 ```
 
 This opens the Microsoft OAuth flow and saves `MICROSOFT_*` credentials
-(access token, refresh token, scopes, email) to your project `.env` and
-`~/.co/keys.env`. Tokens auto-refresh.
+(access token, refresh token, scopes, email, expiry) to the global
+`~/.co/keys.env`, or to the file named by `co --env-file PATH auth microsoft`.
+A project directory never selects credentials on its own.
+
+The stored access token is used for as long as it is valid; a refresh happens
+only within five minutes of its expiry or after Microsoft Graph answers 401.
+Before 1.8.4 every command discarded the stored token and went through the
+refresh broker first, so an oo-api outage made a perfectly reachable mailbox
+look expired (#1312).
 
 Microsoft credentials remain CLI-local. oo-api performs the OAuth exchange and
 refresh as a stateless proxy, while Outlook saves rotated tokens back to the
-local env files; the backend does not retain the token pair.
+selected env file; the backend does not retain the token pair.
 
-Contact commands require `Contacts.ReadWrite`. If you authenticated before
-contact support was added, run `co auth microsoft` once more to grant the new
-permission. See [Microsoft Integration](../integrations/microsoft.md) for all
-requested scopes.
+Contact commands require `Contacts.ReadWrite` and calendar commands require
+`Calendars`. If you authenticated before those were requested, run
+`co auth microsoft` once more to grant them — a refresh cannot widen scopes.
+See [Microsoft Integration](../integrations/microsoft.md) for all requested
+scopes.
 
 ## Commands
 
@@ -121,8 +140,21 @@ reply draft that Exchange holds until then, so it needs the `Mail.ReadWrite`
 scope and shows up in `co outlook scheduled` like any other scheduled send.
 
 **Options**
+- `--cc` — CC recipients (comma-separated); the reply stays in its thread
+- `--bcc` — BCC recipients (comma-separated)
 - `--attach, -a FILE` — attach a local file; repeat for multiple
 - `--at` — schedule delivery: `+30m`, `+2h`, or a UTC ISO time
+
+**Copying a third person** — `--cc` and `--bcc` are set on Graph's reply
+action (or on the deferred reply draft when `--at` is used), so the message
+keeps its `In-Reply-To` / `References` headers and lands in the existing
+conversation. Before 1.8.4b1 the only way to copy someone was a fresh
+`co outlook send` with "RE:" in the subject, which the recipient saw as a new,
+history-less thread (#1247):
+
+```bash
+co outlook reply 3 "Looping in Sam so he has the context." --cc sam@example.com
+```
 
 **Attachments** — same files, limit, and flag as `send`, still a real reply:
 
@@ -173,7 +205,15 @@ co outlook send bob@example.com "Launch" "We're live!" --at 2026-07-06T15:30:00Z
 ```
 
 `+30m` / `+2h` are relative to now; anything else is taken as a UTC ISO time.
-See what's queued with `co outlook scheduled`.
+The confirmation names the way back, because a scheduled send is the one you
+are most likely to want to take back (#1314):
+
+```
+✓ Scheduled for 2026-09-09T22:30:00Z to bob@example.com
+  From: you@example.com
+  Cancel before it goes out: co outlook scheduled, then co outlook cancel <#>
+Next: co outlook scheduled
+```
 
 **Long bodies** — pass `-` as the message to read the body from stdin:
 
@@ -220,6 +260,44 @@ Scheduled emails sit in Drafts until delivery time; `cancel` deletes the
 pending message so it never goes out. (Some Exchange work/school tenants
 reject the delete with 403 — there, use Outlook's own "Cancel Send".)
 
+### `co outlook calendar` — Your calendar
+
+The Microsoft half of what `co gcalendar` does for Google, leaf for leaf
+(`teams` where Google has `meet`). Event IDs are stable Graph IDs, never row
+numbers. Reads run at once; every write previews by default and prints the
+exact `--yes` command that performs it.
+
+| Command | Python method on `MicrosoftCalendar` |
+|---|---|
+| `list --days 7 -n 20` | `list_events` |
+| `today` | `get_today_events` |
+| `read EVENT_ID` | `get_event` |
+| `meetings --days 7` | `get_upcoming_meetings` |
+| `free 2026-09-10 --minutes 30` | `find_free_slots` |
+| `create TITLE START END [--attendees … --location … --description …]` | `create_event` |
+| `teams TITLE START END --attendees EMAILS` | `create_teams_meeting` |
+| `update EVENT_ID --title … --start … --end …` | `update_event` |
+| `delete EVENT_ID` | `delete_event` |
+
+```bash
+co outlook calendar                                 # bare = upcoming events
+co outlook calendar today
+co outlook calendar free 2026-09-10 --minutes 30
+co outlook calendar create "Standup" 2026-09-10T09:00:00+10:00 2026-09-10T09:15:00+10:00
+# {"mode": "preview", "operation": "create", ...}
+# No changes made.
+# Next: co outlook calendar create Standup 2026-09-10T09:00:00+10:00 2026-09-10T09:15:00+10:00 --yes
+```
+
+Times: an ISO offset is converted to UTC, and a naive time means UTC — Graph
+receives every event with `timeZone: UTC`. `update` preserves omitted fields;
+empty strings do not clear a field. `free` covers 09:00–17:00 UTC on this
+calendar only, not attendees'. Needs the `Calendars` scope.
+
+Exit 0 is a read, a preview, or a successful write; 1 is an operational failure
+with a recovery command; 2 is invalid arguments. A Graph error prints its HTTP
+status and a next command, never the response body.
+
 ## Same functions, in your agent
 
 The CLI is a thin wrapper over the [Outlook tool](../useful_tools/outlook.md),
@@ -251,14 +329,19 @@ outlook.send(
 
 ## Troubleshooting
 
-- **"Microsoft account not connected"** → run `co auth microsoft`.
-- **Missing Mail scopes** → run `co auth microsoft` again to re-consent.
-- **Missing `Contacts.ReadWrite`** → run `co auth microsoft` again; an older
-  token cannot gain the new permission through refresh alone.
-- **OpenOnion authentication failed during token refresh** → run `co auth`.
-- **Microsoft authorization expired or permission denied** → tokens
-  auto-refresh when possible; re-run `co auth microsoft` if Microsoft revoked
-  the refresh token or the operation needs another scope.
+Each failure names the layer that actually broke, so the printed `Next:` line
+is the fix (#1313). Three layers can fail, and each has its own command:
+
+| Printed cause | Layer | Next command |
+|---|---|---|
+| `Microsoft account not connected` | no local record | `co auth microsoft` |
+| `Microsoft <scope> permission missing` (Mail, `Contacts.ReadWrite`, `Calendars`) | record predates the scope | `co auth microsoft` — a refresh cannot widen scopes |
+| `No OpenOnion API key …` / `OpenOnion authentication failed while refreshing provider access.` | your OpenOnion key is missing or dead; the Microsoft grant is fine | `co auth` |
+| `Microsoft authorization expired or was revoked.` | Microsoft rejected the refresh token | `co auth microsoft` |
+| `Microsoft access token is expiring and the saved record has no refresh token.` | incomplete local record | `co auth microsoft` |
+| `Microsoft Graph API error (HTTP nnn).` | Graph refused the call; the body is never printed | the command's own next step (`co outlook inbox`, `co outlook calendar list`) |
+
+Other cases:
 - **`No email #N in your inbox`** → the number is out of range; run
   `co outlook inbox` to refresh the listing.
 - **`co outlook cancel` rejected with 403** → some Exchange work/school

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -10,6 +10,13 @@ Preview releases never replace the stable recommendation. Install one with
 
 ## Current release work
 
+Preview **1.8.4b1** (first 1.8.4 beta) closes the open Outlook issues —
+stored-token reuse, credential errors that name the right `co auth`, scheduled
+sends that say how to cancel, `reply --cc/--bcc` — and adds `co outlook
+calendar` over the existing Microsoft Calendar tool. See
+[1.8.4b1 notes](releases/1.8.4b1.md). Earlier 1.8.4 previews:
+[1.8.4a1](releases/1.8.4a1.md), [1.8.4a2](releases/1.8.4a2.md).
+
 Version **1.8.3** brings Gmail, Drive, Calendar and YouTube together through
 local Google authorization, with supported scopes by default and an optional
 `--scopes` restriction. It adds Gmail draft attachments and Calendar/YouTube

--- a/docs/releases/1.8.4b1.md
+++ b/docs/releases/1.8.4b1.md
@@ -50,7 +50,7 @@ printed; the status code and a next command are.
 
 ## Evidence
 
-- Core regression on the release commit: recorded in the release PR (#TBD),
+- Core regression on the release commit: recorded in the release PR (#1468),
   with the same `not slow and not real_api and not network` selection as CI.
 - 41 new unit tests across `tests/unit/test_outlook_cli_fixes_1312_1313_1314_1247.py`
   and `tests/unit/test_outlook_calendar_cli.py`. Run against the public 1.8.3
@@ -77,3 +77,5 @@ Ordinary stable installation remains on 1.8.3. To return to stable:
 ```bash
 python -m pip install --upgrade 'connectonion==1.8.3'
 ```
+
+Review follow-up: Teams creation requires a usable HTTPS meeting link before reporting success. An existing event without a confirmed link is reported as partial, with an inspection command and no automatic repeat POST.

--- a/docs/releases/1.8.4b1.md
+++ b/docs/releases/1.8.4b1.md
@@ -1,0 +1,79 @@
+# ConnectOnion 1.8.4b1 — Outlook fixes and `co outlook calendar`
+
+Prepared 8 September 2026. This is the first 1.8.4 **beta**: an opt-in preview
+whose command surface is now frozen for exercise. Stable remains **1.8.3**;
+final 1.8.4 is not released, and the physical Synology acceptance that gates it
+is unchanged from 1.8.4a2.
+
+## Outlook
+
+Four complaints from one working day, each fixed where a user hit it:
+
+- **A valid token is used, not thrown away (#1312).** The stored Microsoft
+  access token serves every command until five minutes before its expiry, or
+  until Graph answers 401. Before 1.8.4 every command went through the refresh
+  broker first, so an oo-api outage made a reachable mailbox look expired. The
+  behaviour shipped in 1.8.3; this release adds the regression test that pins it
+  (it passes on the public 1.8.3 wheel and fails on none of the credential
+  layers below).
+- **The error names the credential that actually failed (#1313).** A missing
+  `OPENONION_API_KEY`, or oo-api rejecting it during a refresh, ends with
+  `Next: co auth`. A Microsoft-revoked refresh token, or a saved record that has
+  no refresh token, ends with `Next: co auth microsoft`. A token that predates a
+  scope says which scope. Three of the four cases were still misattributed on
+  the public 1.8.3 wheel; the fourth ("expiring, no refresh token") was reported
+  as invalid command arguments until this release.
+- **A scheduled send says how to cancel it (#1314).** `send --at` and
+  `reply --at` confirm with `Cancel before it goes out: co outlook scheduled,
+  then co outlook cancel <#>` and end with `Next: co outlook scheduled`. The
+  `--at` help says the same, and `co outlook --help` groups the surface as
+  Mail, Send, Scheduled sends, Contacts and Calendar.
+- **`reply --cc` / `--bcc` keep the thread (#1247).** Recipients are set on
+  Graph's reply action, or PATCHed onto the deferred reply draft with the
+  deferred-send time, so copying a third person no longer means a fresh
+  `send` with "RE:" in the subject.
+
+Every `co outlook` command now ends with one next command, including when its
+output is piped. The `--mark-read` scope check reads the same selected record
+as the token instead of a per-field process variable.
+
+## `co outlook calendar` (#816)
+
+The Microsoft half of what `co gcalendar` does for Google, leaf for leaf, over
+the existing `MicrosoftCalendar` tool: `list`, `today`, `read`, `meetings`,
+`free`, `create`, `teams`, `update`, `delete`. It sits under `co outlook`
+beside `contact` because Outlook is one product with three panes. Reads run at
+once; every write previews by default and prints the exact `--yes` command that
+performs it. ISO offsets are converted to UTC and naive times mean UTC, so a
+Sydney time no longer books ten hours late. Graph error bodies are never
+printed; the status code and a next command are.
+
+## Evidence
+
+- Core regression on the release commit: recorded in the release PR (#TBD),
+  with the same `not slow and not real_api and not network` selection as CI.
+- 41 new unit tests across `tests/unit/test_outlook_cli_fixes_1312_1313_1314_1247.py`
+  and `tests/unit/test_outlook_calendar_cli.py`. Run against the public 1.8.3
+  wheel, 13 of the 15 Outlook-fix tests fail; the two that pass guard #1312,
+  which 1.8.3 already fixed.
+- Every exit code was provoked with the real CLI in an empty configuration
+  directory, and every printed failure names a next command. The tip test from
+  `cli-skill-design` (output only, `co/gemini-3.7-flash`, no help text) passed
+  26 of 26 rows after the last `--at` tip was added; the tables are in the PR.
+- Help and `co-mail-and-drive` skill parity is asserted by tests for
+  `co outlook`, `co outlook contact` and `co outlook calendar`.
+- No live Microsoft account was used. Graph request shapes are covered by
+  mocked tests; the first real-mailbox exercise of `reply --cc` and
+  `calendar teams` is what this beta is for.
+
+Install explicitly after publication:
+
+```bash
+python -m pip install --upgrade 'connectonion==1.8.4b1'
+```
+
+Ordinary stable installation remains on 1.8.3. To return to stable:
+
+```bash
+python -m pip install --upgrade 'connectonion==1.8.3'
+```

--- a/docs/releases/assets/v1.8.4b1/cli-outlook.svg
+++ b/docs/releases/assets/v1.8.4b1/cli-outlook.svg
@@ -1,0 +1,449 @@
+<svg class="rich-terminal" viewBox="0 0 1238 2441.2" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-3553752358-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-3553752358-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-3553752358-r1 { fill: #68a0b3;font-weight: bold }
+.terminal-3553752358-r2 { fill: #c5c8c6 }
+.terminal-3553752358-r3 { fill: #98a84b }
+.terminal-3553752358-r4 { fill: #00823d;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-3553752358-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="2390.2" />
+    </clipPath>
+    <clipPath id="terminal-3553752358-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-7">
+    <rect x="0" y="172.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-8">
+    <rect x="0" y="196.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-9">
+    <rect x="0" y="221.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-10">
+    <rect x="0" y="245.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-11">
+    <rect x="0" y="269.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-12">
+    <rect x="0" y="294.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-13">
+    <rect x="0" y="318.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-14">
+    <rect x="0" y="343.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-15">
+    <rect x="0" y="367.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-16">
+    <rect x="0" y="391.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-17">
+    <rect x="0" y="416.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-18">
+    <rect x="0" y="440.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-19">
+    <rect x="0" y="465.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-20">
+    <rect x="0" y="489.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-21">
+    <rect x="0" y="513.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-22">
+    <rect x="0" y="538.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-23">
+    <rect x="0" y="562.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-24">
+    <rect x="0" y="587.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-25">
+    <rect x="0" y="611.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-26">
+    <rect x="0" y="635.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-27">
+    <rect x="0" y="660.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-28">
+    <rect x="0" y="684.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-29">
+    <rect x="0" y="709.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-30">
+    <rect x="0" y="733.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-31">
+    <rect x="0" y="757.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-32">
+    <rect x="0" y="782.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-33">
+    <rect x="0" y="806.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-34">
+    <rect x="0" y="831.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-35">
+    <rect x="0" y="855.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-36">
+    <rect x="0" y="879.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-37">
+    <rect x="0" y="904.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-38">
+    <rect x="0" y="928.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-39">
+    <rect x="0" y="953.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-40">
+    <rect x="0" y="977.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-41">
+    <rect x="0" y="1001.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-42">
+    <rect x="0" y="1026.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-43">
+    <rect x="0" y="1050.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-44">
+    <rect x="0" y="1075.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-45">
+    <rect x="0" y="1099.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-46">
+    <rect x="0" y="1123.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-47">
+    <rect x="0" y="1148.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-48">
+    <rect x="0" y="1172.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-49">
+    <rect x="0" y="1197.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-50">
+    <rect x="0" y="1221.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-51">
+    <rect x="0" y="1245.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-52">
+    <rect x="0" y="1270.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-53">
+    <rect x="0" y="1294.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-54">
+    <rect x="0" y="1319.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-55">
+    <rect x="0" y="1343.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-56">
+    <rect x="0" y="1367.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-57">
+    <rect x="0" y="1392.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-58">
+    <rect x="0" y="1416.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-59">
+    <rect x="0" y="1441.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-60">
+    <rect x="0" y="1465.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-61">
+    <rect x="0" y="1489.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-62">
+    <rect x="0" y="1514.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-63">
+    <rect x="0" y="1538.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-64">
+    <rect x="0" y="1563.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-65">
+    <rect x="0" y="1587.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-66">
+    <rect x="0" y="1611.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-67">
+    <rect x="0" y="1636.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-68">
+    <rect x="0" y="1660.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-69">
+    <rect x="0" y="1685.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-70">
+    <rect x="0" y="1709.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-71">
+    <rect x="0" y="1733.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-72">
+    <rect x="0" y="1758.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-73">
+    <rect x="0" y="1782.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-74">
+    <rect x="0" y="1807.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-75">
+    <rect x="0" y="1831.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-76">
+    <rect x="0" y="1855.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-77">
+    <rect x="0" y="1880.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-78">
+    <rect x="0" y="1904.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-79">
+    <rect x="0" y="1929.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-80">
+    <rect x="0" y="1953.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-81">
+    <rect x="0" y="1977.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-82">
+    <rect x="0" y="2002.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-83">
+    <rect x="0" y="2026.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-84">
+    <rect x="0" y="2051.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-85">
+    <rect x="0" y="2075.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-86">
+    <rect x="0" y="2099.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-87">
+    <rect x="0" y="2124.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-88">
+    <rect x="0" y="2148.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-89">
+    <rect x="0" y="2173.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-90">
+    <rect x="0" y="2197.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-91">
+    <rect x="0" y="2221.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-92">
+    <rect x="0" y="2246.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-93">
+    <rect x="0" y="2270.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-94">
+    <rect x="0" y="2295.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-95">
+    <rect x="0" y="2319.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3553752358-line-96">
+    <rect x="0" y="2343.9" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="2439.2" rx="8"/><text class="terminal-3553752358-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">ConnectOnion&#160;1.8.4b1&#160;·&#160;co&#160;outlook</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3553752358-clip-terminal)">
+    
+    <g class="terminal-3553752358-matrix">
+    <text class="terminal-3553752358-r1" x="0" y="20" textLength="231.8" clip-path="url(#terminal-3553752358-line-0)">$&#160;co&#160;outlook&#160;--help</text><text class="terminal-3553752358-r2" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-3553752358-line-0)">
+</text><text class="terminal-3553752358-r2" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-1)">
+</text><text class="terminal-3553752358-r2" x="0" y="68.8" textLength="1220" clip-path="url(#terminal-3553752358-line-2)">&#160;Usage:&#160;python&#160;-m&#160;connectonion.cli.main&#160;outlook&#160;[OPTIONS]&#160;COMMAND&#160;[ARGS]...&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3553752358-r2" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-2)">
+</text><text class="terminal-3553752358-r2" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-3)">
+</text><text class="terminal-3553752358-r2" x="0" y="117.6" textLength="1220" clip-path="url(#terminal-3553752358-line-4)">&#160;Your&#160;Outlook&#160;account:&#160;mail,&#160;scheduled&#160;sends,&#160;contacts&#160;and&#160;calendar.&#160;Bare&#160;&#x27;co&#160;outlook&#x27;&#160;shows&#160;the&#160;&#160;&#160;&#160;</text><text class="terminal-3553752358-r2" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-4)">
+</text><text class="terminal-3553752358-r2" x="0" y="142" textLength="1220" clip-path="url(#terminal-3553752358-line-5)">&#160;inbox.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3553752358-r2" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-3553752358-line-5)">
+</text><text class="terminal-3553752358-r2" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-6)">
+</text><text class="terminal-3553752358-r2" x="0" y="190.8" textLength="1220" clip-path="url(#terminal-3553752358-line-7)">╭─&#160;Options&#160;────────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3553752358-r2" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-7)">
+</text><text class="terminal-3553752358-r2" x="0" y="215.2" textLength="1220" clip-path="url(#terminal-3553752358-line-8)">│&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-8)">
+</text><text class="terminal-3553752358-r2" x="0" y="239.6" textLength="1220" clip-path="url(#terminal-3553752358-line-9)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3553752358-r2" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-9)">
+</text><text class="terminal-3553752358-r2" x="0" y="264" textLength="1220" clip-path="url(#terminal-3553752358-line-10)">╭─&#160;Send&#160;───────────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3553752358-r2" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-3553752358-line-10)">
+</text><text class="terminal-3553752358-r2" x="0" y="288.4" textLength="1220" clip-path="url(#terminal-3553752358-line-11)">│&#160;send&#160;&#160;&#160;&#160;&#160;&#160;&#160;Send&#160;an&#160;email&#160;from&#160;your&#160;Outlook&#160;account,&#160;now&#160;or&#160;scheduled&#160;with&#160;--at.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-11)">
+</text><text class="terminal-3553752358-r2" x="0" y="312.8" textLength="1220" clip-path="url(#terminal-3553752358-line-12)">│&#160;reply&#160;&#160;&#160;&#160;&#160;&#160;Reply&#160;to&#160;an&#160;email&#160;(threaded),&#160;now&#160;or&#160;scheduled&#160;with&#160;--at.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-12)">
+</text><text class="terminal-3553752358-r2" x="0" y="337.2" textLength="1220" clip-path="url(#terminal-3553752358-line-13)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3553752358-r2" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-13)">
+</text><text class="terminal-3553752358-r2" x="0" y="361.6" textLength="1220" clip-path="url(#terminal-3553752358-line-14)">╭─&#160;Mail&#160;───────────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3553752358-r2" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-14)">
+</text><text class="terminal-3553752358-r2" x="0" y="386" textLength="1220" clip-path="url(#terminal-3553752358-line-15)">│&#160;inbox&#160;&#160;&#160;&#160;&#160;&#160;List&#160;recent&#160;emails&#160;in&#160;your&#160;Outlook&#160;inbox.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-3553752358-line-15)">
+</text><text class="terminal-3553752358-r2" x="0" y="410.4" textLength="1220" clip-path="url(#terminal-3553752358-line-16)">│&#160;read&#160;&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;one&#160;email&#x27;s&#160;body&#160;without&#160;changing&#160;its&#160;unread&#160;state.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-16)">
+</text><text class="terminal-3553752358-r2" x="0" y="434.8" textLength="1220" clip-path="url(#terminal-3553752358-line-17)">│&#160;download&#160;&#160;&#160;Save&#160;an&#160;email&#x27;s&#160;attachments&#160;to&#160;disk.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="434.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-17)">
+</text><text class="terminal-3553752358-r2" x="0" y="459.2" textLength="1220" clip-path="url(#terminal-3553752358-line-18)">│&#160;sent&#160;&#160;&#160;&#160;&#160;&#160;&#160;List&#160;recently&#160;sent&#160;Outlook&#160;emails.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="459.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-18)">
+</text><text class="terminal-3553752358-r2" x="0" y="483.6" textLength="1220" clip-path="url(#terminal-3553752358-line-19)">│&#160;search&#160;&#160;&#160;&#160;&#160;Search&#160;your&#160;Outlook&#160;emails.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="483.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-19)">
+</text><text class="terminal-3553752358-r2" x="0" y="508" textLength="1220" clip-path="url(#terminal-3553752358-line-20)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3553752358-r2" x="1220" y="508" textLength="12.2" clip-path="url(#terminal-3553752358-line-20)">
+</text><text class="terminal-3553752358-r2" x="0" y="532.4" textLength="1220" clip-path="url(#terminal-3553752358-line-21)">╭─&#160;Scheduled&#160;sends&#160;────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3553752358-r2" x="1220" y="532.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-21)">
+</text><text class="terminal-3553752358-r2" x="0" y="556.8" textLength="1220" clip-path="url(#terminal-3553752358-line-22)">│&#160;scheduled&#160;&#160;List&#160;emails&#160;waiting&#160;for&#160;scheduled&#160;delivery.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="556.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-22)">
+</text><text class="terminal-3553752358-r2" x="0" y="581.2" textLength="1220" clip-path="url(#terminal-3553752358-line-23)">│&#160;cancel&#160;&#160;&#160;&#160;&#160;Cancel&#160;a&#160;scheduled&#160;email&#160;before&#160;it&#160;goes&#160;out.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="581.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-23)">
+</text><text class="terminal-3553752358-r2" x="0" y="605.6" textLength="1220" clip-path="url(#terminal-3553752358-line-24)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3553752358-r2" x="1220" y="605.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-24)">
+</text><text class="terminal-3553752358-r2" x="0" y="630" textLength="1220" clip-path="url(#terminal-3553752358-line-25)">╭─&#160;Contacts&#160;───────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3553752358-r2" x="1220" y="630" textLength="12.2" clip-path="url(#terminal-3553752358-line-25)">
+</text><text class="terminal-3553752358-r2" x="0" y="654.4" textLength="1220" clip-path="url(#terminal-3553752358-line-26)">│&#160;contact&#160;&#160;&#160;&#160;Add,&#160;list,&#160;and&#160;search&#160;Outlook&#160;contacts.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="654.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-26)">
+</text><text class="terminal-3553752358-r2" x="0" y="678.8" textLength="1220" clip-path="url(#terminal-3553752358-line-27)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3553752358-r2" x="1220" y="678.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-27)">
+</text><text class="terminal-3553752358-r2" x="0" y="703.2" textLength="1220" clip-path="url(#terminal-3553752358-line-28)">╭─&#160;Calendar&#160;───────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3553752358-r2" x="1220" y="703.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-28)">
+</text><text class="terminal-3553752358-r2" x="0" y="727.6" textLength="1220" clip-path="url(#terminal-3553752358-line-29)">│&#160;calendar&#160;&#160;&#160;Your&#160;Outlook&#160;calendar:&#160;events,&#160;Teams&#160;meetings,&#160;free&#160;slots.&#160;Bare&#160;&#x27;co&#160;outlook&#160;calendar&#x27;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="727.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-29)">
+</text><text class="terminal-3553752358-r2" x="0" y="752" textLength="1220" clip-path="url(#terminal-3553752358-line-30)">│&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;lists&#160;events.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="752" textLength="12.2" clip-path="url(#terminal-3553752358-line-30)">
+</text><text class="terminal-3553752358-r2" x="0" y="776.4" textLength="1220" clip-path="url(#terminal-3553752358-line-31)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3553752358-r2" x="1220" y="776.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-31)">
+</text><text class="terminal-3553752358-r2" x="1220" y="800.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-32)">
+</text><text class="terminal-3553752358-r2" x="1220" y="825.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-33)">
+</text><text class="terminal-3553752358-r1" x="0" y="849.6" textLength="292.8" clip-path="url(#terminal-3553752358-line-34)">$&#160;co&#160;outlook&#160;send&#160;--help</text><text class="terminal-3553752358-r2" x="1220" y="849.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-34)">
+</text><text class="terminal-3553752358-r2" x="1220" y="874" textLength="12.2" clip-path="url(#terminal-3553752358-line-35)">
+</text><text class="terminal-3553752358-r2" x="0" y="898.4" textLength="1220" clip-path="url(#terminal-3553752358-line-36)">&#160;Usage:&#160;python&#160;-m&#160;connectonion.cli.main&#160;outlook&#160;send&#160;[OPTIONS]&#160;{to}&#160;{subject}&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3553752358-r2" x="1220" y="898.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-36)">
+</text><text class="terminal-3553752358-r2" x="0" y="922.8" textLength="1220" clip-path="url(#terminal-3553752358-line-37)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;{message}&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3553752358-r2" x="1220" y="922.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-37)">
+</text><text class="terminal-3553752358-r2" x="1220" y="947.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-38)">
+</text><text class="terminal-3553752358-r2" x="0" y="971.6" textLength="1220" clip-path="url(#terminal-3553752358-line-39)">&#160;Send&#160;an&#160;email&#160;from&#160;your&#160;Outlook&#160;account,&#160;now&#160;or&#160;scheduled&#160;with&#160;--at.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3553752358-r2" x="1220" y="971.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-39)">
+</text><text class="terminal-3553752358-r2" x="1220" y="996" textLength="12.2" clip-path="url(#terminal-3553752358-line-40)">
+</text><text class="terminal-3553752358-r2" x="0" y="1020.4" textLength="1220" clip-path="url(#terminal-3553752358-line-41)">╭─&#160;Arguments&#160;──────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3553752358-r2" x="1220" y="1020.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-41)">
+</text><text class="terminal-3553752358-r2" x="0" y="1044.8" textLength="1220" clip-path="url(#terminal-3553752358-line-42)">│&#160;*&#160;&#160;&#160;&#160;to&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&lt;str&gt;&#160;&#160;Recipient&#160;email&#160;address&#160;(comma-separated&#160;for&#160;multiple)&#160;[required]&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1044.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-42)">
+</text><text class="terminal-3553752358-r2" x="0" y="1069.2" textLength="1220" clip-path="url(#terminal-3553752358-line-43)">│&#160;*&#160;&#160;&#160;&#160;subject&#160;&#160;&#160;&#160;&#160;&#160;&lt;str&gt;&#160;&#160;Subject&#160;line&#160;[required]&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1069.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-43)">
+</text><text class="terminal-3553752358-r2" x="0" y="1093.6" textLength="1220" clip-path="url(#terminal-3553752358-line-44)">│&#160;*&#160;&#160;&#160;&#160;message&#160;&#160;&#160;&#160;&#160;&#160;&lt;str&gt;&#160;&#160;Body&#160;(plain&#160;text,&#160;or&#160;&#x27;-&#x27;&#160;to&#160;read&#160;from&#160;stdin)&#160;[required]&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1093.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-44)">
+</text><text class="terminal-3553752358-r2" x="0" y="1118" textLength="1220" clip-path="url(#terminal-3553752358-line-45)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3553752358-r2" x="1220" y="1118" textLength="12.2" clip-path="url(#terminal-3553752358-line-45)">
+</text><text class="terminal-3553752358-r2" x="0" y="1142.4" textLength="1220" clip-path="url(#terminal-3553752358-line-46)">╭─&#160;Options&#160;────────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3553752358-r2" x="1220" y="1142.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-46)">
+</text><text class="terminal-3553752358-r2" x="0" y="1166.8" textLength="1220" clip-path="url(#terminal-3553752358-line-47)">│&#160;--cc&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&lt;str&gt;&#160;&#160;CC&#160;recipients&#160;(comma-separated)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1166.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-47)">
+</text><text class="terminal-3553752358-r2" x="0" y="1191.2" textLength="1220" clip-path="url(#terminal-3553752358-line-48)">│&#160;--bcc&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&lt;str&gt;&#160;&#160;BCC&#160;recipients&#160;(comma-separated)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1191.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-48)">
+</text><text class="terminal-3553752358-r2" x="0" y="1215.6" textLength="1220" clip-path="url(#terminal-3553752358-line-49)">│&#160;--attach&#160;&#160;-a&#160;&#160;&#160;&#160;&#160;&#160;&lt;str&gt;&#160;&#160;File&#160;to&#160;attach&#160;(repeat&#160;for&#160;multiple)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1215.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-49)">
+</text><text class="terminal-3553752358-r2" x="0" y="1240" textLength="1220" clip-path="url(#terminal-3553752358-line-50)">│&#160;--at&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&lt;str&gt;&#160;&#160;Schedule&#160;delivery:&#160;+30m,&#160;+2h,&#160;or&#160;UTC&#160;ISO&#160;time&#160;(2026-07-06T15:30:00Z);&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1240" textLength="12.2" clip-path="url(#terminal-3553752358-line-50)">
+</text><text class="terminal-3553752358-r2" x="0" y="1264.4" textLength="1220" clip-path="url(#terminal-3553752358-line-51)">│&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;cancel&#160;before&#160;it&#160;goes&#160;out&#160;with&#160;co&#160;outlook&#160;cancel&#160;&lt;#&gt;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1264.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-51)">
+</text><text class="terminal-3553752358-r2" x="0" y="1288.8" textLength="1220" clip-path="url(#terminal-3553752358-line-52)">│&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1288.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-52)">
+</text><text class="terminal-3553752358-r2" x="0" y="1313.2" textLength="1220" clip-path="url(#terminal-3553752358-line-53)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3553752358-r2" x="1220" y="1313.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-53)">
+</text><text class="terminal-3553752358-r2" x="1220" y="1337.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-54)">
+</text><text class="terminal-3553752358-r2" x="0" y="1362" textLength="1220" clip-path="url(#terminal-3553752358-line-55)">&#160;Examples:&#160;&#160;co&#160;outlook&#160;send&#160;a@b.com&#160;&quot;Hi&quot;&#160;&quot;Quick&#160;note&quot;&#160;&#160;|&#160;&#160;cat&#160;body.txt&#160;|&#160;co&#160;outlook&#160;send&#160;a@b.com&#160;&#160;&#160;&#160;</text><text class="terminal-3553752358-r2" x="1220" y="1362" textLength="12.2" clip-path="url(#terminal-3553752358-line-55)">
+</text><text class="terminal-3553752358-r2" x="0" y="1386.4" textLength="1220" clip-path="url(#terminal-3553752358-line-56)">&#160;&quot;Report&quot;&#160;-&#160;&#160;|&#160;&#160;co&#160;outlook&#160;send&#160;a@b.com&#160;&quot;Invoice&quot;&#160;&quot;Attached&quot;&#160;--attach&#160;invoice.pdf&#160;--at&#160;+2h&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3553752358-r2" x="1220" y="1386.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-56)">
+</text><text class="terminal-3553752358-r2" x="1220" y="1410.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-57)">
+</text><text class="terminal-3553752358-r2" x="1220" y="1435.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-58)">
+</text><text class="terminal-3553752358-r2" x="1220" y="1459.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-59)">
+</text><text class="terminal-3553752358-r1" x="0" y="1484" textLength="341.6" clip-path="url(#terminal-3553752358-line-60)">$&#160;co&#160;outlook&#160;calendar&#160;--help</text><text class="terminal-3553752358-r2" x="1220" y="1484" textLength="12.2" clip-path="url(#terminal-3553752358-line-60)">
+</text><text class="terminal-3553752358-r2" x="1220" y="1508.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-61)">
+</text><text class="terminal-3553752358-r2" x="0" y="1532.8" textLength="1220" clip-path="url(#terminal-3553752358-line-62)">&#160;Usage:&#160;python&#160;-m&#160;connectonion.cli.main&#160;outlook&#160;calendar&#160;[OPTIONS]&#160;COMMAND&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3553752358-r2" x="1220" y="1532.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-62)">
+</text><text class="terminal-3553752358-r2" x="0" y="1557.2" textLength="1220" clip-path="url(#terminal-3553752358-line-63)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;[ARGS]...&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3553752358-r2" x="1220" y="1557.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-63)">
+</text><text class="terminal-3553752358-r2" x="1220" y="1581.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-64)">
+</text><text class="terminal-3553752358-r2" x="0" y="1606" textLength="1220" clip-path="url(#terminal-3553752358-line-65)">&#160;Your&#160;Outlook&#160;calendar:&#160;events,&#160;Teams&#160;meetings,&#160;free&#160;slots.&#160;Bare&#160;&#x27;co&#160;outlook&#160;calendar&#x27;&#160;lists&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3553752358-r2" x="1220" y="1606" textLength="12.2" clip-path="url(#terminal-3553752358-line-65)">
+</text><text class="terminal-3553752358-r2" x="0" y="1630.4" textLength="1220" clip-path="url(#terminal-3553752358-line-66)">&#160;events.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3553752358-r2" x="1220" y="1630.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-66)">
+</text><text class="terminal-3553752358-r2" x="1220" y="1654.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-67)">
+</text><text class="terminal-3553752358-r2" x="0" y="1679.2" textLength="1220" clip-path="url(#terminal-3553752358-line-68)">╭─&#160;Options&#160;────────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3553752358-r2" x="1220" y="1679.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-68)">
+</text><text class="terminal-3553752358-r2" x="0" y="1703.6" textLength="1220" clip-path="url(#terminal-3553752358-line-69)">│&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1703.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-69)">
+</text><text class="terminal-3553752358-r2" x="0" y="1728" textLength="1220" clip-path="url(#terminal-3553752358-line-70)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3553752358-r2" x="1220" y="1728" textLength="12.2" clip-path="url(#terminal-3553752358-line-70)">
+</text><text class="terminal-3553752358-r2" x="0" y="1752.4" textLength="1220" clip-path="url(#terminal-3553752358-line-71)">╭─&#160;Commands&#160;───────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3553752358-r2" x="1220" y="1752.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-71)">
+</text><text class="terminal-3553752358-r2" x="0" y="1776.8" textLength="1220" clip-path="url(#terminal-3553752358-line-72)">│&#160;list&#160;&#160;&#160;&#160;&#160;&#160;List&#160;upcoming&#160;events&#160;with&#160;stable&#160;event&#160;IDs&#160;(not&#160;row&#160;numbers).&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1776.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-72)">
+</text><text class="terminal-3553752358-r2" x="0" y="1801.2" textLength="1220" clip-path="url(#terminal-3553752358-line-73)">│&#160;today&#160;&#160;&#160;&#160;&#160;Read&#160;today&#x27;s&#160;events.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1801.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-73)">
+</text><text class="terminal-3553752358-r2" x="0" y="1825.6" textLength="1220" clip-path="url(#terminal-3553752358-line-74)">│&#160;read&#160;&#160;&#160;&#160;&#160;&#160;Read&#160;one&#160;event&#160;by&#160;ID.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1825.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-74)">
+</text><text class="terminal-3553752358-r2" x="0" y="1850" textLength="1220" clip-path="url(#terminal-3553752358-line-75)">│&#160;meetings&#160;&#160;Read&#160;upcoming&#160;events&#160;that&#160;have&#160;attendees.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1850" textLength="12.2" clip-path="url(#terminal-3553752358-line-75)">
+</text><text class="terminal-3553752358-r2" x="0" y="1874.4" textLength="1220" clip-path="url(#terminal-3553752358-line-76)">│&#160;free&#160;&#160;&#160;&#160;&#160;&#160;Find&#160;free&#160;slots&#160;between&#160;09:00&#160;and&#160;17:00&#160;UTC&#160;on&#160;one&#160;day.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1874.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-76)">
+</text><text class="terminal-3553752358-r2" x="0" y="1898.8" textLength="1220" clip-path="url(#terminal-3553752358-line-77)">│&#160;create&#160;&#160;&#160;&#160;Create&#160;an&#160;event.&#160;Previews&#160;until&#160;--yes.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1898.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-77)">
+</text><text class="terminal-3553752358-r2" x="0" y="1923.2" textLength="1220" clip-path="url(#terminal-3553752358-line-78)">│&#160;teams&#160;&#160;&#160;&#160;&#160;Create&#160;an&#160;event&#160;with&#160;a&#160;Microsoft&#160;Teams&#160;meeting&#160;link.&#160;Previews&#160;until&#160;--yes.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1923.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-78)">
+</text><text class="terminal-3553752358-r2" x="0" y="1947.6" textLength="1220" clip-path="url(#terminal-3553752358-line-79)">│&#160;update&#160;&#160;&#160;&#160;Update&#160;the&#160;supplied&#160;fields;&#160;omitted&#160;fields&#160;are&#160;preserved.&#160;Previews&#160;until&#160;--yes.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1947.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-79)">
+</text><text class="terminal-3553752358-r2" x="0" y="1972" textLength="1220" clip-path="url(#terminal-3553752358-line-80)">│&#160;delete&#160;&#160;&#160;&#160;Delete&#160;an&#160;event&#160;by&#160;its&#160;stable&#160;ID,&#160;never&#160;by&#160;a&#160;listing&#160;number.&#160;Previews&#160;until&#160;--yes.&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3553752358-r2" x="1220" y="1972" textLength="12.2" clip-path="url(#terminal-3553752358-line-80)">
+</text><text class="terminal-3553752358-r2" x="0" y="1996.4" textLength="1220" clip-path="url(#terminal-3553752358-line-81)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3553752358-r2" x="1220" y="1996.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-81)">
+</text><text class="terminal-3553752358-r2" x="1220" y="2020.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-82)">
+</text><text class="terminal-3553752358-r2" x="1220" y="2045.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-83)">
+</text><text class="terminal-3553752358-r1" x="0" y="2069.6" textLength="353.8" clip-path="url(#terminal-3553752358-line-84)">$&#160;co&#160;outlook&#160;calendar&#160;create&#160;</text><text class="terminal-3553752358-r3" x="353.8" y="2069.6" textLength="183" clip-path="url(#terminal-3553752358-line-84)">&quot;Design&#160;review&quot;</text><text class="terminal-3553752358-r1" x="549" y="2069.6" textLength="48.8" clip-path="url(#terminal-3553752358-line-84)">2026</text><text class="terminal-3553752358-r1" x="597.8" y="2069.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-84)">-</text><text class="terminal-3553752358-r1" x="610" y="2069.6" textLength="24.4" clip-path="url(#terminal-3553752358-line-84)">09</text><text class="terminal-3553752358-r1" x="634.4" y="2069.6" textLength="48.8" clip-path="url(#terminal-3553752358-line-84)">-10T</text><text class="terminal-3553752358-r4" x="683.2" y="2069.6" textLength="97.6" clip-path="url(#terminal-3553752358-line-84)">20:00:00</text><text class="terminal-3553752358-r1" x="780.8" y="2069.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-84)">+</text><text class="terminal-3553752358-r4" x="793" y="2069.6" textLength="61" clip-path="url(#terminal-3553752358-line-84)">10:00</text><text class="terminal-3553752358-r1" x="866.2" y="2069.6" textLength="48.8" clip-path="url(#terminal-3553752358-line-84)">2026</text><text class="terminal-3553752358-r1" x="915" y="2069.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-84)">-</text><text class="terminal-3553752358-r1" x="927.2" y="2069.6" textLength="24.4" clip-path="url(#terminal-3553752358-line-84)">09</text><text class="terminal-3553752358-r1" x="951.6" y="2069.6" textLength="48.8" clip-path="url(#terminal-3553752358-line-84)">-10T</text><text class="terminal-3553752358-r4" x="1000.4" y="2069.6" textLength="97.6" clip-path="url(#terminal-3553752358-line-84)">21:00:00</text><text class="terminal-3553752358-r1" x="1098" y="2069.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-84)">+</text><text class="terminal-3553752358-r4" x="1110.2" y="2069.6" textLength="61" clip-path="url(#terminal-3553752358-line-84)">10:00</text><text class="terminal-3553752358-r2" x="1220" y="2069.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-84)">
+</text><text class="terminal-3553752358-r1" x="0" y="2094" textLength="305" clip-path="url(#terminal-3553752358-line-85)">--attendees&#160;a@example.com</text><text class="terminal-3553752358-r2" x="1220" y="2094" textLength="12.2" clip-path="url(#terminal-3553752358-line-85)">
+</text><text class="terminal-3553752358-r2" x="0" y="2118.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-86)">{</text><text class="terminal-3553752358-r2" x="1220" y="2118.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-86)">
+</text><text class="terminal-3553752358-r2" x="0" y="2142.8" textLength="268.4" clip-path="url(#terminal-3553752358-line-87)">&#160;&#160;&#160;&#160;&#x27;mode&#x27;:&#160;&#x27;preview&#x27;,</text><text class="terminal-3553752358-r2" x="1220" y="2142.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-87)">
+</text><text class="terminal-3553752358-r2" x="0" y="2167.2" textLength="317.2" clip-path="url(#terminal-3553752358-line-88)">&#160;&#160;&#160;&#160;&#x27;operation&#x27;:&#160;&#x27;create&#x27;,</text><text class="terminal-3553752358-r2" x="1220" y="2167.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-88)">
+</text><text class="terminal-3553752358-r2" x="0" y="2191.6" textLength="341.6" clip-path="url(#terminal-3553752358-line-89)">&#160;&#160;&#160;&#160;&#x27;arg1&#x27;:&#160;&#x27;Design&#160;review&#x27;,</text><text class="terminal-3553752358-r2" x="1220" y="2191.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-89)">
+</text><text class="terminal-3553752358-r2" x="0" y="2216" textLength="488" clip-path="url(#terminal-3553752358-line-90)">&#160;&#160;&#160;&#160;&#x27;arg2&#x27;:&#160;&#x27;2026-09-10T20:00:00+10:00&#x27;,</text><text class="terminal-3553752358-r2" x="1220" y="2216" textLength="12.2" clip-path="url(#terminal-3553752358-line-90)">
+</text><text class="terminal-3553752358-r2" x="0" y="2240.4" textLength="488" clip-path="url(#terminal-3553752358-line-91)">&#160;&#160;&#160;&#160;&#x27;arg3&#x27;:&#160;&#x27;2026-09-10T21:00:00+10:00&#x27;,</text><text class="terminal-3553752358-r2" x="1220" y="2240.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-91)">
+</text><text class="terminal-3553752358-r2" x="0" y="2264.8" textLength="390.4" clip-path="url(#terminal-3553752358-line-92)">&#160;&#160;&#160;&#160;&#x27;attendees&#x27;:&#160;&#x27;a@example.com&#x27;</text><text class="terminal-3553752358-r2" x="1220" y="2264.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-92)">
+</text><text class="terminal-3553752358-r2" x="0" y="2289.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-93)">}</text><text class="terminal-3553752358-r2" x="1220" y="2289.2" textLength="12.2" clip-path="url(#terminal-3553752358-line-93)">
+</text><text class="terminal-3553752358-r2" x="0" y="2313.6" textLength="195.2" clip-path="url(#terminal-3553752358-line-94)">No&#160;changes&#160;made.</text><text class="terminal-3553752358-r2" x="1220" y="2313.6" textLength="12.2" clip-path="url(#terminal-3553752358-line-94)">
+</text><text class="terminal-3553752358-r2" x="0" y="2338" textLength="1220" clip-path="url(#terminal-3553752358-line-95)">Next:&#160;co&#160;outlook&#160;calendar&#160;create&#160;&#x27;Design&#160;review&#x27;&#160;2026-09-10T20:00:00+10:00&#160;2026-09-10T21:00:00+10:00</text><text class="terminal-3553752358-r2" x="1220" y="2338" textLength="12.2" clip-path="url(#terminal-3553752358-line-95)">
+</text><text class="terminal-3553752358-r2" x="0" y="2362.4" textLength="378.2" clip-path="url(#terminal-3553752358-line-96)">--attendees&#160;a@example.com&#160;--yes</text><text class="terminal-3553752358-r2" x="1220" y="2362.4" textLength="12.2" clip-path="url(#terminal-3553752358-line-96)">
+</text><text class="terminal-3553752358-r2" x="1220" y="2386.8" textLength="12.2" clip-path="url(#terminal-3553752358-line-97)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/releases/assets/v1.8.4b1/manifest.yml
+++ b/docs/releases/assets/v1.8.4b1/manifest.yml
@@ -1,0 +1,9 @@
+version: v1.8.4b1
+images:
+- file: cli-outlook.svg
+  alt: co outlook --help grouped as Mail, Send, Scheduled sends, Contacts and Calendar; send --help naming co outlook cancel; the new co outlook calendar group; and a create preview ending with the exact --yes command.
+  caption: Every Outlook command now ends by naming the next one, scheduling reads as one feature, and the Microsoft calendar has a terminal.
+  scenario: Account-free rendering of the installed CLI in an empty configuration directory, no credentials loaded, 100-column terminal.
+  viewport: 100-column terminal
+  commit: 27d31825c1a7d7d80b54e77b880a40632ce1a67a
+  source_run: scripts/capture_184b1_release_cli.py

--- a/docs/useful_tools/outlook.md
+++ b/docs/useful_tools/outlook.md
@@ -226,3 +226,5 @@ refresh still needs a valid OpenOnion session.
 **Microsoft authorization expired or permission denied**: Run
 `co auth microsoft` again. Tokens auto-refresh when possible; reauthorization
 is required after Microsoft revokes a refresh token or when a scope is missing.
+
+If Teams creation returns an event without a usable meeting link, the command exits 1 and retains the event ID. Follow `co outlook calendar read EVENT_ID` to inspect that event; do not repeat creation. A missing event ID requires listing the calendar before another write.

--- a/docs/useful_tools/outlook.md
+++ b/docs/useful_tools/outlook.md
@@ -121,7 +121,7 @@ outlook.send(
 )
 ```
 
-**`reply(email_id, body, send_at=None, *, attachments=None)`**
+**`reply(email_id, body, send_at=None, *, attachments=None, cc=None, bcc=None)`**
 - Reply to an existing email (threaded), now or scheduled
 - `body` is plain text — paragraphs (blank-line separated) convert to HTML
   `<p>` blocks and single newlines to `<br>`, with HTML characters escaped,
@@ -132,11 +132,16 @@ outlook.send(
 - `attachments`: Keyword-only list of local file paths, validated and limited
   exactly like `send()`. They travel on Graph's reply action, so the message
   stays in the original conversation
+- `cc`, `bcc`: Keyword-only comma-separated addresses. They are set on the
+  reply action's message (or PATCHed onto the deferred reply draft when
+  `send_at` is given), so copying a third person keeps the reply in its
+  thread instead of starting a new "RE:" conversation (#1247)
 
 ```python
 outlook.reply(
     email_id, "Signed copy attached.",
     attachments=["signed.pdf"],
+    cc="sam@example.com",
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.8.4a2"
+version = "1.8.4b1"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -25,7 +25,7 @@ keywords = [
     "xray",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",

--- a/scripts/capture_184b1_release_cli.py
+++ b/scripts/capture_184b1_release_cli.py
@@ -1,0 +1,68 @@
+"""Capture the account-free `co outlook` help screens for the 1.8.4b1 release visuals.
+
+The release's primary user-visible change is a CLI surface — grouped Outlook
+help, `send --at` naming its cancel path, `reply --cc/--bcc`, and the new
+`co outlook calendar` group — so the visual evidence is the terminal itself
+(docs/releases/README.md, rule 5). Runs with an empty configuration directory
+and no credentials, so nothing private can end up in the SVG.
+
+    python scripts/capture_184b1_release_cli.py --version 1.8.4b1
+"""
+import argparse
+import io
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+from rich.console import Console
+from rich.text import Text
+
+SCREENS = (
+    ("outlook", "--help"),
+    ("outlook", "send", "--help"),
+    ("outlook", "calendar", "--help"),
+    ("outlook", "calendar", "create", "Design review",
+     "2026-09-10T20:00:00+10:00", "2026-09-10T21:00:00+10:00", "--attendees", "a@example.com"),
+)
+
+
+def capture(destination: Path, expected_version: str) -> None:
+    console = Console(record=True, width=100, force_terminal=False, file=io.StringIO())
+    with tempfile.TemporaryDirectory(prefix="co-release-help-") as temporary:
+        config = Path(temporary) / "config"
+        config.mkdir()
+        environment = {
+            "PATH": os.defpath,
+            "AGENT_CONFIG_PATH": str(config),
+            "NO_COLOR": "1",
+            "COLUMNS": "100",
+        }
+        version = subprocess.check_output(
+            [sys.executable, "-c", "import connectonion; print(connectonion.__version__)"],
+            cwd=temporary, env=environment, text=True, timeout=30,
+        ).strip()
+        if version != expected_version:
+            raise ValueError(f"Expected {expected_version}, found {version}")
+        for args in SCREENS:
+            result = subprocess.run(
+                [sys.executable, "-m", "connectonion.cli.main", *args],
+                cwd=temporary, env=environment, capture_output=True, text=True, timeout=30,
+            )
+            console.print("$ co " + " ".join(a if " " not in a else f'"{a}"' for a in args), style="bold cyan")
+            console.print(Text.from_ansi(result.stdout + result.stderr))
+    console.save_svg(str(destination), title=f"ConnectOnion {version} · co outlook")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", default="1.8.4b1")
+    args = parser.parse_args()
+    destination = Path(__file__).resolve().parents[1] / "docs/releases/assets" / f"v{args.version}"
+    destination.mkdir(parents=True, exist_ok=True)
+    capture(destination / "cli-outlook.svg", args.version)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/cli/test_cli_outlook_reply.py
+++ b/tests/e2e/cli/test_cli_outlook_reply.py
@@ -18,7 +18,7 @@ def test_outlook_reply_routes_without_attachments():
         ])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("3", "Sounds good", attachments=None, at=None)
+    handler.assert_called_once_with("3", "Sounds good", attachments=None, at=None, cc=None, bcc=None)
 
 
 def test_outlook_reply_collects_repeated_attach_flags():
@@ -34,7 +34,7 @@ def test_outlook_reply_collects_repeated_attach_flags():
     assert result.exit_code == 0
     handler.assert_called_once_with(
         "3", "Both attached",
-        attachments=["report.pdf", "chart.png"], at=None,
+        attachments=["report.pdf", "chart.png"], at=None, cc=None, bcc=None,
     )
 
 
@@ -49,5 +49,22 @@ def test_outlook_reply_routes_attachments_with_schedule():
 
     assert result.exit_code == 0
     handler.assert_called_once_with(
-        "3", "Tomorrow", attachments=["report.pdf"], at="+2h",
+        "3", "Tomorrow", attachments=["report.pdf"], at="+2h", cc=None, bcc=None,
+    )
+
+
+def test_outlook_reply_routes_cc_and_bcc():
+    """#1247: a copied third person rides on the threaded reply, not a new send."""
+    with patch(
+        "connectonion.cli.commands.outlook_commands.handle_outlook_reply"
+    ) as handler:
+        result = runner.invoke(app, [
+            "outlook", "reply", "3", "Looping in Sam",
+            "--cc", "sam@example.com", "--bcc", "me@example.com",
+        ])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(
+        "3", "Looping in Sam", attachments=None, at=None,
+        cc="sam@example.com", bcc="me@example.com",
     )

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -1165,8 +1165,9 @@ class TestOutlookReplyPositionalCompatibility:
         from connectonion.useful_tools.outlook import Outlook
 
         params = inspect.signature(Outlook.reply).parameters
-        assert list(params) == ["self", "email_id", "body", "send_at", "attachments"]
-        assert params["attachments"].kind is inspect.Parameter.KEYWORD_ONLY
+        assert list(params) == ["self", "email_id", "body", "send_at", "attachments", "cc", "bcc"]
+        for name in ("attachments", "cc", "bcc"):
+            assert params[name].kind is inspect.Parameter.KEYWORD_ONLY
 
 
 class TestOutlookActions:

--- a/tests/unit/test_outlook_calendar_cli.py
+++ b/tests/unit/test_outlook_calendar_cli.py
@@ -120,3 +120,43 @@ def test_offsets_normalize_to_utc_and_naive_means_utc(given, expected, monkeypat
     monkeypatch.setenv("MICROSOFT_SCOPES", "Calendars.ReadWrite")
     monkeypatch.setenv("MICROSOFT_ACCESS_TOKEN", "t")
     assert MicrosoftCalendar()._parse_time(given).isoformat() == expected
+
+
+@pytest.mark.parametrize('meeting', [None, {}, {'joinUrl':''}, {'joinUrl':'not-a-url'}])
+def test_teams_without_a_link_is_partial_and_never_repeats_creation(monkeypatch, meeting):
+    from connectonion.useful_tools.microsoft_calendar import MicrosoftCalendar
+    client=object.__new__(MicrosoftCalendar)
+    client._request=MagicMock(return_value={'id':'event-created','onlineMeeting':meeting})
+    monkeypatch.setattr(commands,'_client',lambda:client)
+    args=next(args for args,method in WRITES if method=='create_teams_meeting')
+    result=CliRunner().invoke(app,['outlook','calendar',*args,'--yes'])
+    assert result.exit_code == 1,result.output
+    assert 'Event created' in result.output and 'event-created' in result.output
+    assert 'Teams meeting created:' not in result.output
+    assert 'co outlook calendar read event-created' in result.output
+    client._request.assert_called_once()
+
+
+def test_teams_success_requires_a_usable_link(monkeypatch):
+    from connectonion.useful_tools.microsoft_calendar import MicrosoftCalendar
+    client=object.__new__(MicrosoftCalendar)
+    client._request=MagicMock(return_value={'id':'event-created','onlineMeeting':{'joinUrl':'https://teams.example.test/join'}})
+    monkeypatch.setattr(commands,'_client',lambda:client)
+    args=next(args for args,method in WRITES if method=='create_teams_meeting')
+    result=CliRunner().invoke(app,['outlook','calendar',*args,'--yes'])
+    assert result.exit_code==0,result.output
+    assert 'https://teams.example.test/join' in result.output
+    client._request.assert_called_once()
+
+
+def test_read_recovers_the_existing_events_join_url(monkeypatch):
+    from connectonion.useful_tools.microsoft_calendar import MicrosoftCalendar
+    client=object.__new__(MicrosoftCalendar)
+    client._request=MagicMock(return_value={'subject':'Existing','start':{'dateTime':'2026-09-10T10:00:00'},
+        'end':{'dateTime':'2026-09-10T11:00:00'},'onlineMeeting':{'joinUrl':'https://teams.example.test/existing'}})
+    monkeypatch.setattr(commands,'_client',lambda:client)
+    result=CliRunner().invoke(app,['outlook','calendar','read','event-created'])
+    assert result.exit_code==0,result.output
+    assert 'https://teams.example.test/existing' in result.output
+    assert client._request.call_args.args[0]=='GET'
+    assert 'onlineMeeting' in client._request.call_args.kwargs['params']['$select'].split(',')

--- a/tests/unit/test_outlook_calendar_cli.py
+++ b/tests/unit/test_outlook_calendar_cli.py
@@ -1,0 +1,122 @@
+"""`co outlook calendar`: the Microsoft half of #816, shaped like `co gcalendar`.
+
+Outlook is one product with three panes — Mail, Calendar, People — so the
+calendar lives under `co outlook`, beside `contact`, rather than as a fourth
+top-level name an agent would have to guess. Every leaf maps to one
+MicrosoftCalendar method; writes preview by default and the preview prints the
+exact command that performs them.
+"""
+from pathlib import Path
+from unittest.mock import MagicMock
+import os
+import re
+
+import pytest
+from rich.text import Text
+from typer.main import get_command
+from typer.testing import CliRunner
+
+from connectonion.cli.main import app
+from connectonion.cli.commands import outlook_calendar_commands as commands
+
+READS = [([], 'list_events'), (['list'], 'list_events'), (['today'], 'get_today_events'),
+         (['read', 'event-a'], 'get_event'), (['meetings'], 'get_upcoming_meetings'),
+         (['free', '2026-09-10'], 'find_free_slots')]
+WRITES = [(['create', 'Demo', '2026-09-10T10:00:00Z', '2026-09-10T11:00:00Z'], 'create_event'),
+          (['teams', 'Demo', '2026-09-10T10:00:00Z', '2026-09-10T11:00:00Z', '--attendees', 'a@example.invalid'], 'create_teams_meeting'),
+          (['update', 'event-a', '--title', 'Changed'], 'update_event'),
+          (['delete', 'event-a'], 'delete_event')]
+
+
+def plain(output: str) -> str:
+    return Text.from_ansi(output).plain
+
+
+@pytest.mark.parametrize('args,method', READS + WRITES)
+def test_dispatch_and_piped_tip(args, method, monkeypatch):
+    client = MagicMock()
+    getattr(client, method).return_value = 'Event\n   ID: event-a'
+    monkeypatch.setattr(commands, '_client', lambda: client)
+    result = CliRunner().invoke(app, ['outlook', 'calendar', *args, *(['--yes'] if (args, method) in WRITES else [])])
+    assert result.exit_code == 0, result.output
+    getattr(client, method).assert_called_once()
+    assert plain(result.output).strip().splitlines()[-1].startswith('Next: co outlook calendar ')
+
+
+def test_list_tip_names_the_first_event_id(monkeypatch):
+    client = MagicMock()
+    client.list_events.return_value = 'Upcoming events:\n- 2026-09-10 10:00 AM: Demo\n   ID: AAMkAGI2-event=\n'
+    monkeypatch.setattr(commands, '_client', lambda: client)
+    result = CliRunner().invoke(app, ['outlook', 'calendar'])
+    assert plain(result.output).strip().splitlines()[-1] == 'Next: co outlook calendar read AAMkAGI2-event='
+
+
+@pytest.mark.parametrize('args,method', WRITES)
+def test_write_preview_prints_the_exact_command_that_performs_it(args, method, monkeypatch):
+    monkeypatch.setattr(commands, '_client', lambda: pytest.fail('Preview reached provider'))
+    result = CliRunner().invoke(app, ['outlook', 'calendar', *args])
+    output = plain(result.output)
+    assert result.exit_code == 0 and 'No changes made' in output
+    last = output.strip().splitlines()[-1]
+    assert last.startswith(f'Next: co outlook calendar {args[0]} ') and last.endswith(' --yes')
+    for value in args[1:]:
+        assert value in last
+
+
+@pytest.mark.parametrize('path', [('outlook',), ('outlook', 'contact'), ('outlook', 'calendar')])
+def test_help_and_skill_parity(path):
+    command = get_command(app)
+    for name in path:
+        command = command.commands[name]
+    visible = {name for name, child in command.commands.items() if not child.hidden}
+    skill = (Path(__file__).resolve().parents[2] / 'connectonion/useful_skills/co-mail-and-drive/SKILL.md').read_text()
+    documented = set(re.findall(r'co ' + ' '.join(path) + r' ([a-z][a-z-]*)', skill))
+    assert visible == documented, (visible ^ documented)
+    result = CliRunner().invoke(app, [*path, '--help'])
+    assert result.exit_code == 0
+    for name in visible:
+        assert re.search(r'\b' + name + r'\b', plain(result.output))
+        assert CliRunner().invoke(app, [*path, name, '--help']).exit_code == 0
+
+
+def test_invalid_update_is_actionable():
+    result = CliRunner().invoke(app, ['outlook', 'calendar', 'update', 'event-a'])
+    assert result.exit_code == 2 and 'co outlook calendar update --help' in plain(result.output)
+
+
+def test_graph_failure_is_sanitized_and_recoverable(monkeypatch):
+    from connectonion.useful_tools.microsoft_calendar import MicrosoftCalendar
+    env = {"MICROSOFT_ACCESS_TOKEN": "t", "MICROSOFT_REFRESH_TOKEN": "r",
+           "MICROSOFT_SCOPES": "Calendars.ReadWrite", "MICROSOFT_TOKEN_EXPIRES_AT": "2099-01-01T00:00:00Z"}
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    failed = MagicMock(status_code=500, text='PRIVATE tenant detail')
+    monkeypatch.setattr('connectonion.useful_tools.microsoft_calendar.httpx.request', lambda *a, **k: failed)
+    monkeypatch.setattr(commands, '_client', MicrosoftCalendar)
+    result = CliRunner().invoke(app, ['outlook', 'calendar'])
+    output = plain(result.output)
+    assert result.exit_code == 1 and 'PRIVATE' not in output
+    assert re.search(r'^Next: co ', output, re.MULTILINE)
+
+
+def test_missing_calendar_scope_asks_for_reconsent(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("AGENT_CONFIG_PATH", str(tmp_path / ".co"))
+    for key, value in {"MICROSOFT_ACCESS_TOKEN": "t", "MICROSOFT_SCOPES": "Mail.Read,Mail.Send"}.items():
+        monkeypatch.setenv(key, value)
+    result = CliRunner().invoke(app, ['outlook', 'calendar'])
+    output = plain(result.output)
+    assert result.exit_code == 1
+    assert 'Calendars' in output and re.search(r'^Next: co auth microsoft$', output, re.MULTILINE)
+
+
+@pytest.mark.parametrize('given,expected', [
+    ('2026-09-10T20:00:00+10:00', '2026-09-10T10:00:00'),
+    ('2026-09-10T10:00:00Z', '2026-09-10T10:00:00'),
+    ('2026-09-10 10:00', '2026-09-10T10:00:00'),
+])
+def test_offsets_normalize_to_utc_and_naive_means_utc(given, expected, monkeypatch):
+    from connectonion.useful_tools.microsoft_calendar import MicrosoftCalendar
+    monkeypatch.setenv("MICROSOFT_SCOPES", "Calendars.ReadWrite")
+    monkeypatch.setenv("MICROSOFT_ACCESS_TOKEN", "t")
+    assert MicrosoftCalendar()._parse_time(given).isoformat() == expected

--- a/tests/unit/test_outlook_cli_fixes_1312_1313_1314_1247.py
+++ b/tests/unit/test_outlook_cli_fixes_1312_1313_1314_1247.py
@@ -71,7 +71,7 @@ class TestAValidTokenNeedsNoBroker:
 
         assert result.exit_code == 0, result.output
         assert calls and all(auth == "Bearer stored-token" for _, _, auth in calls)
-        assert "graph.microsoft.com" in calls[0][1]
+        assert calls[0][1].startswith("https://graph.microsoft.com/v1.0/")
 
 
 class TestTheErrorNamesTheLayerThatFailed:

--- a/tests/unit/test_outlook_cli_fixes_1312_1313_1314_1247.py
+++ b/tests/unit/test_outlook_cli_fixes_1312_1313_1314_1247.py
@@ -1,0 +1,241 @@
+"""Four Outlook complaints from one working day, each pinned to the command a user typed.
+
+#1312 — a valid, unexpired token was thrown away and every command died with the
+        refresh broker. The stored token must serve `co outlook inbox` with no
+        OpenOnion key and no backend call at all.
+#1313 — a dead OpenOnion key was reported as "Microsoft session expired", and a
+        missing key as "Microsoft Mail permission missing". Three causes, three
+        different next commands: `co auth`, `co auth microsoft`, and re-consent.
+#1314 — `send --at` never said how to cancel. Every scheduled send and reply now
+        ends by naming `co outlook scheduled`, and the help groups the three
+        scheduling commands as one feature.
+#1247 — `reply` had no --cc / --bcc, so adding a third person meant starting a
+        new thread. The flags ride on Graph's reply action and on the deferred
+        reply draft, so the conversation stays threaded.
+"""
+
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+from rich.text import Text
+
+from connectonion.cli.main import app
+from connectonion.cli.commands import outlook_commands
+
+VALID = {
+    "MICROSOFT_ACCESS_TOKEN": "stored-token",
+    "MICROSOFT_REFRESH_TOKEN": "stored-refresh",
+    "MICROSOFT_SCOPES": "Mail.ReadWrite,Mail.Send",
+    "MICROSOFT_EMAIL": "me@example.com",
+    "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z",
+}
+
+
+def plain(output: str) -> str:
+    return Text.from_ansi(output).plain
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    """No real ~/.co, no ambient OpenOnion key unless a test sets one."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("AGENT_CONFIG_PATH", str(home / ".co"))
+    monkeypatch.delenv("OPENONION_API_KEY", raising=False)
+    monkeypatch.setattr(outlook_commands, "INBOX_CACHE", home / "outlook_last_inbox.json")
+    return home
+
+
+class TestAValidTokenNeedsNoBroker:
+    """#1312: the mailbox is reachable, so the CLI must reach it."""
+
+    def test_inbox_uses_the_stored_token_without_any_backend_call(self, isolated_home, monkeypatch):
+        graph = MagicMock(status_code=200, text='{"value": []}')
+        graph.json.return_value = {"value": []}
+        calls = []
+
+        def request(method, url, headers=None, **kwargs):
+            calls.append((method, url, headers["Authorization"]))
+            return graph
+
+        monkeypatch.setattr("connectonion.useful_tools.outlook.httpx.request", request)
+        monkeypatch.setattr("connectonion.useful_tools.outlook.httpx.post",
+                            lambda *a, **k: pytest.fail("refresh broker was called"))
+        with patch.dict(os.environ, VALID, clear=False):
+            result = CliRunner().invoke(app, ["outlook", "inbox"])
+
+        assert result.exit_code == 0, result.output
+        assert calls and all(auth == "Bearer stored-token" for _, _, auth in calls)
+        assert "graph.microsoft.com" in calls[0][1]
+
+
+class TestTheErrorNamesTheLayerThatFailed:
+    """#1313: each failure points at the credential that is actually broken."""
+
+    def _expiring(self):
+        return {**VALID, "MICROSOFT_TOKEN_EXPIRES_AT":
+                (datetime.now(timezone.utc) + timedelta(minutes=1)).isoformat()}
+
+    def test_missing_openonion_key_is_not_a_missing_microsoft_scope(self, isolated_home):
+        with patch.dict(os.environ, self._expiring(), clear=False):
+            result = CliRunner().invoke(app, ["outlook", "inbox"])
+
+        output = plain(result.output)
+        assert result.exit_code == 1
+        assert "permission missing" not in output
+        assert re.search(r"^Next: co auth$", output, re.MULTILINE), output
+
+    def test_dead_openonion_key_is_not_a_microsoft_expiry(self, isolated_home, monkeypatch):
+        rejected = MagicMock(status_code=401)
+        rejected.json.return_value = {"detail": "Invalid token"}
+        monkeypatch.setenv("OPENONION_API_KEY", "dead-key")
+        monkeypatch.setattr("connectonion.useful_tools.outlook.httpx.post", lambda *a, **k: rejected)
+        with patch.dict(os.environ, self._expiring(), clear=False):
+            result = CliRunner().invoke(app, ["outlook", "inbox"])
+
+        output = plain(result.output)
+        assert result.exit_code == 1
+        assert "Microsoft session expired" not in output and "Microsoft authorization expired" not in output
+        assert re.search(r"^Next: co auth$", output, re.MULTILINE), output
+
+    def test_microsoft_revocation_points_to_microsoft(self, isolated_home, monkeypatch):
+        revoked = MagicMock(status_code=401)
+        revoked.json.return_value = {"detail": {"error": "reauth_required"}}
+        monkeypatch.setenv("OPENONION_API_KEY", "good-key")
+        monkeypatch.setattr("connectonion.useful_tools.outlook.httpx.post", lambda *a, **k: revoked)
+        with patch.dict(os.environ, self._expiring(), clear=False):
+            result = CliRunner().invoke(app, ["outlook", "inbox"])
+
+        assert result.exit_code == 1
+        assert re.search(r"^Next: co auth microsoft$", plain(result.output), re.MULTILINE)
+
+    def test_expiring_token_with_no_refresh_token_is_an_incomplete_record(self, isolated_home):
+        """Not 'invalid input; check the command arguments' — nothing about the
+        arguments is wrong, the saved record is missing its refresh half."""
+        record = {**self._expiring(), "MICROSOFT_REFRESH_TOKEN": ""}
+        with patch.dict(os.environ, record, clear=False):
+            result = CliRunner().invoke(app, ["outlook", "inbox"])
+
+        output = plain(result.output)
+        assert result.exit_code == 1
+        assert "check the command arguments" not in output
+        assert re.search(r"^Next: co auth microsoft$", output, re.MULTILINE), output
+
+    def test_mark_read_reads_the_scope_from_the_record_not_the_process(self, isolated_home, monkeypatch):
+        """The write-scope check must follow the same record as everything else."""
+        outlook = MagicMock()
+        outlook._credentials.scopes = {"Mail.ReadWrite", "Mail.Send"}
+        outlook.get_email_body.return_value = "From: a@b.c\n--- Email Body ---\nhi"
+        monkeypatch.delenv("MICROSOFT_SCOPES", raising=False)
+        with patch.object(outlook_commands, "_outlook", return_value=outlook):
+            outlook_commands.handle_outlook_read("msg-1", mark_read=True)
+        outlook.mark_read.assert_called_once_with("msg-1")
+
+
+class TestSchedulingIsOneDiscoverableFeature:
+    """#1314: the send that most needs taking back is the one that says how."""
+
+    @pytest.fixture
+    def outlook(self, isolated_home):
+        client = MagicMock()
+        client._credentials.get.return_value = "me@example.com"
+        with patch.dict(os.environ, VALID, clear=False), \
+             patch.object(outlook_commands, "_outlook", return_value=client):
+            yield client
+
+    def test_scheduled_send_names_the_cancel_path(self, outlook):
+        result = CliRunner().invoke(app, ["outlook", "send", "x@y.com", "Hi", "Body", "--at", "+2h"])
+        assert result.exit_code == 0, result.output
+        assert plain(result.output).strip().splitlines()[-1] == "Next: co outlook scheduled"
+        assert "co outlook cancel <#>" in plain(result.output)
+
+    def test_scheduled_reply_names_the_cancel_path(self, outlook):
+        result = CliRunner().invoke(app, ["outlook", "reply", "AAMkAGI2", "On it", "--at", "+30m"])
+        assert result.exit_code == 0, result.output
+        assert plain(result.output).strip().splitlines()[-1] == "Next: co outlook scheduled"
+
+    def test_immediate_send_still_ends_with_a_next_command(self, outlook):
+        result = CliRunner().invoke(app, ["outlook", "send", "x@y.com", "Hi", "Body"])
+        assert result.exit_code == 0, result.output
+        assert plain(result.output).strip().splitlines()[-1] == "Next: co outlook sent"
+
+    def test_send_help_says_how_to_cancel(self):
+        output = plain(CliRunner().invoke(app, ["outlook", "send", "--help"]).output)
+        assert "co outlook cancel" in output
+
+    def test_group_help_shows_scheduling_as_one_feature(self):
+        output = plain(CliRunner().invoke(app, ["outlook", "--help"]).output)
+        assert "Scheduled sends" in output
+        block = output.split("Scheduled sends", 1)[1]
+        assert "scheduled" in block and "cancel" in block
+
+
+class TestReplyCarriesCcAndBcc:
+    """#1247: a threaded reply can copy a third person."""
+
+    def _replied(self, mock_request, **kwargs):
+        from connectonion.useful_tools.outlook import Outlook
+        with patch.dict(os.environ, VALID, clear=False):
+            return Outlook().reply("msg-1", "Thanks", **kwargs)
+
+    def test_immediate_reply_sets_recipients_on_the_reply_action(self, monkeypatch):
+        calls = []
+        ok = MagicMock(status_code=202, text="")
+
+        def request(method, url, **kwargs):
+            calls.append((method, url, kwargs.get("json")))
+            return ok
+
+        monkeypatch.setattr("connectonion.useful_tools.outlook.httpx.request", request)
+        self._replied(request, cc="a@x.com, b@x.com", bcc="c@x.com")
+
+        (method, url, body), = calls
+        assert method == "POST" and url.endswith("/me/messages/msg-1/reply")
+        assert body["comment"] == "<p>Thanks</p>"
+        assert body["message"]["ccRecipients"] == [
+            {"emailAddress": {"address": "a@x.com"}}, {"emailAddress": {"address": "b@x.com"}}]
+        assert body["message"]["bccRecipients"] == [{"emailAddress": {"address": "c@x.com"}}]
+
+    def test_scheduled_reply_patches_recipients_onto_the_deferred_draft(self, monkeypatch):
+        calls = []
+        created = MagicMock(status_code=201, text='{"id": "draft-9"}')
+        created.json.return_value = {"id": "draft-9"}
+        ok = MagicMock(status_code=200, text="")
+
+        def request(method, url, **kwargs):
+            calls.append((method, url, kwargs.get("json")))
+            return created if url.endswith("/createReply") else ok
+
+        monkeypatch.setattr("connectonion.useful_tools.outlook.httpx.request", request)
+        self._replied(request, send_at="2026-07-06T15:30:00Z", cc="a@x.com")
+
+        patched = [body for method, url, body in calls if method == "PATCH"]
+        assert len(patched) == 1
+        assert patched[0]["ccRecipients"] == [{"emailAddress": {"address": "a@x.com"}}]
+        assert "bccRecipients" not in patched[0]
+        assert patched[0]["singleValueExtendedProperties"][0]["value"] == "2026-07-06T15:30:00Z"
+
+    def test_reply_without_cc_is_unchanged(self, monkeypatch):
+        calls = []
+        ok = MagicMock(status_code=202, text="")
+        monkeypatch.setattr("connectonion.useful_tools.outlook.httpx.request",
+                            lambda m, u, **k: calls.append(k.get("json")) or ok)
+        self._replied(None)
+        assert calls == [{"comment": "<p>Thanks</p>"}]
+
+    def test_cli_forwards_the_flags_and_prints_them(self, isolated_home):
+        client = MagicMock()
+        client._credentials.get.return_value = "me@example.com"
+        with patch.dict(os.environ, VALID, clear=False), \
+             patch.object(outlook_commands, "_outlook", return_value=client):
+            result = CliRunner().invoke(app, ["outlook", "reply", "AAMkAGI2", "Thanks",
+                                              "--cc", "a@x.com", "--bcc", "c@x.com"])
+        assert result.exit_code == 0, result.output
+        assert client.reply.call_args.kwargs["cc"] == "a@x.com"
+        assert client.reply.call_args.kwargs["bcc"] == "c@x.com"
+        assert "Cc: a@x.com" in plain(result.output)

--- a/tests/unit/test_outlook_commands.py
+++ b/tests/unit/test_outlook_commands.py
@@ -254,8 +254,11 @@ class TestHandleOutlookInbox:
 class TestHandleOutlookRead:
     """Opening a message preserves unread state unless --mark-read was chosen."""
 
-    def _outlook_mock(self):
+    def _outlook_mock(self, scopes=("Mail.ReadWrite", "Mail.Send", "Contacts.ReadWrite")):
         outlook = MagicMock()
+        # The handler reads the write scope from the same selected record the
+        # token came from, not from a per-field os.getenv.
+        outlook._credentials.scopes = set(scopes)
         outlook.get_email_body.return_value = (
             "From: alice@example.com\nSubject: Hello\n--- Email Body ---\nThe body text"
         )
@@ -280,7 +283,7 @@ class TestHandleOutlookRead:
         assert "Marked read" in capsys.readouterr().out
 
     def test_explicit_mark_read_explains_missing_scope(self, capsys):
-        outlook = self._outlook_mock()
+        outlook = self._outlook_mock(scopes=("Mail.Read", "Mail.Send"))
         with patch.dict(os.environ, CONNECTED_ENV, clear=False), \
              patch.object(outlook_commands, "_outlook", return_value=outlook):
             outlook_commands.handle_outlook_read("msg-123", mark_read=True)
@@ -345,7 +348,7 @@ class TestHandleOutlookReply:
         self._reply(outlook, monkeypatch, email_id="3", message="Sounds good")
 
         outlook.reply.assert_called_once_with(
-            "msg-cached-3", "Sounds good", attachments=None, send_at=None,
+            "msg-cached-3", "Sounds good", attachments=None, send_at=None, cc=None, bcc=None,
         )
         output = capsys.readouterr().out
         assert "Replied" in output
@@ -363,7 +366,7 @@ class TestHandleOutlookReply:
 
         outlook.reply.assert_called_once_with(
             "msg-cached-3", "Both attached",
-            attachments=[str(report), str(chart)], send_at=None,
+            attachments=[str(report), str(chart)], send_at=None, cc=None, bcc=None,
         )
         output = capsys.readouterr().out
         assert "Replied" in output
@@ -380,7 +383,7 @@ class TestHandleOutlookReply:
 
         outlook.reply.assert_called_once_with(
             "msg-cached-3", "Body from stdin\nline two\n",
-            attachments=[str(report)], send_at=None,
+            attachments=[str(report)], send_at=None, cc=None, bcc=None,
         )
 
     def test_scheduled_reply_keeps_its_attachment(self, tmp_path, monkeypatch, capsys):
@@ -393,7 +396,7 @@ class TestHandleOutlookReply:
 
         outlook.reply.assert_called_once_with(
             "msg-cached-3", "Tomorrow",
-            attachments=[str(report)], send_at="2026-07-06T15:30:00Z",
+            attachments=[str(report)], send_at="2026-07-06T15:30:00Z", cc=None, bcc=None,
         )
         output = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().out)
         assert "Reply scheduled" in output
@@ -454,7 +457,7 @@ class TestHandleOutlookReplyPositionalCompatibility:
 
         outlook.reply.assert_called_once_with(
             "msg-cached-3", "See you then",
-            attachments=None, send_at="2026-07-06T15:30:00Z",
+            attachments=None, send_at="2026-07-06T15:30:00Z", cc=None, bcc=None,
         )
         output = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().out)
         assert "Reply scheduled" in output
@@ -476,8 +479,9 @@ class TestHandleOutlookReplyPositionalCompatibility:
         import inspect
 
         params = inspect.signature(handle_outlook_reply).parameters
-        assert list(params) == ["email_id", "message", "at", "attachments"]
-        assert params["attachments"].kind is inspect.Parameter.KEYWORD_ONLY
+        assert list(params) == ["email_id", "message", "at", "attachments", "cc", "bcc"]
+        for name in ("attachments", "cc", "bcc"):
+            assert params[name].kind is inspect.Parameter.KEYWORD_ONLY
 
 
 class TestHandleOutlookContacts:

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.8.4a2"
+version = "1.8.4b1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Description

Four Outlook complaints from one working day, each fixed where the user hit it, plus the Microsoft half of #816: `co outlook calendar`. Published as the first 1.8.4 **beta** (`1.8.4b1`), an opt-in preview; stable remains 1.8.3.

- **#1312** A valid Microsoft token is used until five minutes before expiry or a Graph 401, never discarded on every command. The behaviour already shipped in 1.8.3 (the new test passes on the public 1.8.3 wheel); this PR adds the regression test that pins it and documents it.
- **#1313** The error names the credential layer that failed: missing or oo-api-rejected `OPENONION_API_KEY` → `Next: co auth`; Microsoft-revoked refresh token, or a record with no refresh token → `Next: co auth microsoft`; missing scope → named scope. The "expiring, no refresh token" case was reported as *invalid command arguments* until this PR.
- **#1314** `send --at` / `reply --at` end with `Cancel before it goes out: co outlook scheduled, then co outlook cancel <#>` and `Next: co outlook scheduled`; the `--at` help says so; `co outlook --help` groups Mail / Send / Scheduled sends / Contacts / Calendar.
- **#1247** `reply --cc/--bcc`, set on Graph's reply action (or PATCHed onto the deferred reply draft with the deferred-send time) so the reply stays threaded.
- **#816 (Microsoft half)** `co outlook calendar` — list, today, read, meetings, free, create, teams, update, delete — mirrors `co gcalendar` leaf for leaf over the existing `MicrosoftCalendar` tool. Writes preview by default and print the exact `--yes` command. ISO offsets convert to UTC. Graph error bodies are never printed (they were, via `ValueError(response.text)`). A returned event without a usable Teams link is now an explicit partial outcome, with its ID and a read command; creation is never automatically repeated.
- Every `co outlook` command ends with one next command that survives piping. `--mark-read` reads the scope from the selected record instead of `os.getenv`.

## Related Issue

Fixes #1312, fixes #1313, fixes #1314, fixes #1247. Refs #816 (calendar half; Telegram/Discord/WhatsApp outbound remain open). Refs #1445 (release ledger).

## Labels and target release (required)

- **Suggested labels:** bug, feature, tests, documentation
- **Proposed target version:** 1.8.4b1
- **Estimated release window:** next beta (this PR is the release commit)
- **Milestone:** 1.8.4
- **Why this release:** All four issues are daily-use Outlook failures with wrong recovery instructions; one of them sent a user through the Microsoft consent flow twice for a dead OpenOnion key. The calendar tool existed with no terminal surface. Beta freezes the 1.8.4 command surface for exercise; rollback is `pip install connectonion==1.8.3`.
- **Forward-port tracking issue (stable patches only):** N/A — mainline work

## How this was written

- [x] AI-assisted — I reviewed every line and can explain why each change is there

**Which model?** Claude Fable 5.1, Claude Code.

- *Least confident about:* the Graph request shapes for `reply` with `ccRecipients` inside the reply action's `message`, and `PATCH` of recipients on a `createReply` draft. Both follow the documented writable-properties contract and are covered by mocked tests, but no real mailbox has exercised them yet — that is what the beta is for.
- *Not verified:* any live Microsoft account. No `co outlook calendar` command has hit a real tenant. Windows was not run locally (CI matrix covers it).
- *If wrong, what breaks first:* `reply --cc` could send the reply without the CC (Graph ignoring the `message` block) rather than failing loudly; `calendar teams` may create an event without a Teams link on tenants that do not enable the provider; that outcome now exits 1 and preserves the event ID for inspection.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Dev Blog (required)

> docs/blog/2026-09-08-the-command-that-blamed-the-wrong-password.md

## Changes Made

- `connectonion/useful_tools/outlook.py` — `reply(..., *, attachments, cc, bcc)`; recipients on the reply action or the deferred draft's PATCH; expiring-without-refresh raises `ProviderCredentialError("incomplete_record", …, auth_command)` instead of a bare `ValueError`.
- `connectonion/useful_tools/microsoft_calendar.py` — `_parse_time` accepts ISO offsets and normalizes to naive UTC; non-2xx Graph responses raise a sanitized `ProviderCredentialError` (status only).
- `connectonion/cli/commands/outlook_commands.py` — shared `_microsoft_record()` guard; `_after_send()` cancel-path tip; `print_tip` on every handler including empty results; scope from the record.
- `connectonion/cli/commands/outlook_calendar_commands.py` (new) — the calendar group; `_OneSuggestion` class so a typo is answered once; previews print the performing command.
- `connectonion/cli/main.py` — `rich_help_panel` groups; `--at` help names cancel; `reply --cc/--bcc`; calendar group registered under `outlook`.
- `connectonion/useful_skills/co-mail-and-drive/SKILL.md`, `docs/cli/outlook.md`, `docs/useful_tools/outlook.md` — routing row, calendar section, recovery table with the three credential layers.
- Version: `_version.py`, `pyproject.toml` (+ `Development Status :: 4 - Beta`), `uv.lock`, `VERSIONING.md`, `docs/releases/1.8.4b1.md`, `docs/releases.md`, `docs/releases/assets/v1.8.4b1/{manifest.yml,cli-outlook.svg}` (captured by `scripts/capture_184b1_release_cli.py`).
- Tests: `tests/unit/test_outlook_cli_fixes_1312_1313_1314_1247.py` (15), `tests/unit/test_outlook_calendar_cli.py` (26), `tests/e2e/cli/test_cli_outlook_reply.py` (+1); existing reply-signature and mark-read tests updated for the new keyword-only parameters and the record-based scope.

## Testing

Current review fix, offline full selection:

```
pytest tests/ -n 4 --dist loadfile -m "not slow and not real_api and not network" -q
8597 passed, 22 skipped, 6 warnings in 71.80s
```

The targeted Outlook/calendar tests passed locally. New regressions cover missing/null/malformed Teams links, a successful usable HTTPS link, and reading the existing event's modern `onlineMeeting.joinUrl` field. Creation is performed once; incomplete outcomes preserve the event ID and return a read command with exit 1 rather than claim Teams success or repeat POST.

No live Microsoft account was used. These changes establish request/error behavior through mocks, not live delivery or tenant compatibility. The earlier 26/26 model tip evaluation is historical; the new partial-result path is covered by deterministic regression tests. Current CI must pass on this exact head before merging.

## Scope

`connectonion/useful_tools/{outlook,microsoft_calendar}.py` (tool behaviour), `connectonion/cli/commands/{outlook_commands,outlook_calendar_commands}.py` + `cli/main.py` (surface), skill + three docs pages (what an agent and a person read), version/release/blog files (the 1.8.4b1 release commit), tests. Not touched: Gmail, Google Calendar, the credential resolver, the release workflow.

Deferred, not hidden: Outlook still numbers rows from a mutable last-listing cache while Gmail/Drive use frozen listing tokens (noted in the 8 Sept 1.8.4 review); #1418's 1.7.x backport decision is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZ4HA38XUNCnnCqaieQTry
