### PR TITLE
feat(cli): add co env to see, set and repair the selected env file

### DIFF
--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -27,6 +27,22 @@ from ...project import project_co_dir, project_identity
 
 console = Console()
 
+# The right-hand column of every credential row is a command, not an
+# instruction. "set OPENAI_API_KEY in global keys.env" told people what to
+# achieve and left them to find the file; `co env set` is the file.
+CREDENTIAL_ACTIONS = {
+    "OPENONION_API_KEY": "co auth",
+    "OPENAI_API_KEY": "co env set OPENAI_API_KEY <key>",
+    "ANTHROPIC_API_KEY": "co env set ANTHROPIC_API_KEY <key>",
+    "GEMINI_API_KEY": "co env set GEMINI_API_KEY <key>",
+    "GOOGLE_API_KEY": "co env set GOOGLE_API_KEY <key>",
+    "GROQ_API_KEY": "co env set GROQ_API_KEY <key>",
+    "XAI_API_KEY": "co env set XAI_API_KEY <key>",
+    "OPENROUTER_API_KEY": "co env set OPENROUTER_API_KEY <key>",
+    "MISTRAL_API_KEY": "co env set MISTRAL_API_KEY <key>",
+    "TELEGRAM_BOT_TOKEN": "co env set TELEGRAM_BOT_TOKEN <token>",
+}
+
 
 def _repair_runtime(*, yes: bool) -> None:
     """Show the complete plan, apply approved mutations, and print outcomes."""
@@ -393,18 +409,7 @@ def handle_doctor(*, fix: bool = False, yes: bool = False, json_output: bool = F
         _short_account,
     )
 
-    credential_actions = {
-        "OPENONION_API_KEY": "co auth",
-        "OPENAI_API_KEY": "set OPENAI_API_KEY in global keys.env",
-        "ANTHROPIC_API_KEY": "set ANTHROPIC_API_KEY in global keys.env",
-        "GEMINI_API_KEY": "set GEMINI_API_KEY in global keys.env",
-        "GOOGLE_API_KEY": "set GOOGLE_API_KEY in global keys.env",
-        "GROQ_API_KEY": "set GROQ_API_KEY in global keys.env",
-        "XAI_API_KEY": "set XAI_API_KEY in global keys.env",
-        "OPENROUTER_API_KEY": "set OPENROUTER_API_KEY in global keys.env",
-        "MISTRAL_API_KEY": "set MISTRAL_API_KEY in global keys.env",
-        "TELEGRAM_BOT_TOKEN": "set TELEGRAM_BOT_TOKEN in ~/.co/keys.env",
-    }
+    credential_actions = CREDENTIAL_ACTIONS
     project_dir = project_co_dir().parent
     selected_api_key = _selected_credential_values(
         ("OPENONION_API_KEY",),

--- a/connectonion/cli/commands/env_commands.py
+++ b/connectonion/cli/commands/env_commands.py
@@ -1,0 +1,220 @@
+"""
+Purpose: `co env` — show, read, set and remove settings in the selected env file, and explain a broken one
+LLM-Note:
+  Dependencies: imports from [re, pathlib, typer, rich, environment, env_file, command_tips] | imported by [cli/main.py via handle_env_*] | tested by [tests/unit/test_co_env.py]
+  Data flow: handle_env_show() → selected_env_file() + read_env_file() → one row per setting with a masked value and its source (file / process override / ignored provider record) | handle_env_get(key) → process value, else file value, printed bare for $(...) | handle_env_set(key, value) → name/record checks → env_file.upsert_env() (lock, atomic replace, 0600) | handle_env_unset(key) → upsert_env(remove=...) — a provider record field removes the whole record
+  State/Effects: reads and writes only the selected env file (global ~/.co/keys.env unless --env-file was given) | never rewrites a file that fails to parse | never prints a secret unless --reveal | never touches os.environ
+  Integration: the one command that still runs when the selected file is broken — every other command exits 2 and names it | tips keep the --env-file selector through command_tips.print_tip
+  Performance: one file read per command; no network
+  Errors: exit 2 for a bad name, a protected key (AGENT_CONFIG_PATH, provider record fields), a missing explicitly selected file, or a file that does not parse | exit 1 when `get`/`unset` names a setting that is not there | every failure names the next command
+"""
+
+import re
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from ...environment import (
+    PROVIDER_PREFIXES,
+    EnvironmentError,
+    display_path,
+    explicit_env_file,
+    process_environment,
+    provider_keys,
+    read_env_file,
+    selected_env_file,
+    selection_error,
+)
+from .command_tips import print_tip
+
+console = Console()
+
+# What a dotenv parser accepts as a key. Anything else would be written as a
+# line the next read refuses, and `co env` is the command that fixes those.
+_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# A value is masked when its name says it is a secret. Names are the only
+# signal available: an API key and a model name are both opaque strings.
+_SECRET_MARKERS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "PASSPHRASE", "PHRASE", "CREDENTIAL", "PRIVATE")
+
+_PROVIDER_AUTH = {"GOOGLE": "co auth google", "MICROSOFT": "co auth microsoft"}
+_PROVIDER_LABEL = {"GOOGLE": "Google", "MICROSOFT": "Microsoft"}
+
+
+def _provider_of(key: str) -> str | None:
+    """The provider whose account record this field belongs to, if any."""
+    return next((prefix for prefix in PROVIDER_PREFIXES if key in provider_keys(prefix)), None)
+
+
+def _is_secret(key: str) -> bool:
+    upper = key.upper()
+    return any(marker in upper for marker in _SECRET_MARKERS)
+
+
+def _mask(value: str) -> str:
+    """A fixed-width mask; the prefix identifies which key it is, not what it is."""
+    if len(value) <= 10:
+        return "*" * 8
+    return f"{value[:6]}…{'*' * 8}"
+
+
+def _file_label() -> str:
+    return "global" if explicit_env_file() is None else "selected with --env-file"
+
+
+def _fail(message: str, code: int) -> None:
+    print_tip(message)
+    raise typer.Exit(code)
+
+
+def _valid_name(key: str) -> None:
+    if not _NAME.match(key):
+        _fail(f"'{key}' is not a setting name: use letters, digits and underscores, "
+              "starting with a letter or underscore. Next: co env set <KEY> <value>", 2)
+
+
+def _writable_file() -> Path:
+    """The selected file, once it is safe to rewrite.
+
+    A missing file is fine to create. A file that does not parse is not
+    rewritten around the bad line: dropping that line silently is exactly the
+    kind of change nobody can explain afterwards.
+    """
+    error = selection_error()
+    path = selected_env_file()
+    if error is not None and path.exists():
+        print(str(error))
+        raise typer.Exit(2)
+    return path
+
+
+def handle_env_show(reveal: bool = False) -> None:
+    """Every setting in the selected file, where it wins or loses, and what to run next."""
+    path = selected_env_file()
+    error = selection_error()
+    print(f"Env file: {display_path(path)} ({_file_label()})")
+    if error is not None:
+        if error.line is not None:
+            print(f"✗ Invalid syntax on line {error.line}. Fix that line in an editor "
+                  "(it is not printed here: it may hold a secret), then check the file again.")
+            _fail("Next: co env", 2)
+        if not path.exists():
+            _fail("✗ Not found. Create it by saving the first setting. Next: co env set <KEY> <value>", 2)
+        _fail(str(error), 2)
+    if not path.exists():
+        print("✗ Not found. Global setup creates it together with the machine identity.")
+        _fail("Next: co init", 0)
+
+    values = read_env_file(path)
+    inherited = process_environment()
+    blocked = {prefix for prefix in PROVIDER_PREFIXES
+               if any(key in inherited for key in provider_keys(prefix))}
+    table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
+    table.add_column("SETTING")
+    table.add_column("VALUE")
+    table.add_column("SOURCE")
+    for key, value in values.items():
+        shown = value if reveal or not _is_secret(key) else _mask(value)
+        provider = _provider_of(key)
+        if key in inherited and inherited[key] != value:
+            source = "process overrides file"
+        elif provider in blocked:
+            source = f"file, ignored: the process supplies the {_PROVIDER_LABEL[provider]} record"
+        else:
+            source = "file"
+        table.add_row(key, shown, source)
+    for prefix in sorted(blocked):
+        for key in provider_keys(prefix):
+            if key in inherited and key not in values:
+                shown = inherited[key] if reveal or not _is_secret(key) else _mask(inherited[key])
+                table.add_row(key, shown, "process")
+    if values or blocked:
+        console.print(table)
+    else:
+        print("(no settings yet)")
+    if not reveal and any(_is_secret(key) for key in values):
+        print("Secrets are masked; add --reveal to see them. Keep --reveal out of shared logs.")
+    print_tip("Next: co env set <KEY> <value>")
+
+
+def handle_env_path() -> None:
+    """The selected file's path and nothing else, for $(co env path)."""
+    print(selected_env_file())
+
+
+def handle_env_get(key: str) -> None:
+    """The value a command would see: the process wins, then the file. Bare, for $(...)."""
+    _valid_name(key)
+    error = selection_error()
+    if error is not None:
+        print(str(error))
+        raise typer.Exit(2)
+    inherited = process_environment()
+    if key in inherited:
+        print(inherited[key])
+        return
+    path = selected_env_file()
+    values = read_env_file(path)
+    if key in values:
+        print(values[key])
+        return
+    _fail(f"{key} is not set in the process environment or {display_path(path)}. "
+          f"Next: co env set {key} <value>", 1)
+
+
+def handle_env_set(key: str, value: str) -> None:
+    """Save one setting to the selected file, preserving everything else in it."""
+    _valid_name(key)
+    if key == "AGENT_CONFIG_PATH":
+        _fail("AGENT_CONFIG_PATH chooses which global directory is read, so a file inside it "
+              "cannot set it. Export it in your shell instead:\n"
+              "  export AGENT_CONFIG_PATH=/path/to/.co\nNext: co env", 2)
+    provider = _provider_of(key)
+    if provider is not None:
+        auth = _PROVIDER_AUTH[provider]
+        _fail(f"{provider}_* account fields are written only by {auth}, as one record, so a single "
+              f"field can never describe a different account than the rest. Next: {auth}", 2)
+    path = _writable_file()
+    from ...env_file import upsert_env
+    try:
+        upsert_env(path, {key: value})
+    except EnvironmentError as error:
+        print(str(error))
+        raise typer.Exit(2)
+    print(f"✓ {key} saved to {display_path(path)}")
+    inherited = process_environment()
+    if key in inherited and inherited[key] != value:
+        print(f"! Your shell exports {key} with a different value, and process values win. "
+              f"Commands in this shell keep the shell's value until you run: unset {key}")
+    print_tip(f"Next: co env get {key}")
+
+
+def handle_env_unset(key: str) -> None:
+    """Remove one setting; a provider account field removes its whole record."""
+    _valid_name(key)
+    path = _writable_file()
+    if not path.exists():
+        _fail(f"{display_path(path)} does not exist, so there is nothing to remove. Next: co env", 1)
+    values = read_env_file(path)
+    from ...env_file import upsert_env
+    provider = _provider_of(key)
+    if provider is not None:
+        label, auth = _PROVIDER_LABEL[provider], _PROVIDER_AUTH[provider]
+        present = [name for name in provider_keys(provider) if name in values]
+        if not present:
+            _fail(f"No {label} account record in {display_path(path)}. Next: co env", 1)
+        upsert_env(path, {}, remove=set(provider_keys(provider)))
+        console.print(f"✓ Removed the {label} account record ({len(present)} fields) from "
+                      f"{display_path(path)}. Records are all-or-nothing: one field never outlives "
+                      "the rest to be mixed with another account.", markup=False)
+        print_tip(f"Next: {auth}")
+        return
+    if key not in values:
+        _fail(f"{key} is not in {display_path(path)}. Next: co env", 1)
+    upsert_env(path, {}, remove={key})
+    print(f"✓ {key} removed from {display_path(path)}")
+    # "Next: co env" alone measured as `cat ~/.co/keys.env` in the tip test;
+    # the tip must say why the command beats cat.
+    print_tip("Next: co env (lists what the file holds now, secrets masked)")

--- a/connectonion/cli/commands/env_commands.py
+++ b/connectonion/cli/commands/env_commands.py
@@ -2,19 +2,23 @@
 Purpose: `co env` — show, read, set and remove settings in the selected env file, and explain a broken one
 LLM-Note:
   Dependencies: imports from [re, pathlib, typer, rich, environment, env_file, command_tips] | imported by [cli/main.py via handle_env_*] | tested by [tests/unit/test_co_env.py]
-  Data flow: handle_env_show() → selected_env_file() + read_env_file() → one row per setting with a masked value and its source (file / process override / ignored provider record) | handle_env_get(key) → process value, else file value, printed bare for $(...) | handle_env_set(key, value) → name/record checks → env_file.upsert_env() (lock, atomic replace, 0600) | handle_env_unset(key) → upsert_env(remove=...) — a provider record field removes the whole record
-  State/Effects: reads and writes only the selected env file (global ~/.co/keys.env unless --env-file was given) | never rewrites a file that fails to parse | never prints a secret unless --reveal | never touches os.environ
+  Data flow: handle_env_show() → selected_env_file() + read_env_file() → one row per setting with a masked value and its source (file / process override / ignored provider record) | handle_env_get(key) → whole provider record, or process value then file for other keys, printed bare for $(...) | handle_env_set(key, value) → name/record checks → env_file.upsert_env() (lock, atomic replace, 0600) | handle_env_unset(key) → upsert_env(remove=...) — a provider record field removes the whole record
+  State/Effects: reads and writes only the selected env file (global ~/.co/keys.env unless --env-file was given) | never rewrites a file that fails to parse | overview hides all values unless --reveal; get explicitly prints one effective value | never touches os.environ
   Integration: the one command that still runs when the selected file is broken — every other command exits 2 and names it | tips keep the --env-file selector through command_tips.print_tip
   Performance: one file read per command; no network
   Errors: exit 2 for a bad name, a protected key (AGENT_CONFIG_PATH, provider record fields), a missing explicitly selected file, or a file that does not parse | exit 1 when `get`/`unset` names a setting that is not there | every failure names the next command
 """
 
 import re
+import json
 from pathlib import Path
 
 import typer
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
+
+from ... import environment
 
 from ...environment import (
     PROVIDER_PREFIXES,
@@ -35,10 +39,6 @@ console = Console()
 # line the next read refuses, and `co env` is the command that fixes those.
 _NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
-# A value is masked when its name says it is a secret. Names are the only
-# signal available: an API key and a model name are both opaque strings.
-_SECRET_MARKERS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "PASSPHRASE", "PHRASE", "CREDENTIAL", "PRIVATE")
-
 _PROVIDER_AUTH = {"GOOGLE": "co auth google", "MICROSOFT": "co auth microsoft"}
 _PROVIDER_LABEL = {"GOOGLE": "Google", "MICROSOFT": "Microsoft"}
 
@@ -46,18 +46,6 @@ _PROVIDER_LABEL = {"GOOGLE": "Google", "MICROSOFT": "Microsoft"}
 def _provider_of(key: str) -> str | None:
     """The provider whose account record this field belongs to, if any."""
     return next((prefix for prefix in PROVIDER_PREFIXES if key in provider_keys(prefix)), None)
-
-
-def _is_secret(key: str) -> bool:
-    upper = key.upper()
-    return any(marker in upper for marker in _SECRET_MARKERS)
-
-
-def _mask(value: str) -> str:
-    """A fixed-width mask; the prefix identifies which key it is, not what it is."""
-    if len(value) <= 10:
-        return "*" * 8
-    return f"{value[:6]}…{'*' * 8}"
 
 
 def _file_label() -> str:
@@ -90,10 +78,45 @@ def _writable_file() -> Path:
     return path
 
 
-def handle_env_show(reveal: bool = False) -> None:
+_PROCESS_PREFIXES = ('CO_', 'CONNECTONION_', 'OPENONION_', 'OPENAI_', 'ANTHROPIC_',
+                     'GEMINI_', 'GOOGLE_', 'MICROSOFT_')
+
+
+def environment_overview() -> dict:
+    """Describe the selected file and relevant process overrides without values."""
+    path = environment.selected_env_file()
+    values = environment.read_env_file(path, required=environment.explicit_env_file() is not None)
+    process = environment.process_environment()
+    blocked = {key for provider in environment.PROVIDER_PREFIXES
+               if any(key in process for key in environment.provider_keys(provider))
+               for key in environment.provider_keys(provider)}
+    names = set(values) | {key for key in process
+                           if key.startswith(_PROCESS_PREFIXES) or key == 'AGENT_CONFIG_PATH'}
+    rows = []
+    for key in sorted(names):
+        source = ('process' if key in process else 'ignored: process provider record'
+                  if key in blocked else 'file')
+        rows.append({'name':key, 'source':source, 'value':'[redacted]',
+                     'overrides_file':key in process and key in values})
+    return {'schema_version':1, 'mode':'explicit' if environment.explicit_env_file() else 'global',
+            'file':str(path), 'exists':path.is_file(), 'variables':rows,
+            'next_command':environment.selected_command('co status') if path.is_file() else 'co init'}
+
+
+
+def handle_env_show(reveal: bool = False, json_output: bool = False) -> None:
     """Every setting in the selected file, where it wins or loses, and what to run next."""
     path = selected_env_file()
     error = selection_error()
+    if json_output:
+        if reveal:
+            print(json.dumps({'schema_version':1,'ok':False,'error':'JSON values are always redacted; use show --reveal separately.'}))
+            raise typer.Exit(2)
+        if error is not None:
+            print(json.dumps({'schema_version':1,'ok':False,'error':str(error)}))
+            raise typer.Exit(2)
+        print(json.dumps(environment_overview()))
+        return
     print(f"Env file: {display_path(path)} ({_file_label()})")
     if error is not None:
         if error.line is not None:
@@ -109,33 +132,19 @@ def handle_env_show(reveal: bool = False) -> None:
 
     values = read_env_file(path)
     inherited = process_environment()
-    blocked = {prefix for prefix in PROVIDER_PREFIXES
-               if any(key in inherited for key in provider_keys(prefix))}
-    table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
-    table.add_column("SETTING")
-    table.add_column("VALUE")
-    table.add_column("SOURCE")
-    for key, value in values.items():
-        shown = value if reveal or not _is_secret(key) else _mask(value)
-        provider = _provider_of(key)
-        if key in inherited and inherited[key] != value:
-            source = "process overrides file"
-        elif provider in blocked:
-            source = f"file, ignored: the process supplies the {_PROVIDER_LABEL[provider]} record"
-        else:
-            source = "file"
-        table.add_row(key, shown, source)
-    for prefix in sorted(blocked):
-        for key in provider_keys(prefix):
-            if key in inherited and key not in values:
-                shown = inherited[key] if reveal or not _is_secret(key) else _mask(inherited[key])
-                table.add_row(key, shown, "process")
-    if values or blocked:
+    overview = environment_overview()
+    table = Table('SETTING', 'VALUE', 'SOURCE', box=None, pad_edge=False)
+    for row in overview['variables']:
+        key = row['name']
+        source = row['source'] + (' (overrides file)' if row['overrides_file'] else '')
+        value = inherited[key] if row['source'] == 'process' else values.get(key, '')
+        table.add_row(Text(key), Text(value if reveal else '[redacted]'), Text(source))
+    if overview['variables']:
         console.print(table)
     else:
-        print("(no settings yet)")
-    if not reveal and any(_is_secret(key) for key in values):
-        print("Secrets are masked; add --reveal to see them. Keep --reveal out of shared logs.")
+        print('(no settings yet)')
+    if not reveal:
+        print('All values are hidden; use show --reveal for full values. Keep revealed output out of shared logs.')
     print_tip("Next: co env set <KEY> <value>")
 
 
@@ -151,6 +160,15 @@ def handle_env_get(key: str) -> None:
     if error is not None:
         print(str(error))
         raise typer.Exit(2)
+    provider = _provider_of(key)
+    if provider is not None:
+        from ...provider_credentials import resolve_provider_credentials
+        record = resolve_provider_credentials(provider.lower())
+        if key in record.values:
+            print(record.values[key])
+            return
+        _fail(f"{key} is absent from the selected {provider.title()} record ({record.source}). "
+              f"Other account records are not merged. Next: {record.auth_command}", 1)
     inherited = process_environment()
     if key in inherited:
         print(inherited[key])

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -71,12 +71,18 @@ def version_callback(value: bool):
 
 
 def env_file_callback(ctx: typer.Context, value: Optional[Path]):
+    """Select the env file before any command runs.
+
+    A failure is recorded, not raised here: this eager callback runs before
+    Typer knows which command was asked for, and `co env` must still run on a
+    broken file — it is the command that says which line to fix. main() exits
+    for every other command.
+    """
     from ..environment import EnvironmentError, select_env_file
     try:
         select_env_file(value)
-    except EnvironmentError as error:
-        console.print(str(error), markup=False)
-        raise typer.Exit(2) from None
+    except EnvironmentError:
+        pass
     return value
 
 
@@ -88,6 +94,12 @@ def main(
         is_eager=True, help="Use this env file instead of global keys.env; put before the command. Process overrides win."),
 ):
     """ConnectOnion - A simple Python framework for creating AI agents."""
+    from ..environment import selection_error
+    error = selection_error()
+    if error is not None and ctx.invoked_subcommand != "env":
+        # Plain print: Rich would wrap the path and split the "Next:" tip.
+        print(error)
+        raise typer.Exit(2)
     if ctx.invoked_subcommand is None:
         _show_help()
 
@@ -130,6 +142,7 @@ def _show_help():
     console.print()
     console.print("[bold]Configuration:[/bold]")
     console.print("  Global by default: ~/.co/keys.env", markup=False)
+    console.print("  co env                           Show the settings in it; co env set <KEY> <value> saves one", markup=False)
     console.print("  co --env-file .env <command>     Use a project env file", markup=False)
     console.print()
     console.print("  co --help                       All commands", markup=False)
@@ -462,6 +475,54 @@ def announce(
 
 
 # Server command group — the machines `co deploy --to` can target
+env_app = _typer_app(help="Show, set and remove settings in the selected env file (global ~/.co/keys.env unless --env-file was given). Bare 'co env' shows them.")
+app.add_typer(env_app, name="env")
+
+
+@env_app.callback(invoke_without_command=True)
+def env_callback(ctx: typer.Context):
+    """Show, set and remove settings in the selected env file."""
+    if ctx.invoked_subcommand is None:
+        from .commands.env_commands import handle_env_show
+        handle_env_show(reveal=False)
+
+
+@env_app.command("show")
+def env_show(reveal: bool = typer.Option(False, "--reveal", "-r", help="Show full values instead of masked secrets")):
+    """List every setting with its value (secrets masked) and where it wins or loses."""
+    from .commands.env_commands import handle_env_show
+    handle_env_show(reveal=reveal)
+
+
+@env_app.command("path")
+def env_path():
+    """Print the selected env file's path and nothing else, for $(co env path)."""
+    from .commands.env_commands import handle_env_path
+    handle_env_path()
+
+
+@env_app.command("get")
+def env_get(key: str = typer.Argument(..., help="Setting name, e.g. OPENAI_API_KEY")):
+    """Print one value as a command would see it: the process wins, then the file."""
+    from .commands.env_commands import handle_env_get
+    handle_env_get(key)
+
+
+@env_app.command("set")
+def env_set(key: str = typer.Argument(..., help="Setting name, e.g. OPENAI_API_KEY"),
+            value: str = typer.Argument(..., help="Value; quote it if it has spaces")):
+    """Save one setting to the selected file, keeping every other line as it is."""
+    from .commands.env_commands import handle_env_set
+    handle_env_set(key, value)
+
+
+@env_app.command("unset")
+def env_unset(key: str = typer.Argument(..., help="Setting name; a GOOGLE_*/MICROSOFT_* account field removes the whole record")):
+    """Remove one setting from the selected file."""
+    from .commands.env_commands import handle_env_unset
+    handle_env_unset(key)
+
+
 server_app = _typer_app(help="Register, list and preflight the servers you can deploy to")
 app.add_typer(server_app, name="server")
 

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -480,18 +480,21 @@ app.add_typer(env_app, name="env")
 
 
 @env_app.callback(invoke_without_command=True)
-def env_callback(ctx: typer.Context):
+def env_callback(ctx: typer.Context, json_output: bool = typer.Option(False, "--json", help="Redacted configuration provenance as JSON")):
     """Show, set and remove settings in the selected env file."""
     if ctx.invoked_subcommand is None:
         from .commands.env_commands import handle_env_show
-        handle_env_show(reveal=False)
+        handle_env_show(reveal=False, json_output=json_output)
+    elif json_output:
+        raise typer.BadParameter("Put --json on bare co env or after env show.")
 
 
 @env_app.command("show")
-def env_show(reveal: bool = typer.Option(False, "--reveal", "-r", help="Show full values instead of masked secrets")):
-    """List every setting with its value (secrets masked) and where it wins or loses."""
+def env_show(reveal: bool = typer.Option(False, "--reveal", "-r", help="Show full values"),
+             json_output: bool = typer.Option(False, "--json", help="Redacted configuration provenance as JSON")):
+    """List setting sources; all values stay hidden unless --reveal is explicit."""
     from .commands.env_commands import handle_env_show
-    handle_env_show(reveal=reveal)
+    handle_env_show(reveal=reveal, json_output=json_output)
 
 
 @env_app.command("path")

--- a/connectonion/env_file.py
+++ b/connectonion/env_file.py
@@ -7,9 +7,7 @@ from pathlib import Path
 import tempfile
 import time
 
-from dotenv.parser import parse_stream
-
-from .environment import EnvironmentError
+from .environment import EnvironmentError, parse_env_file
 
 
 @contextmanager
@@ -56,17 +54,21 @@ def _encode(value: str) -> str:
 
 
 def write_env_unlocked(path: Path, updates: dict, *, strip_prefix: str | None = None,
-                       initial_comments: str = "") -> None:
-    """Replace a complete file atomically; callers must hold env_lock(path)."""
+                       initial_comments: str = "", remove: frozenset | set = frozenset()) -> None:
+    """Replace a complete file atomically; callers must hold env_lock(path).
+
+    `remove` names keys to drop. A broken file is never rewritten: the parse
+    error names the line, and rewriting around it would silently drop whatever
+    that line was meant to say.
+    """
     updates = {key: str(value) for key, value in updates.items() if value is not None}
     lines, found = ([] if path.exists() or not initial_comments else [initial_comments]), set()
     if path.exists():
-        with path.open(encoding="utf-8") as stream:
-            bindings = list(parse_stream(stream))
-        if any(item.error for item in bindings):
-            raise EnvironmentError("Invalid syntax in the selected env file. Next: co --help")
+        bindings = parse_env_file(path)
         for item in bindings:
             if strip_prefix and item.key and item.key.startswith(strip_prefix):
+                continue
+            if item.key in remove:
                 continue
             if item.key in updates:
                 if item.key not in found:
@@ -89,8 +91,9 @@ def write_env_unlocked(path: Path, updates: dict, *, strip_prefix: str | None = 
 
 
 def upsert_env(path: Path, updates: dict, *, strip_prefix: str | None = None,
-               initial_comments: str = "") -> None:
+               initial_comments: str = "", remove: frozenset | set = frozenset()) -> None:
     """Preserve unrelated settings, serialize updates and replace with mode 0600."""
     path = Path(path).resolve()
     with env_lock(path):
-        write_env_unlocked(path, updates, strip_prefix=strip_prefix, initial_comments=initial_comments)
+        write_env_unlocked(path, updates, strip_prefix=strip_prefix,
+                           initial_comments=initial_comments, remove=remove)

--- a/connectonion/environment.py
+++ b/connectonion/environment.py
@@ -17,10 +17,38 @@ PROVIDER_FIELDS = ("ACCESS_TOKEN", "REFRESH_TOKEN", "TOKEN_EXPIRES_AT", "SCOPES"
 PROVIDER_PREFIXES = ("GOOGLE", "MICROSOFT")
 _selected: Path | None = None
 _loaded: dict[str, str] = {}
+# A selection that failed at CLI startup. Every other command exits on it;
+# `co env` runs anyway, because it is the command that explains the failure.
+_selection_error: "EnvironmentError | None" = None
 
 
 class EnvironmentError(ValueError):
-    """A selected configuration file cannot be used (never includes its contents)."""
+    """A selected configuration file cannot be used (never includes its contents).
+
+    `path` and `line` are carried separately so `co env` can say which line to
+    fix without the message ever quoting what is on it — the broken line of a
+    credentials file is as likely as any other to hold a secret.
+    """
+
+    def __init__(self, message: str, *, path: Path | None = None, line: int | None = None):
+        super().__init__(message)
+        self.path = path
+        self.line = line
+
+
+def selection_error() -> "EnvironmentError | None":
+    return _selection_error
+
+
+def display_path(path: Path) -> str:
+    """The path as people write it: ~ for the home directory, otherwise absolute."""
+    resolved = Path(path).expanduser().resolve()
+    try:
+        # Both sides resolved: on macOS a temporary home is /var/... while the
+        # file resolves to /private/var/..., and the two never match otherwise.
+        return "~/" + resolved.relative_to(Path.home().resolve()).as_posix()
+    except ValueError:
+        return str(resolved)
 
 
 def global_config_dir() -> Path:
@@ -45,17 +73,42 @@ def selected_command(command: str) -> str:
     return command
 
 
-def read_env_file(path: Path, *, required: bool = False) -> dict[str, str]:
-    """Parse without logging dotenv contents or interpolating other accounts."""
-    if not path.exists() and not required:
-        return {}
+def parse_env_file(path: Path) -> list:
+    """Every binding in the file, or an EnvironmentError that names the first bad line.
+
+    The error's tip is `co env`: the one command that still runs on a broken
+    file, and the one that says which line to fix. It used to be `co --help`,
+    which lists commands and repairs nothing.
+    """
+    if not path.exists():
+        shown = display_path(path)
+        raise EnvironmentError(f"Selected env file does not exist: {shown}. "
+                               f"Next: {selected_command('co env set <KEY> <value>')} "
+                               "(creates it owner-only)", path=path)
     try:
         with path.open(encoding="utf-8") as stream:
             bindings = list(parse_stream(stream))
     except (OSError, UnicodeError):
-        raise EnvironmentError("Cannot read the selected env file. No configuration was changed. Run the following command to inspect --env-file before choosing a readable file:\nNext: co --help") from None
-    if any(binding.error for binding in bindings):
-        raise EnvironmentError("Invalid syntax in the selected env file. Next: co --help")
+        raise EnvironmentError(f"Cannot read {display_path(path)}. No configuration was changed. "
+                               f"Next: {selected_command('co env')}", path=path) from None
+    for binding in bindings:
+        if binding.error:
+            # Measured with the text-only tip test: "invalid syntax on line 2.
+            # Next: co env" made the model reply `cat -n ~/.co/keys.env`. The
+            # tip has to say what `co env` does that cat does not.
+            raise EnvironmentError(f"{display_path(path)}: invalid syntax on line "
+                                   f"{binding.original.line}. Do not cat this file into a log; "
+                                   f"it holds secrets. Next: {selected_command('co env')} "
+                                   "(explains the line without printing it)",
+                                   path=path, line=binding.original.line)
+    return bindings
+
+
+def read_env_file(path: Path, *, required: bool = False) -> dict[str, str]:
+    """Parse without logging dotenv contents or interpolating other accounts."""
+    if not path.exists() and not required:
+        return {}
+    bindings = parse_env_file(path)
     return {item.key: item.value for item in bindings if item.key and item.value is not None
             and item.key != "AGENT_CONFIG_PATH"}
 
@@ -104,15 +157,23 @@ def load_environment() -> None:
 
 
 def select_env_file(path: Path | None) -> None:
-    """Switch files before command execution, preserving only explicit overrides."""
-    global _selected
-    selected = path.expanduser().resolve() if path is not None else None
-    read_env_file(selected or global_config_dir() / "keys.env", required=selected is not None)
+    """Switch files before command execution, preserving only explicit overrides.
+
+    The selection is recorded before the file is read, so that when the read
+    fails, `co env` and every tip still name the file the user asked for.
+    """
+    global _selected, _selection_error
+    _selected = path.expanduser().resolve() if path is not None else None
+    _selection_error = None
+    try:
+        read_env_file(selected_env_file(), required=_selected is not None)
+    except EnvironmentError as error:
+        _selection_error = error
+        raise
     for key, value in _loaded.items():
         if os.environ.get(key) == value:
             os.environ.pop(key, None)
     _loaded.clear()
-    _selected = selected
     load_environment()
 
 

--- a/connectonion/provider_credentials.py
+++ b/connectonion/provider_credentials.py
@@ -48,9 +48,26 @@ class ProviderCredentials:
         selector = f" --env-file {shlex.quote(str(self.path))}" if self.path and explicit_env_file() else ""
         return f"co{selector} auth {self.provider}"
 
+    def where(self) -> str:
+        """Which source the record came from, as a person would name it.
+
+        "Not connected" used to be the whole message, and it sent people to
+        re-authorize an account they had connected an hour earlier — in the
+        other env file. Naming the source, and the command that shows it,
+        turns a wrong-file failure into a one-look diagnosis.
+        """
+        from .environment import display_path
+        if self.path is not None:
+            return f"in {display_path(self.path)}"
+        return "in the process environment, which supplies a partial record"
+
     def require_configured(self) -> None:
         if not (self.get("ACCESS_TOKEN") or self.get("REFRESH_TOKEN")):
-            raise ProviderCredentialError("not_configured", f"{self.provider.title()} account not connected.", self.auth_command)
+            raise ProviderCredentialError(
+                "not_configured",
+                f"{self.provider.title()} account not connected {self.where()}. "
+                "Run co env to see what that source holds and which values the shell overrides.",
+                self.auth_command)
 
 
 def resolve_provider_credentials(provider: str) -> ProviderCredentials:
@@ -143,7 +160,11 @@ def refresh_credentials(record: ProviderCredentials, *, backend: str, api_key: s
         else:
             refresh_token = latest.get("REFRESH_TOKEN")
             if not refresh_token:
-                raise ProviderCredentialError("incomplete_record", f"Local {record.provider.title()} refresh token missing.", record.auth_command)
+                raise ProviderCredentialError(
+                    "incomplete_record",
+                    f"Local {record.provider.title()} refresh token missing {record.where()}: "
+                    "the record is incomplete. Run co env to see which source supplies it.",
+                    record.auth_command)
             try:
                 response = post(f"{backend}/api/v1/oauth/{record.provider}/refresh",
                                 headers={"Authorization": f"Bearer {api_key}"},

--- a/connectonion/useful_skills/cli-skill-design/SKILL.md
+++ b/connectonion/useful_skills/cli-skill-design/SKILL.md
@@ -193,3 +193,8 @@ and writes use global `keys.env`. Keep process credentials separate from loaded
 file values and resolve provider fields as whole account records. Test fresh
 processes from root, nested and unrelated directories, including a project-only
 non-OAuth variable that must stay absent by default.
+
+A configuration failure names its source and `co env`, the command that shows
+the selected file and runs even when that file is broken: "not connected in
+~/.co/keys.env … Run co env …" then `Next: co auth google`. A tip that says
+"set X in keys.env" names no command; write `co env set X <value>`.

--- a/connectonion/useful_skills/co-env/SKILL.md
+++ b/connectonion/useful_skills/co-env/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: co-env
+description: See, set, remove and repair settings in the env file a `co` invocation selected — global ~/.co/keys.env by default, or the file named by `co --env-file PATH` — with `co env`. Use when a command says a key is missing, "Next: co env", "account not connected in <file>", or when the user asks which env file is in use or wants an API key saved.
+---
+
+# co env
+
+**Always read the output, not just the exit code.** `co env path` and
+`co env get` print a bare value and no tip, so they compose with `$(...)`;
+every other `co env` command ends with one `Next:` line.
+
+## Which command
+
+| You want to | Run |
+| --- | --- |
+| See which file is in use and what it holds (secrets masked) | `co env` |
+| See full values (never paste into shared logs) | `co env show --reveal` |
+| The file's path, for a script | `co env path` |
+| One value as a command would see it (process wins, then file) | `co env get KEY` |
+| Save a setting, creating the file if needed | `co env set KEY VALUE` |
+| Remove a setting | `co env unset KEY` |
+| Connect a Google / Microsoft account | `co auth google` / `co auth microsoft` — not `co env set` |
+| Disconnect one from this file | `co env unset GOOGLE_EMAIL` (removes the whole record) |
+| Do any of this on a project file | `co --env-file /abs/path/.env env …` (selector **before** `env`) |
+
+## The 80% commands
+
+```bash
+co env                                   # file, settings, sources, next step
+co env set OPENAI_API_KEY "$KEY"         # quote values; spaces are fine
+co env get MODEL                         # bare value
+co --env-file ./project.env env set MODEL co/gemini-3.7-flash
+```
+
+## Gotchas that change a result
+
+- **SOURCE column.** `process overrides file` means the shell exports the same
+  name; the file's value is not what commands see. `set` still saves it and
+  prints the `unset KEY` you need in the shell.
+- **Provider records are all-or-nothing.** `set` refuses the five `GOOGLE_*`
+  and five `MICROSOFT_*` account fields (exit 2, names the auth command).
+  `unset` on any one of them removes all of them and says so.
+- **`AGENT_CONFIG_PATH` cannot be set here.** It chooses which directory is
+  read; `set` refuses it and prints the shell `export` to use.
+- **A broken file stops everything else.** Any other command exits 2 with
+  `<file>: invalid syntax on line N. Next: co env`. `co env` still runs, repeats
+  the line number, never the line, and refuses `set` until the line is fixed
+  in an editor.
+- **Nothing here selects a file.** `co env` shows the file the invocation
+  already chose. To switch, put `--env-file` before the command.
+
+## Exit codes
+
+| exit | provoked by | next command (printed) |
+| --- | --- | --- |
+| 0 | done; or the global file does not exist yet | `co env set <KEY> <value>` · `co env get KEY` · `co init` |
+| 1 | `get`/`unset` of a setting that is not there | `co env set KEY <value>` · `co env` |
+| 2 | bad name · `AGENT_CONFIG_PATH` · provider record field · missing `--env-file` target · file does not parse | `co env set <KEY> <value>` · shell `export …` · `co auth google|microsoft` · `co --env-file … env set …` · `co env` |

--- a/connectonion/useful_skills/co-env/SKILL.md
+++ b/connectonion/useful_skills/co-env/SKILL.md
@@ -7,16 +7,16 @@ description: See, set, remove and repair settings in the env file a `co` invocat
 
 **Always read the output, not just the exit code.** `co env path` and
 `co env get` print a bare value and no tip, so they compose with `$(...)`;
-every other `co env` command ends with one `Next:` line.
+other human-output commands end with one `Next:` line. JSON output contains its next command as a field.
 
 ## Which command
 
 | You want to | Run |
 | --- | --- |
-| See which file is in use and what it holds (secrets masked) | `co env` |
+| See which file is in use and what it holds (all values hidden) | `co env` |
 | See full values (never paste into shared logs) | `co env show --reveal` |
 | The file's path, for a script | `co env path` |
-| One value as a command would see it (process wins, then file) | `co env get KEY` |
+| One value as a command would see it (whole provider record, otherwise process then file) | `co env get KEY` |
 | Save a setting, creating the file if needed | `co env set KEY VALUE` |
 | Remove a setting | `co env unset KEY` |
 | Connect a Google / Microsoft account | `co auth google` / `co auth microsoft` — not `co env set` |
@@ -34,7 +34,7 @@ co --env-file ./project.env env set MODEL co/gemini-3.7-flash
 
 ## Gotchas that change a result
 
-- **SOURCE column.** `process overrides file` means the shell exports the same
+- **SOURCE column.** `process (overrides file)` means the shell exports the same
   name; the file's value is not what commands see. `set` still saves it and
   prints the `unset KEY` you need in the shell.
 - **Provider records are all-or-nothing.** `set` refuses the five `GOOGLE_*`
@@ -56,3 +56,5 @@ co --env-file ./project.env env set MODEL co/gemini-3.7-flash
 | 0 | done; or the global file does not exist yet | `co env set <KEY> <value>` · `co env get KEY` · `co init` |
 | 1 | `get`/`unset` of a setting that is not there | `co env set KEY <value>` · `co env` |
 | 2 | bad name · `AGENT_CONFIG_PATH` · provider record field · missing `--env-file` target · file does not parse | `co env set <KEY> <value>` · shell `export …` · `co auth google|microsoft` · `co --env-file … env set …` · `co env` |
+
+`co env --json` and `co env show --json` return redacted provenance. JSON values are always hidden. Default human output also hides every value, including custom names and credential-bearing URLs; only `show --reveal` displays them. `get` explicitly returns one effective value and respects whole Google/Microsoft records: it never fills a missing process field from another account in the file.

--- a/connectonion/useful_skills/co-google/SKILL.md
+++ b/connectonion/useful_skills/co-google/SKILL.md
@@ -9,7 +9,9 @@ Global `keys.env` is the default for every setting and account. To use a project
 file, put `--env-file` before the command: `co --env-file /absolute/path/.env gmail
 inbox`. Auth and refresh use that selected file. No project env loads implicitly;
 process overrides remain explicit and provider fields are kept as whole records.
-See `docs/cli/environment.md` for migration and error recovery.
+`co env` (same selector) shows which file is in use and what it holds — run it
+first when a command says "not connected in <file>". See
+`docs/cli/environment.md` for migration and error recovery.
 
 
 # Google tools

--- a/connectonion/useful_skills/co-mail-and-drive/SKILL.md
+++ b/connectonion/useful_skills/co-mail-and-drive/SKILL.md
@@ -9,7 +9,9 @@ Global `keys.env` is the default for every setting and account. To use a project
 file, put `--env-file` before the command: `co --env-file /absolute/path/.env gmail
 inbox`. Auth and refresh use that selected file. No project env loads implicitly;
 process overrides remain explicit and provider fields are kept as whole records.
-See `docs/cli/environment.md` for migration and error recovery.
+`co env` (same selector) shows which file is in use, what it holds and which
+values the shell overrides — run it first when a command says "not connected in
+<file>". See `docs/cli/environment.md` for migration and error recovery.
 
 
 # co gmail / co outlook / co email / co gdrive
@@ -335,7 +337,7 @@ The printed messages carry the current recovery step — trust them over this ta
 When a command says the account is not connected:
 
 ```
-❌ Google account not connected     → co auth google
+❌ Google account not connected in <file> → co env shows that file; then co auth google
 ❌ Gmail permission missing         → co auth google      (re-consent)
 ❌ Gmail draft permission missing   → co auth google      (re-consent)
 ❌ Google Drive permission missing  → co auth google      (re-consent)

--- a/connectonion/useful_skills/install-connectonion/SKILL.md
+++ b/connectonion/useful_skills/install-connectonion/SKILL.md
@@ -131,10 +131,11 @@ co doctor        # cross-platform health check; "API Key" line should be ✓
 ```
 
 **Optional — own provider keys instead of managed:** if the person would rather use their
-own OpenAI/Anthropic/Google account, add the key to global `~/.co/keys.env` by default,
-or to an explicitly selected project's `.env`, with the
-`write`/`edit` tool (never echo it back): `OPENAI_API_KEY=…` (`gpt-*`),
-`ANTHROPIC_API_KEY=…` (`claude-*`), `GEMINI_API_KEY=…` (`gemini-*`). Plain init does not
+own OpenAI/Anthropic/Google account, save the key with `co env set` (never echo it back):
+`co env set OPENAI_API_KEY …` (`gpt-*`), `co env set ANTHROPIC_API_KEY …` (`claude-*`),
+`co env set GEMINI_API_KEY …` (`gemini-*`). That writes global `~/.co/keys.env`; put
+`co --env-file /abs/path/.env` before `env set` for a project file. `co env` shows what
+the selected file holds, secrets masked. Plain init does not
 copy implicitly loaded project or process keys into global storage; `--key` is
 an explicit request to save a provider key. Managed `co/*` still
 needs `OPENONION_API_KEY` from Step 3.

--- a/docs/blog/2026-09-08-the-command-that-had-to-run-on-a-broken-file.md
+++ b/docs/blog/2026-09-08-the-command-that-had-to-run-on-a-broken-file.md
@@ -1,0 +1,73 @@
+# The Command That Had to Run on a Broken File
+
+Draft for 1.8.4; publish after release acceptance.
+
+The owner asked a simple question: do we have `co env`? He remembered one.
+Issue #1444 had even told the implementer to audit and reuse it. The audit
+found nothing: there had never been a `co env`. What existed after #1450 was a
+root option, `co --env-file PATH`, that chose which file a command read. Nothing
+showed what that file held, and nothing edited it.
+
+That gap had a shape. `co doctor` reported a missing OpenAI key and, in the
+column that is supposed to name the fix, said "set OPENAI_API_KEY in global
+keys.env". That is an instruction, not a command. A person has to find the file;
+an agent driving the CLI through a shell invents a command and pays a round
+trip for it. The mail commands did the same thing in a subtler way: "Google
+account not connected. Next: co auth google". People ran the auth again. The
+account had been connected an hour earlier — in the other file, the one this
+invocation had not selected. The message never said which file it read.
+
+Then there was the case I reproduced before writing any code. Put one bad line
+in `~/.co/keys.env` — a pasted key with a stray quote, a note without an equals
+sign — and every `co` command stops with exit 2 and `Next: co --help`. Help lists
+thirty commands. None of them opens the file. `import connectonion` raised the
+same message from package startup, so an `agent.py` died with a traceback that
+pointed at a help screen.
+
+So `co env` had one obvious job, showing and setting values, and one job that
+turned out to be the real design constraint: it had to run on the file that
+nothing else could use. That is where the first attempt broke. The env file is
+selected in an eager Typer callback, because it must happen before any command
+loads settings. Eager callbacks run before the parser knows which command was
+asked for. The same check that stopped `co gmail` on a broken file stopped
+`co env`, the command meant to explain it. I could not exempt one command from
+inside a callback that did not yet know the command's name.
+
+The fix was to stop deciding there. The callback now records the failure and
+returns; the group callback, which does know the subcommand, exits for every
+command except `env`. `co env` reads the recorded error and prints the line
+number. It never prints the line, because in a credentials file the broken line
+is as likely as any other to hold a secret. It also refuses to `set` anything
+while the file fails to parse: rewriting around a bad line drops that line
+silently, and that is precisely the kind of change nobody can explain later.
+
+The second constraint came from the fix that had just landed. #1450 made
+provider credentials whole records, so a token from one account could not be
+stitched to the email of another. A `co env set GOOGLE_ACCESS_TOKEN …` would
+reopen that hole by hand. So `set` refuses the ten record fields and names the
+auth command instead, and `unset` on any one of them removes the whole record
+and says so. That last part is also the first supported way to disconnect an
+account from a file.
+
+Everything else followed from those two decisions. The doctor's column now
+reads `co env set OPENAI_API_KEY <key>`. The provider errors name the file they
+read, or say that the process supplied a partial record, and point at `co env`
+before their `Next: co auth …` line. The startup message became
+`~/.co/keys.env: invalid syntax on line 2. Next: co env`, and running that
+command tells you what to do.
+
+What I measured: the new test file has 31 cases, written before the command
+existed and red until it did. The two existing contract tests that had pinned
+`co --help` as the recovery were changed on purpose and say why. The full unit
+suite passed with 8,014 tests, and the CLI e2e suite with 435; the one e2e
+failure is a pre-existing case that shells out to whichever `co` is on PATH,
+which on this machine is a different install. The text-only tip test from the
+CLI design skill was run per command, twelve cases, and it earned its keep:
+the first run scored 10 of 12, and both misses were a model answering `cat`
+on the credentials file. The tips now say what `co env` does that `cat` does
+not, and the rerun scored 12 of 12. Its table is in the pull request.
+
+The lesson is small and I will forget it without writing it down: a tip is only
+a tip if the command it names can run in the state the error describes. `co
+--help` was reachable and useless. `co env` was useful and, until the callback
+moved, unreachable.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -389,6 +389,26 @@ The CLI wraps the same `Outlook` tool your agents use. See
 
 ---
 
+#### `co env` - See, Set and Repair the Selected Env File
+
+Works on global `~/.co/keys.env`, or on the file chosen with `co --env-file PATH`.
+
+```bash
+co env                              # every setting, secrets masked, with its source
+co env get MODEL                    # one value, bare, for $(...)
+co env set OPENAI_API_KEY sk-...    # save one setting (creates the file if needed)
+co env unset OPENAI_API_KEY         # remove one setting
+co env path                         # the selected file's path
+co --env-file ./project.env env     # the same on a project file
+```
+
+- Secrets (`*KEY*`, `*TOKEN*`, `*SECRET*`, …) are masked; `co env show --reveal` prints them.
+- `GOOGLE_*` / `MICROSOFT_*` account fields are refused by `set` and removed as a whole record by `unset`; use `co auth google` / `co auth microsoft` to connect an account.
+- `AGENT_CONFIG_PATH` cannot live in the file it selects; `export` it in your shell.
+- When the file has a broken line, every other `co` command exits 2 and says `Next: co env`; `co env` names the line to fix (never its contents).
+
+Full reference: [env.md](env.md).
+
 #### `co status` - Check Credentials, Account, and Deployments
 
 Shows redacted provider credential availability and source paths, followed by your

--- a/docs/cli/env.md
+++ b/docs/cli/env.md
@@ -6,7 +6,8 @@ global `~/.co/keys.env` by default, or the file named by `co --env-file PATH`
 and it never touches your shell's variables.
 
 ```bash
-co env                              # every setting, secrets masked, with its source
+co env                              # every setting, all values hidden, with its source
+co env --json                       # redacted sources as JSON
 co env show --reveal                # the same with full values (keep out of shared logs)
 co env path                         # the selected file's path, bare, for $(co env path)
 co env get OPENAI_API_KEY           # one value, bare, as a command would see it
@@ -20,10 +21,10 @@ co --env-file ./project.env env     # the same commands on a project file
 ```
 Env file: ~/.co/keys.env (global)
 SETTING             VALUE               SOURCE
-OPENONION_API_KEY   eyJhbG…********     file
-MODEL               co/gemini-3.7-flash process overrides file
-GOOGLE_EMAIL        me@example.test     file, ignored: the process supplies the Google record
-Secrets are masked; add --reveal to see them. Keep --reveal out of shared logs.
+OPENONION_API_KEY    [redacted]          file
+MODEL               [redacted]          process (overrides file)
+GOOGLE_EMAIL        [redacted]          ignored: process provider record
+All values are hidden; use show --reveal for full values.
 Next: co env set <KEY> <value>
 ```
 
@@ -31,9 +32,13 @@ Next: co env set <KEY> <value>
   shell exports the same name with a different value, and process values win.
   `ignored` marks a provider record the file holds while the shell supplies
   another one; records are used whole, never merged (see #1444).
-- Values are masked when the name says secret: `KEY`, `TOKEN`, `SECRET`,
-  `PASSWORD`, `PHRASE`, `CREDENTIAL`, `PRIVATE`. An email or a model name shows
-  in full.
+- Every value is `[redacted]` by default, including custom names, passwords and
+  URLs that contain credentials. `show --reveal` explicitly displays full values.
+- `co env --json` and `co env show --json` expose redacted provenance, including
+  process-only provider/ConnectOnion settings. JSON cannot be combined with `--reveal`.
+- `get` explicitly prints one effective value. Google/Microsoft fields come
+  from the same whole record as provider commands. A missing field in a process
+  record does not fall back to another account in the file; it exits 1.
 - The file is read as-is; nothing is loaded into the process.
 
 ## `set` and `unset` rules

--- a/docs/cli/env.md
+++ b/docs/cli/env.md
@@ -1,0 +1,91 @@
+# `co env` — see, set and repair the selected env file
+
+Added in 1.8.4. `co env` works on whichever env file this invocation selected:
+global `~/.co/keys.env` by default, or the file named by `co --env-file PATH`
+(see [Environment selection](environment.md)). It never selects a file itself,
+and it never touches your shell's variables.
+
+```bash
+co env                              # every setting, secrets masked, with its source
+co env show --reveal                # the same with full values (keep out of shared logs)
+co env path                         # the selected file's path, bare, for $(co env path)
+co env get OPENAI_API_KEY           # one value, bare, as a command would see it
+co env set OPENAI_API_KEY sk-...    # save one setting; creates the file if needed
+co env unset OPENAI_API_KEY         # remove one setting
+co --env-file ./project.env env     # the same commands on a project file
+```
+
+## What `co env` shows
+
+```
+Env file: ~/.co/keys.env (global)
+SETTING             VALUE               SOURCE
+OPENONION_API_KEY   eyJhbG…********     file
+MODEL               co/gemini-3.7-flash process overrides file
+GOOGLE_EMAIL        me@example.test     file, ignored: the process supplies the Google record
+Secrets are masked; add --reveal to see them. Keep --reveal out of shared logs.
+Next: co env set <KEY> <value>
+```
+
+- **SOURCE** says whether a setting wins. `process overrides file` means your
+  shell exports the same name with a different value, and process values win.
+  `ignored` marks a provider record the file holds while the shell supplies
+  another one; records are used whole, never merged (see #1444).
+- Values are masked when the name says secret: `KEY`, `TOKEN`, `SECRET`,
+  `PASSWORD`, `PHRASE`, `CREDENTIAL`, `PRIVATE`. An email or a model name shows
+  in full.
+- The file is read as-is; nothing is loaded into the process.
+
+## `set` and `unset` rules
+
+`co env set` rewrites the file atomically under the same lock that provider
+refresh uses, keeps every comment and unrelated line, quotes values with
+spaces, and leaves the file owner-only (`0600`) on Unix. Existing keys are
+replaced in place; new ones are appended.
+
+Three names are refused, each with the command to use instead:
+
+| Name | Why | Use instead |
+| --- | --- | --- |
+| `AGENT_CONFIG_PATH` | It chooses which global directory is read, so a file inside that directory cannot set it | `export AGENT_CONFIG_PATH=/path/to/.co` in your shell |
+| `GOOGLE_ACCESS_TOKEN`, `GOOGLE_REFRESH_TOKEN`, `GOOGLE_TOKEN_EXPIRES_AT`, `GOOGLE_SCOPES`, `GOOGLE_EMAIL` | An account record is written as a whole; one edited field could describe a different account than the rest | `co auth google` |
+| The same five `MICROSOFT_*` fields | Same rule | `co auth microsoft` |
+
+`co env unset` on any one of those record fields removes the **whole** record,
+and says so. That is the supported way to disconnect an account from a file.
+
+If your shell exports the name you just set, `set` still saves it and then
+tells you the shell's value will keep winning until you `unset` it there.
+
+## A broken file
+
+One malformed line in `~/.co/keys.env` — a pasted key with a stray quote, a
+line without `=` — stops every `co` command with exit 2:
+
+```
+~/.co/keys.env: invalid syntax on line 7. Next: co env
+```
+
+`co env` is the one command that still runs on that file. It repeats the line
+number (never the line's contents, which may be a secret) and exits 2 until
+the line is fixed in an editor. `co env set` refuses to rewrite a file it
+cannot parse, so the broken line is never silently dropped.
+
+## Exit codes
+
+| Exit | Meaning | Next command (printed) |
+| --- | --- | --- |
+| 0 | Done | `co env set <KEY> <value>`, `co env get <KEY>`, or `co init` when the global file does not exist yet |
+| 1 | `get` or `unset` named a setting that is not there | `co env set <KEY> <value>` / `co env` |
+| 2 | Bad name, protected name, missing explicitly selected file, or a file that does not parse | The command named in the message: `co env`, `co env set …`, `co auth google`, or a shell `export` |
+
+`co env path` and `co env get` print only the value so they compose with
+`$(...)`; they are the two commands that print no `Next:` line.
+
+## Where else the selected file shows up
+
+`co status`, `co doctor` and `co keys` inspect the same selected sources and
+name `co env set …` as the fix for a missing provider key. `co gmail`,
+`co gdrive`, `co gcalendar`, `co youtube`, `co outlook` and their SDK clients
+say which file (or that the process) supplied an incomplete account record,
+and point at `co env` before asking you to re-authorize.

--- a/docs/cli/environment.md
+++ b/docs/cli/environment.md
@@ -119,3 +119,5 @@ sources. Default diagnostics show source/state, never token values. Keep
 incomplete record, names the source it read and points at `co env` before its
 `Next: co auth …` line. This document describes the implementation branch, not
 a published 1.8.4.
+
+The environment overview hides all values by default; `co env --json` exposes the same redacted sources for scripts. `co env get` follows whole-record provider selection rather than filling missing account fields from another source.

--- a/docs/cli/environment.md
+++ b/docs/cli/environment.md
@@ -21,8 +21,25 @@ co --env-file /path/to/project/.env status
 
 The selected file replaces the global env file; there is no per-key fallback.
 Missing, unreadable or malformed explicitly selected files fail with exit 2
-before the command runs. Relative paths are relative to the invocation's working
-directory. Absolute paths give the same selection from any directory.
+before the command runs — except `co env`, which runs on any selected file so
+it can name the missing file or the broken line. Relative paths are relative
+to the invocation's working directory. Absolute paths give the same selection
+from any directory.
+
+## Seeing and editing the selected file
+
+`co env` shows what the selected file holds, which of its values the shell
+overrides, and which provider record is ignored because the process supplies
+another. `co env set KEY VALUE` and `co env unset KEY` edit it in place, under
+the same lock provider refresh uses. Provider account fields are refused by
+`set` and removed as a whole record by `unset`, so a record can never be edited
+into describing two accounts. See [`co env`](env.md).
+
+```sh
+co env                                  # global ~/.co/keys.env
+co --env-file /path/to/project/.env env # the project file, same selector rule
+co env set OPENAI_API_KEY sk-...
+```
 
 Inherited process variables take precedence over file settings. For Google and
 Microsoft, supplying any access-token, refresh-token, expiry, scope or email
@@ -65,8 +82,9 @@ initialization remain available.
 ## Migration from 1.8.3
 
 PRs #1381/#1382 implemented canonical **project-first** loading. The 1.8.4 change
-intentionally replaces that policy. No `co env` command existed in the reviewed
-mainline history; `--env-file` is the single CLI selector added here.
+intentionally replaces that policy. `--env-file` is the single CLI selector.
+No `co env` command existed before 1.8.4; the one added in 1.8.4 shows and
+edits whichever file the selector chose, and never selects a file itself.
 
 Applications importing `connectonion` now load only global settings. To keep an
 application's project-specific environment, explicitly load its file in your own
@@ -89,12 +107,15 @@ selects a project file; update the deployment command to select it explicitly.
 
 | Failure | Exit | Next command |
 | --- | --- | --- |
-| Invalid explicitly selected file | 2 | `co --help` |
+| Selected file missing, unreadable or malformed | 2 | `co env` with the same selector: it names the broken line, or `co env set` creates a missing file |
 | Provider not configured or explicitly revoked | 1 | `co auth google` or `co auth microsoft`, with the same selector |
 | OpenOnion broker key missing/rejected | 1 | `co auth` |
 | Network/provider failure, invalid refresh response, concurrent account change | 1 | `co status`, then retry the intended read |
 | Actual Google/Graph permission denial | 1 | The provider auth command printed by the failing operation |
 
-`co status`, `co doctor` and `co keys` inspect the same selected sources. Default
-diagnostics show source/state, never token values. Keep `--reveal` out of shared
-logs. This document describes the implementation branch, not a published 1.8.4.
+`co env`, `co status`, `co doctor` and `co keys` inspect the same selected
+sources. Default diagnostics show source/state, never token values. Keep
+`--reveal` out of shared logs. A provider command that finds no token, or an
+incomplete record, names the source it read and points at `co env` before its
+`Next: co auth …` line. This document describes the implementation branch, not
+a published 1.8.4.

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -94,6 +94,8 @@ co init ./ --yes --template co-ai
 ```
 
 Global setup scripts can keep `co init --yes`. `co create` is unchanged.
-At runtime, explicit process variables take precedence over the selected
-project's `.env`, which takes precedence over global `~/.co/keys.env`.
+At runtime, explicit process variables take precedence over the selected env
+file, which is global `~/.co/keys.env` unless `co --env-file PATH` names a
+project file; there is no per-key fallback between files. `co env` shows what
+the selected file holds and `co env set` edits it.
 See [CLI reference](README.md) for authentication and credential diagnostics.

--- a/docs/releases/1.8.4.md
+++ b/docs/releases/1.8.4.md
@@ -10,6 +10,12 @@ checks and remaining acceptance are tracked in the
 - Global settings and provider credential records follow the explicitly selected
   source across authentication, refresh and diagnostics. Working directory no
   longer silently selects a project `.env` or changes accounts.
+- `co env` shows, sets and removes settings in the selected env file, masks
+  secrets, says which values the shell overrides, and refuses to edit provider
+  account records field by field. A broken line in `keys.env` now stops other
+  commands with `Next: co env` and a line number instead of `co --help`;
+  `co doctor` and the provider commands name `co env set …` / `co env` as the
+  fix instead of describing the file.
 - Gmail lists have frozen account-bound row contexts. Mailbox actions and incoming
   attachments use bounded JSON, truthful failures and private, collision-safe
   downloads. `unanswered` means the latest non-draft message is incoming.

--- a/tests/unit/test_co_env.py
+++ b/tests/unit/test_co_env.py
@@ -51,7 +51,7 @@ class TestShow:
         result = run(["env"], home)
         assert result.exit_code == 0, result.output
         assert "keys.env" in result.output
-        assert "MODEL" in result.output and "co/gemini-3.7-flash" in result.output
+        assert "MODEL" in result.output and "co/gemini-3.7-flash" not in result.output
         assert "sk-secret-1234567890abcdef" not in result.output
         assert "Next: co env set" in result.output
 
@@ -264,3 +264,45 @@ def test_doctor_actions_all_name_a_command():
     from connectonion.cli.commands.doctor_commands import CREDENTIAL_ACTIONS
     for credential, action in CREDENTIAL_ACTIONS.items():
         assert action.startswith("co "), f"{credential}: {action!r} names no command"
+
+
+@pytest.mark.parametrize('key', ['SMTP_PASS','DATABASE_URL','CUSTOM_VALUE','MODEL'])
+def test_overview_hides_all_values_until_explicit_reveal(home, keys_env, key):
+    keys_env.write_text(f'{key}=synthetic-sensitive-value\n')
+    result=run(['env'],home)
+    assert result.exit_code == 0
+    assert 'synthetic-sensitive-value' not in result.output
+    assert '[redacted]' in result.output
+    assert 'synthetic-sensitive-value' in run(['env','show','--reveal'],home).output
+
+
+@pytest.mark.parametrize('provider', ['GOOGLE','MICROSOFT'])
+def test_get_never_merges_a_file_field_into_a_process_account(home, keys_env, provider):
+    keys_env.write_text(f'{provider}_REFRESH_TOKEN=account-a-refresh\n')
+    result=run(['env','get',f'{provider}_REFRESH_TOKEN'],home,
+               environ={f'{provider}_ACCESS_TOKEN':'account-b-access'})
+    assert result.exit_code == 1
+    assert 'account-a-refresh' not in result.output
+    assert 'process' in result.output
+    assert f'co auth {provider.lower()}' in result.output
+
+
+def test_json_overview_includes_process_only_keys_and_no_values(home, keys_env):
+    import json
+    result=run(['env','--json'],home,environ={'OPENAI_API_KEY':'process-secret'})
+    assert result.exit_code == 0,result.output
+    data=json.loads(result.stdout)
+    rows={row['name']:row for row in data['variables']}
+    assert rows['OPENAI_API_KEY']['source'] == 'process'
+    assert all(row['value']=='[redacted]' for row in rows.values())
+    assert 'process-secret' not in result.stdout
+
+
+def test_json_overview_marks_whole_record_exclusion(home, keys_env):
+    import json
+    keys_env.write_text('GOOGLE_REFRESH_TOKEN=file-refresh\n')
+    result=run(['env','show','--json'],home,environ={'GOOGLE_ACCESS_TOKEN':'process-token'})
+    assert result.exit_code == 0,result.output
+    data=json.loads(result.stdout)
+    row=next(r for r in data['variables'] if r['name']=='GOOGLE_REFRESH_TOKEN')
+    assert row['source']=='ignored: process provider record'

--- a/tests/unit/test_co_env.py
+++ b/tests/unit/test_co_env.py
@@ -1,0 +1,266 @@
+"""`co env` is the one place to see, set and repair the selected env file.
+
+Before it existed, the selected file could only be edited by hand, `co doctor`
+told people to "set OPENAI_API_KEY in global keys.env" without naming a command,
+and a single broken line in ~/.co/keys.env made every `co` command exit 2 with
+"Next: co --help" — a tip that cannot repair anything.
+"""
+
+import os
+import shlex
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from connectonion import environment
+from connectonion.cli.main import app
+
+
+def run(args, home, *, env_file=None, environ=None):
+    """Invoke `co` in-process with an isolated home; never the developer's own keys.env."""
+    process = {"HOME": str(home), "USERPROFILE": str(home), **(environ or {})}
+    with patch.dict(os.environ, process, clear=True), \
+         patch.object(Path, "home", return_value=home), \
+         patch.object(environment, "_loaded", {}), \
+         patch.object(environment, "_selected", None), \
+         patch.object(environment, "_selection_error", None):
+        argv = (["--env-file", str(env_file)] if env_file else []) + args
+        return CliRunner().invoke(app, argv, prog_name="co")
+
+
+@pytest.fixture
+def home(tmp_path):
+    home = tmp_path / "home"
+    (home / ".co").mkdir(parents=True)
+    return home
+
+
+@pytest.fixture
+def keys_env(home):
+    path = home / ".co" / "keys.env"
+    path.write_text("# Managed keys\nOPENONION_API_KEY=sk-secret-1234567890abcdef\nMODEL=co/gemini-3.7-flash\n")
+    return path
+
+
+class TestShow:
+    def test_bare_env_names_the_file_and_masks_secrets(self, home, keys_env):
+        result = run(["env"], home)
+        assert result.exit_code == 0, result.output
+        assert "keys.env" in result.output
+        assert "MODEL" in result.output and "co/gemini-3.7-flash" in result.output
+        assert "sk-secret-1234567890abcdef" not in result.output
+        assert "Next: co env set" in result.output
+
+    def test_reveal_prints_full_values(self, home, keys_env):
+        result = run(["env", "show", "--reveal"], home)
+        assert result.exit_code == 0, result.output
+        assert "sk-secret-1234567890abcdef" in result.output
+
+    def test_process_override_is_labelled(self, home, keys_env):
+        result = run(["env"], home, environ={"MODEL": "from-shell"})
+        assert result.exit_code == 0, result.output
+        assert "overrides" in result.output
+
+    def test_missing_global_file_points_at_init(self, home):
+        result = run(["env"], home)
+        assert result.exit_code == 0, result.output
+        assert "not found" in result.output.lower()
+        assert "Next: co init" in result.output
+
+    def test_help_lists_every_subcommand(self, home):
+        result = run(["env", "--help"], home)
+        assert result.exit_code == 0
+        for name in ("show", "path", "get", "set", "unset"):
+            assert name in result.output
+
+
+class TestPathAndGet:
+    def test_path_prints_only_the_path(self, home, keys_env):
+        result = run(["env", "path"], home)
+        assert result.exit_code == 0
+        assert result.output.strip() == str(keys_env.resolve())
+
+    def test_get_prints_only_the_value(self, home, keys_env):
+        result = run(["env", "get", "MODEL"], home)
+        assert result.exit_code == 0
+        assert result.output.strip() == "co/gemini-3.7-flash"
+
+    def test_get_prefers_the_process_value(self, home, keys_env):
+        result = run(["env", "get", "MODEL"], home, environ={"MODEL": "from-shell"})
+        assert result.output.strip() == "from-shell"
+
+    def test_get_missing_exits_1_and_names_set(self, home, keys_env):
+        result = run(["env", "get", "NOPE"], home)
+        assert result.exit_code == 1
+        assert "Next: co env set NOPE <value>" in result.output
+
+
+class TestSet:
+    def test_set_appends_and_preserves_comments(self, home, keys_env):
+        result = run(["env", "set", "OPENAI_API_KEY", "sk-new"], home)
+        assert result.exit_code == 0, result.output
+        text = keys_env.read_text()
+        assert text.startswith("# Managed keys\n")
+        assert "OPENAI_API_KEY=sk-new\n" in text
+        assert "MODEL=co/gemini-3.7-flash\n" in text
+        assert "Next: co env get OPENAI_API_KEY" in result.output
+
+    def test_set_replaces_in_place(self, home, keys_env):
+        run(["env", "set", "MODEL", "co/other"], home)
+        lines = keys_env.read_text().splitlines()
+        assert lines.count("MODEL=co/other") == 1
+        assert not any(line.startswith("MODEL=co/gemini") for line in lines)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions")
+    def test_set_creates_the_global_file_owner_only(self, home):
+        result = run(["env", "set", "MODEL", "co/x"], home)
+        assert result.exit_code == 0, result.output
+        path = home / ".co" / "keys.env"
+        assert path.read_text() == "MODEL=co/x\n"
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    def test_set_quotes_values_with_spaces(self, home, keys_env):
+        run(["env", "set", "GREETING", "hello world"], home)
+        assert run(["env", "get", "GREETING"], home).output.strip() == "hello world"
+
+    def test_set_rejects_a_bad_name(self, home, keys_env):
+        result = run(["env", "set", "not-a-name", "x"], home)
+        assert result.exit_code == 2
+        assert "Next: co env set <KEY> <value>" in result.output
+        assert "not-a-name" not in keys_env.read_text()
+
+    def test_set_refuses_agent_config_path(self, home, keys_env):
+        result = run(["env", "set", "AGENT_CONFIG_PATH", "/elsewhere"], home)
+        assert result.exit_code == 2
+        assert "export AGENT_CONFIG_PATH" in result.output
+        assert "AGENT_CONFIG_PATH" not in keys_env.read_text()
+
+    @pytest.mark.parametrize("key,auth", [("GOOGLE_ACCESS_TOKEN", "co auth google"),
+                                          ("MICROSOFT_EMAIL", "co auth microsoft")])
+    def test_set_refuses_provider_record_fields(self, home, keys_env, key, auth):
+        result = run(["env", "set", key, "x"], home)
+        assert result.exit_code == 2
+        assert f"Next: {auth}" in result.output
+        assert key not in keys_env.read_text()
+
+    def test_set_warns_when_the_shell_overrides_it(self, home, keys_env):
+        result = run(["env", "set", "MODEL", "co/other"], home, environ={"MODEL": "from-shell"})
+        assert result.exit_code == 0, result.output
+        assert "MODEL=co/other" in keys_env.read_text()
+        assert "unset MODEL" in result.output
+
+
+class TestUnset:
+    def test_unset_removes_the_line(self, home, keys_env):
+        result = run(["env", "unset", "MODEL"], home)
+        assert result.exit_code == 0, result.output
+        assert "MODEL" not in keys_env.read_text()
+        assert "OPENONION_API_KEY" in keys_env.read_text()
+        assert "Next: co env" in result.output
+
+    def test_unset_missing_exits_1(self, home, keys_env):
+        result = run(["env", "unset", "NOPE"], home)
+        assert result.exit_code == 1
+        assert "Next: co env" in result.output
+
+    def test_unset_a_provider_field_removes_the_whole_record(self, home, keys_env):
+        keys_env.write_text("GOOGLE_API_KEY=gemini\nGOOGLE_ACCESS_TOKEN=a\nGOOGLE_REFRESH_TOKEN=r\n"
+                            "GOOGLE_EMAIL=me@example.test\nGOOGLE_SCOPES=gmail\n")
+        result = run(["env", "unset", "GOOGLE_EMAIL"], home)
+        assert result.exit_code == 0, result.output
+        text = keys_env.read_text()
+        assert text == "GOOGLE_API_KEY=gemini\n"
+        assert "Next: co auth google" in result.output
+
+
+class TestExplicitFile:
+    def test_missing_selected_file_env_names_set(self, home, tmp_path):
+        target = tmp_path / "project.env"
+        result = run(["env"], home, env_file=target)
+        assert result.exit_code == 2, result.output
+        assert f"Next: co --env-file {shlex.quote(str(target.resolve()))} env set" in result.output
+
+    def test_set_creates_the_selected_file(self, home, tmp_path):
+        target = tmp_path / "project.env"
+        result = run(["env", "set", "MODEL", "co/x"], home, env_file=target)
+        assert result.exit_code == 0, result.output
+        assert target.read_text() == "MODEL=co/x\n"
+        assert f"Next: co --env-file {shlex.quote(str(target.resolve()))} env get MODEL" in result.output
+
+    def test_set_never_touches_the_global_file(self, home, keys_env, tmp_path):
+        target = tmp_path / "project.env"
+        before = keys_env.read_text()
+        run(["env", "set", "MODEL", "co/x"], home, env_file=target)
+        assert keys_env.read_text() == before
+
+    def test_path_prints_the_selected_file(self, home, keys_env, tmp_path):
+        target = tmp_path / "project.env"
+        target.write_text("A=1\n")
+        assert run(["env", "path"], home, env_file=target).output.strip() == str(target.resolve())
+
+
+class TestBrokenFile:
+    @pytest.fixture
+    def broken(self, home):
+        path = home / ".co" / "keys.env"
+        path.write_text("A=1\nthis line is broken\nB=2\n")
+        return path
+
+    def test_env_names_the_broken_line(self, home, broken):
+        result = run(["env"], home)
+        assert result.exit_code == 2, result.output
+        assert "line 2" in result.output
+        assert "keys.env" in result.output
+        assert "Next: co env" in result.output
+        assert "this line is broken" not in result.output
+
+    def test_other_commands_exit_2_and_name_co_env(self, home, broken):
+        result = run(["keys"], home)
+        assert result.exit_code == 2, result.output
+        assert "line 2" in result.output
+        assert "Next: co env" in result.output
+
+    def test_set_refuses_to_rewrite_a_broken_file(self, home, broken):
+        before = broken.read_text()
+        result = run(["env", "set", "C", "3"], home)
+        assert result.exit_code == 2
+        assert broken.read_text() == before
+
+
+class TestProviderFailuresPointAtEnv:
+    """`co gmail` / `co outlook` used to say only "not connected" — and people
+    re-authorized an account that was connected all along, in the other file."""
+
+    def failure(self, home, environ=None) -> str:
+        """The message a Google client raises, resolved and checked inside the isolated home."""
+        from connectonion.provider_credentials import resolve_provider_credentials
+        process = {"HOME": str(home), "USERPROFILE": str(home), **(environ or {})}
+        with patch.dict(os.environ, process, clear=True), \
+             patch.object(Path, "home", return_value=home), \
+             patch.object(environment, "_loaded", {}), \
+             patch.object(environment, "_selected", None):
+            with pytest.raises(ValueError) as exc:
+                resolve_provider_credentials("google").require_configured()
+            return str(exc.value)
+
+    def test_a_file_without_a_token_names_the_file_and_co_env(self, home, keys_env):
+        keys_env.write_text("GOOGLE_EMAIL=me@example.test\n")
+        text = self.failure(home)
+        assert "Google account not connected in ~/.co/keys.env" in text
+        assert "co env" in text
+        assert text.endswith("Next: co auth google")
+
+    def test_a_partial_process_record_says_so(self, home, keys_env):
+        text = self.failure(home, environ={"GOOGLE_EMAIL": "shell@example.test"})
+        assert "process environment" in text
+        assert "co env" in text
+
+
+def test_doctor_actions_all_name_a_command():
+    from connectonion.cli.commands.doctor_commands import CREDENTIAL_ACTIONS
+    for credential, action in CREDENTIAL_ACTIONS.items():
+        assert action.startswith("co "), f"{credential}: {action!r} names no command"

--- a/tests/unit/test_env_cli_discoverability.py
+++ b/tests/unit/test_env_cli_discoverability.py
@@ -18,7 +18,7 @@ CASES = [
     (["gcalendar", "list"], "Connect the Google account for this command", "auth google"),
     (["youtube", "channel"], "Connect the Google account for this command", "auth google"),
     (["outlook", "inbox"], "Connect the Microsoft account for this command", "auth microsoft"),
-    (["gmail", "inbox"], "Repair the selected env file configuration", None),
+    (["gmail", "inbox"], "Create the selected env file so the command can run", None),
     (["init"], "Initialize global configuration", "init"),
 ]
 
@@ -39,7 +39,10 @@ def capture(args, root, invalid=False):
 def test_selected_source_is_in_piped_recovery(args, goal, recovery, tmp_path):
     result = capture(args, tmp_path, invalid=recovery is None)
     assert result.exit_code == (2 if recovery in (None, "init") else 1), result.output
-    expected = ("co --help" if recovery is None else "co init" if recovery == "init"
+    # A missing selected file is created by saving its first setting; the tip
+    # used to be `co --help`, which lists commands and creates nothing.
+    expected = (f"co --env-file {shlex.quote(str(tmp_path / 'absent.env'))} env set" if recovery is None
+                else "co init" if recovery == "init"
                 else f"co --env-file {shlex.quote(str(tmp_path / 'test.env'))} {recovery}")
     assert expected in result.output, result.output
     assert "Traceback" not in result.output
@@ -51,7 +54,8 @@ if __name__ == "__main__":
         root = Path(directory).resolve()
         for args, goal, recovery in CASES:
             result = capture(args, root, invalid=recovery is None)
-            expected = ("co --help" if recovery is None else "co init" if recovery == "init"
+            expected = (f"co --env-file {shlex.quote(str(root / 'absent.env'))} env set" if recovery is None
+                        else "co init" if recovery == "init"
                         else f"co --env-file {shlex.quote(str(root / 'test.env'))} {recovery}")
             reply = llm_do(f"You just ran a shell command. Its full output was:\n\n{result.output}\n\n"
                            f"Your goal: {goal}. Reply with ONE shell command and nothing else.",

--- a/tests/unit/test_global_env_contract.py
+++ b/tests/unit/test_global_env_contract.py
@@ -109,8 +109,11 @@ def test_custom_global_path_ignores_routing_inside_env(layout):
 def test_invalid_explicit_file_fails_before_command(layout, name):
     result = probe(layout, layout[2], selected=layout[1] / name)
     assert result.returncode == 2
-    assert "co --help" in result.stderr + result.stdout
-    assert "global-token" not in result.stderr + result.stdout
+    # The tip keeps the selector and names `co env`, the command that runs on
+    # a file nothing else can use — not `co --help`, which repairs nothing.
+    output = result.stderr + result.stdout
+    assert f"Next: co --env-file {layout[1] / name} env" in output
+    assert "global-token" not in output
 
 
 def test_malformed_explicit_file_does_not_print_credentials(layout):
@@ -118,7 +121,7 @@ def test_malformed_explicit_file_does_not_print_credentials(layout):
     path.write_text('GOOGLE_ACCESS_TOKEN="secret-unclosed\n')
     result = probe(layout, layout[2], selected=path)
     assert result.returncode == 2
-    assert "Invalid syntax" in result.stdout + result.stderr
+    assert "invalid syntax on line 1" in result.stdout + result.stderr
     assert "secret-unclosed" not in result.stdout + result.stderr
     assert "global-token" not in result.stdout + result.stderr
 

--- a/tests/unit/test_global_env_contract.py
+++ b/tests/unit/test_global_env_contract.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shlex
 from pathlib import Path
 import subprocess
 import sys
@@ -112,7 +113,8 @@ def test_invalid_explicit_file_fails_before_command(layout, name):
     # The tip keeps the selector and names `co env`, the command that runs on
     # a file nothing else can use — not `co --help`, which repairs nothing.
     output = result.stderr + result.stdout
-    assert f"Next: co --env-file {layout[1] / name} env" in output
+    selector = shlex.quote(str((layout[1] / name).resolve()))
+    assert f"Next: co --env-file {selector} env" in output
     assert "global-token" not in output
 
 


### PR DESCRIPTION
## Description

Add `co env` to inspect, set, remove and repair settings in the selected env file: global `~/.co/keys.env`, or an explicit `--env-file`. A broken file identifies its line without printing its contents; other commands point to this inspection flow.

The overview hides **all values** by default, including custom names and URLs containing credentials. `show --reveal` explicitly reveals values. `co env --json` and `co env show --json` return redacted provenance, including relevant process-only settings, and cannot be combined with `--reveal`.

`get KEY` explicitly prints one effective value for scripting. Google/Microsoft fields use the same whole-account resolver as provider commands: a partial process record never borrows another account's refresh token from the file. Other keys retain process-over-file precedence. `set` refuses individual provider-account fields; `unset` removes their whole record. Writes preserve unrelated lines, use the existing lock and atomic replace, and create owner-only files.

Includes credential-source diagnostics, actionable doctor tips, docs and skill routing. Unifies the prior local read-only env work here so the separate NAS patch can merge without a competing env implementation.

Refs #1444 and #1445. Built on merged #1450.

## Labels and target release

- **Suggested labels:** feature, tests, documentation
- **Proposed target version:** 1.8.4
- **Estimated release window:** next coordinated 1.8.4 preview after review and current CI
- **Forward-port tracking issue (stable patches only):** N/A — mainline work

## Testing

```
pytest tests/unit/test_co_env.py tests/unit/test_global_env_contract.py tests/unit/test_env_cli_discoverability.py -q
59 passed

pytest tests/ -n 4 --dist loadfile -m "not slow and not real_api and not network" -q
8589 passed, 22 skipped, 6 warnings in 71.74s
```

Eight new review regressions failed before the fix. They cover default privacy for arbitrary names, both provider record families, process-only keys and redacted JSON. The full run uses the checkout's package and an isolated test configuration, not the user's keys. Current remote CI still determines platform readiness.

The earlier implementation measured 12/12 output-only next-command cases with co/gemini-3.7-flash. That is historical evidence; the new JSON/privacy boundary tests are deterministic regressions, not a new model evaluation. No live provider calls were needed for these fixes.

## Dev Blog

`docs/blog/2026-09-08-the-command-that-had-to-run-on-a-broken-file.md`

## Limitations

Explicit `get` and `show --reveal` print full values and must be kept out of shared logs. No docs-site publication or package release occurs in this PR. Windows validation comes from CI; local validation used Python 3.14 on macOS.
