### PR TITLE
fix(syno): verify sharing settings before returning links

### DIFF
--- a/connectonion/cli/commands/synology_commands.py
+++ b/connectonion/cli/commands/synology_commands.py
@@ -128,6 +128,8 @@ def emit(operation: str, result=None, error=None, *, options: dict | None = None
         next_step=next_command(operation,result or {},options)
     elif error['code'] in {'auth_required','auth_failed','otp_required','otp_rejected','not_configured'}:
         next_step=shlex.join(['co','syno','login']+(['--name',options['nas']] if options.get('nas') else []))
+    elif operation=='share create' and error['code'] in {'submission_unknown','share_verification_failed'}:
+        next_step=shlex.join(['co','syno']+(['--nas',options['nas']] if options.get('nas') else [])+['share','list'])
     elif error['code'] in {'stale_cursor','listing_required','invalid_reference'}:
         next_step=shlex.join(['co','syno']+(['--nas',options['nas']] if options.get('nas') else [])+['ls'])
     else:

--- a/connectonion/useful_tools/synology_sharing.py
+++ b/connectonion/useful_tools/synology_sharing.py
@@ -19,7 +19,7 @@ class SharingMixin:
     @staticmethod
     def _share_dict(item: dict, show_url: bool = False) -> dict:
         result={'id':link_id(item.get('id')), 'path':nas_path(item.get('path'),root=False),
-                'expires':None if item.get('date_expired') in {None,0,'0'} else item['date_expired'],
+                'expires':None if item.get('date_expired') in (None,0,'0','') else item['date_expired'],
                 'protected':item.get('has_password'),'status':item.get('status'),'nas_timezone':None}
         if show_url:
             url = item.get('url')
@@ -53,10 +53,35 @@ class SharingMixin:
         links=data.get('links')
         if not isinstance(links,list) or len(links)!=1 or links[0].get('error') not in {0,None}:
             raise SynologyError('DSM did not confirm sharing-link creation; inspect existing links before retrying.', 'submission_unknown')
-        item={**links[0],'date_expired':expires or '0','has_password':password is not None}
+        item=links[0]
         if item.get('path')!=path:
             raise SynologyError('DSM returned a different sharing path; inspect links before retrying.', 'submission_unknown')
-        return {**self._share_dict(item,True),'dry_run':False}
+        return self._verify_created_share(link_id(item.get('id')),path,expires,password is not None)
+
+    def _verify_created_share(self, identifier: str, path: str, expires: str | None, protected: bool) -> dict:
+        try:
+            item=self._request('SYNO.FileStation.Sharing','getinfo',version=3,id=json.dumps(identifier))
+        except SynologyError:
+            raise SynologyError('The link was created but its protection could not be verified. Inspect co syno share list before retrying.', 'submission_unknown') from None
+        if item.get('id')!=identifier or item.get('path')!=path:
+            raise SynologyError('The created link identity could not be verified. Inspect co syno share list before retrying.', 'submission_unknown')
+        expiry=item.get('date_expired')
+        expiry_day=expiry.split(' ',1)[0] if isinstance(expiry,str) else expiry
+        matches=('date_expired' in item and not isinstance(expiry,bool)
+                 and (expiry_day==expires if expires else expiry in (None,0,'0','')))
+        if item.get('has_password') is not protected or not matches:
+            try:
+                cleanup=self._request('SYNO.FileStation.Sharing','delete',version=3,id=[identifier])
+                if cleanup.get('errors'):
+                    raise SynologyError('Revocation failed','revoke_failed')
+            except SynologyError:
+                raise SynologyError('Link protection differs from the request and revocation is unconfirmed. Inspect co syno share list.', 'submission_unknown') from None
+            raise SynologyError('The new link was revoked because its password or expiry did not match the request.', 'share_verification_failed')
+        try:
+            result=self._share_dict(item,True)
+        except SynologyError:
+            raise SynologyError('The link was created but its URL could not be verified. Inspect co syno share list before retrying.', 'submission_unknown') from None
+        return {**result,'dry_run':False,'settings_verified':True}
 
     @command_budget
     def share_list(self, *, limit: int = 20, cursor: str | None = None, show_url: bool = False) -> dict:

--- a/docs/blog/2026-09-07-the-request-ended-the-copy-did-not.md
+++ b/docs/blog/2026-09-07-the-request-ended-the-copy-did-not.md
@@ -99,3 +99,23 @@ Implementation details and current evidence are recorded in the
 [Synology decision](../design-decisions/070-synology-inspections-and-durable-operations.md)
 and [acceptance record](../acceptance/1.8.4-synology.md). This is a candidate
 implementation, not a package release announcement.
+
+## A returned link was not proof of its settings
+
+A sharing regression exposed the same boundary. Its fake NAS accepted a create
+request, then returned a link with password protection disabled. The client had
+been filling the result from the request, so it could describe protection that
+the returned link did not have.
+
+Creation now reads the link back before returning it. The regression supplies a
+matching link ID and path but the wrong protection flag. The client revokes only
+that identified new link and reports a failure. If the identity does not match,
+it cannot safely choose a link to revoke. If readback or cleanup is uncertain,
+it names that uncertainty and asks for inspection before another create call.
+
+The fixtures also distinguish a missing expiry field from an explicit no-expiry
+value. Empty-string and zero sentinels normalize to no expiry; missing metadata
+cannot certify the requested settings. A settings check still cannot prove that
+a browser enforces a password or that an in-flight download stops on revocation.
+Those are separate acceptance questions, just as a returned task ID is separate
+from a completed copy.

--- a/docs/cli/synology.md
+++ b/docs/cli/synology.md
@@ -136,7 +136,8 @@ canonical options. New help examples and recovery commands use canonical names.
 
 ## Listings and search
 
-`ls` now sorts by name ascending, replacing the historical modified-time order.
+`ls` requests DSM name-ascending order, replacing the historical modified-time
+order. DSM can group directories before files; pagination preserves that order.
 Directories have `size: null`; an empty file has `size: 0`. Machine output keeps
 complete paths. Live directory/link pages can change between requests; they
 are not immutable snapshots.
@@ -241,7 +242,15 @@ are prompted with `--password` or read from one line with `--password-stdin`.
 The negotiated v3 contract accepts at most 16 characters; no truncation or
 silent weakening occurs.
 
-Creation returns its usable URL. Inventory hides bearer URLs unless `--show-url`
+Creation reads the new link back from DSM and checks its identity, password
+protection flag and expiry date before returning its URL with
+`settings_verified: true`. The expiry includes DSM's returned time, when present.
+If settings differ, the CLI attempts to revoke only that newly identified link
+and reports a failure. Uncertain readback or revocation requires inspecting
+`co syno share list` before retrying; it never silently creates another link.
+This settings check does not replace testing access through the sharing page.
+
+Inventory hides bearer URLs unless `--show-url`
 is given, and includes ID/path/expiry/protection/provider status. Revocation
 requires confirmation or `--yes` and never deletes the source. There is no
 public file-delete or service-control command in this core.
@@ -264,3 +273,11 @@ Read the result as well as the exit code. Missing authentication, unsupported
 sources, stale cursors, conflicts, incomplete searches and uncertain writes
 have distinct error codes. Empty results never suggest downloading a nonexistent
 first row.
+
+For opt-in command acceptance, run `scripts/acceptance/synology_release.py` with
+the candidate's Python and explicit `--nas`, `--parent`, and
+`--allow-fixture-writes`. Add `--allow-test-share` only when synthetic sharing
+links are wanted. The script creates a unique fixture directory, checks command
+results and transfer bytes, then removes its own files and links. It retains the
+owner login. Reports may contain local test paths and should be reviewed before
+sharing. No real-device reports are included in this change.

--- a/scripts/acceptance/synology_release.py
+++ b/scripts/acceptance/synology_release.py
@@ -1,0 +1,228 @@
+"""Opt-in installed-CLI NAS acceptance using only an owned disposable directory.
+
+Run with the installed candidate's Python. Existing files and login are retained.
+SNMP/SSH absence is recorded as unavailable, never promoted to a health pass.
+"""
+import argparse
+from datetime import date, timedelta
+import json
+from pathlib import Path
+import os
+import subprocess
+import sys
+import tempfile
+import uuid
+
+
+class Journey:
+    def __init__(self, nas, parent, local):
+        self.nas, self.local = nas, local
+        self.root = parent.rstrip('/') + '/.co-acceptance-' + uuid.uuid4().hex
+        self.created = self.sharing_attempted = False
+        self.report = {'passed':False, 'checks':[], 'cleanup':[], 'unverified':[]}
+
+    def cli(self, name, *args, error=None, partial=False, stdin=None):
+        command = [sys.executable, '-m', 'connectonion.cli.main', 'syno', '--nas', self.nas,
+                   '--timeout', '90', *args, '--json']
+        child = subprocess.run(command, cwd=self.local, capture_output=True, text=True,
+                               input=stdin, timeout=120,
+                               env={k:v for k,v in os.environ.items() if k != 'PYTHONPATH'})
+        try:
+            result = json.loads(child.stdout)
+        except ValueError:
+            raise AssertionError(name + ': expected one JSON result') from None
+        assert result.get('schema_version') == 1, name
+        assert result.get('next_command', '').startswith('co syno'), name
+        actual = (result.get('error') or {}).get('code')
+        if error:
+            passed = child.returncode in {1,2} and actual == error
+        elif partial:
+            passed = child.returncode in {0,1} and result.get('error') is None
+        else:
+            passed = child.returncode == 0 and result.get('ok') is True
+        self.report['checks'].append({'name':name, 'passed':passed, 'exit':child.returncode,
+                                      'error_code':actual})
+        print(name + ': ' + ('PASS' if passed else 'FAIL'), file=sys.stderr, flush=True)
+        assert passed, name + ': ' + str(actual)
+        return result.get('data') or {}
+
+    def inspect(self):
+        profiles = self.cli('profile inventory', 'nas', 'list')
+        assert any(p['name'] == self.nas for p in profiles['items'])
+        status = self.cli('aggregate status', 'status', '--refresh', partial=True)
+        assert status['checks']['connectivity']['data']['authenticated'] is True
+        for name, args in [('network', ('network','status')), ('storage', ('storage','status')),
+                           ('disks', ('storage','disks')), ('services', ('service','list'))]:
+            check = status['checks'][name]
+            if check.get('error',{}).get('code') == 'source_not_configured':
+                self.cli(name + ' unavailable', *args, error='source_not_configured')
+                self.report['unverified'].append(name + ': optional source not configured')
+            else:
+                self.cli(name + ' inspection', *args, partial=True)
+        self.cli('share roots', 'ls')
+        self.report['unverified'].append('logout: retained owner login; covered by isolated regressions')
+
+    def transfer(self):
+        root, local = self.root, self.local
+        tree = local/'tree'; (tree/'nested').mkdir(parents=True)
+        (tree/'empty.bin').write_bytes(b'')
+        (tree/'hello world.txt').write_bytes(b'synthetic NAS fixture\n')
+        (tree/'nested'/'unicode-\u4e2d.bin').write_bytes(bytes(range(256))*3)
+        self.cli('mkdir', 'mkdir', root); self.created = True
+        self.cli('mkdir parents', 'mkdir', root+'/deep/child', '--parents')
+        self.cli('mkdir dry run', 'mkdir', root+'/dry-dir', '--dry-run')
+        self.cli('dry directory absent', 'info', root+'/dry-dir', error='not_found')
+        self.cli('upload recursive required', 'upload', str(tree), root, error='recursive_required')
+        self.cli('upload dry run', 'upload', str(tree), root, '--recursive', '--dry-run')
+        self.cli('dry upload absent', 'info', root+'/tree', error='not_found')
+        self.cli('recursive upload', 'upload', str(tree), root, '--recursive')
+        self.cli('upload conflict', 'upload', str(tree/'hello world.txt'), root+'/tree', error='conflict')
+        skip = self.cli('upload skip existing', 'upload', str(tree/'hello world.txt'), root+'/tree', '--skip-existing')
+        assert skip['skipped'] and not skip['completed']
+        (tree/'hello world.txt').write_bytes(b'updated synthetic fixture\n')
+        self.cli('upload overwrite', 'upload', str(tree/'hello world.txt'), root+'/tree', '--overwrite')
+        target = local/'download'; target.mkdir()
+        self.cli('download recursive required', 'download', root+'/tree', '--to', str(target), error='recursive_required')
+        self.cli('download dry run', 'download', root+'/tree', '--to', str(target), '--recursive', '--dry-run')
+        assert not list(target.iterdir())
+        self.cli('recursive download', 'download', root+'/tree', '--to', str(target), '--recursive')
+        assert file_bytes(tree) == file_bytes(target/'tree'), 'recursive bytes mismatch'
+        self.cli('download conflict', 'download', root+'/tree/hello world.txt', '--to', str(target/'tree'), error='conflict')
+        (target/'tree/hello world.txt').write_bytes(b'preserve local fixture')
+        self.cli('download skip existing', 'download', root+'/tree/hello world.txt', '--to', str(target/'tree'), '--skip-existing')
+        assert (target/'tree/hello world.txt').read_bytes() == b'preserve local fixture'
+        self.cli('download overwrite', 'download', root+'/tree/hello world.txt', '--to', str(target/'tree'), '--overwrite')
+        assert file_bytes(tree) == file_bytes(target/'tree')
+        self.report['checks'].append({'name':'all recursive file bytes incl empty/Unicode', 'passed':True})
+
+    def browse(self):
+        path = self.root+'/tree'
+        first = self.cli('listing page 1', 'ls', path, '--limit','1')
+        assert first['next_cursor']
+        items, cursor = list(first['items']), first['next_cursor']
+        self.cli('cursor parameter mismatch', 'ls', path, '--limit','2','--cursor',cursor,error='stale_cursor')
+        while cursor:
+            page = self.cli('listing next page', 'ls',path,'--limit','1','--cursor',cursor)
+            items += page['items']; cursor = page['next_cursor']
+        assert len({i['path'] for i in items}) == len(items) == 3
+        assert {i['name'] for i in items} == {'nested','empty.bin','hello world.txt'}, 'listing omitted or added a fixture'
+        whole = self.cli('listing pagination preserves provider order','ls',path,'--limit','1000')
+        assert items == whole['items'], 'paged listing differs from the complete fixture listing'
+        for kind in ('dir','file'):
+            names = [i['name'] for i in items if i['type'] == kind]
+            assert names == sorted(names), 'fixture names are not ascending within '+kind
+        self.report['listing_order'] = [i['name'] for i in items]
+        info = self.cli('empty file info', 'info',path+'/empty.bin'); assert info['size'] == 0
+        found = self.cli('plain search','search','hello','--in',path,'--type','file')
+        assert [i['path'] for i in found['items']] == [path+'/hello world.txt']
+        found = self.cli('glob search','search','*.bin','--glob','--in',path,'--type','file','--limit','1')
+        assert found['items'] and found['next_cursor']
+        self.cli('search next page','search','*.bin','--glob','--in',path,'--type','file','--limit','1','--cursor',found['next_cursor'])
+        self.cli('invalid path','info',self.root+'/../outside',error='invalid_path')
+        self.cli('invalid page size','ls',path,'--limit','0',error='usage_error')
+
+    def operation(self, name, *args):
+        result = self.cli(name,*args,partial=True)
+        for _ in range(8):
+            if result.get('status') == 'complete':
+                self.cli(name+' durable receipt','status','--operation',result['operation_id'],partial=True)
+                return
+            if result.get('status') == 'operation_pending':
+                result = self.cli(name+' poll','status','--operation',result['operation_id'],'--wait',partial=True)
+            elif result.get('status') == 'continuation_required':
+                result = self.cli(name+' resume',*args,partial=True)
+            else:
+                raise AssertionError(name+': '+str(result.get('status')))
+        raise AssertionError(name+': task did not complete within bounded polls')
+
+    def operations(self):
+        root = self.root; source = root+'/tree/hello world.txt'
+        self.cli('copy dry run','copy',source,root+'/copy.txt','--dry-run')
+        self.cli('dry copy absent','info',root+'/copy.txt',error='not_found')
+        self.operation('copy renamed cross folder','copy',source,root+'/copy.txt')
+        self.cli('copy collision','copy',source,root+'/copy.txt',error='conflict')
+        self.operation('copy explicit overwrite','copy',source,root+'/copy.txt','--overwrite')
+        self.operation('move renamed cross folder','move',root+'/copy.txt',root+'/deep/moved.txt')
+        self.cli('move removed source','info',root+'/copy.txt',error='not_found')
+        self.cli('move destination','info',root+'/deep/moved.txt')
+        self.operation('recursive copy','copy',root+'/tree',root+'/tree-copy','--recursive')
+        self.cli('self descendant rejected','copy',root+'/tree',root+'/tree/child','--recursive',error='path_conflict')
+
+    def sharing(self):
+        path = self.root+'/tree/hello world.txt'
+        tomorrow = (date.today()+timedelta(days=1)).isoformat()
+        self.cli('share dry run','share','create',path,'--expires',tomorrow,'--yes','--dry-run')
+        self.sharing_attempted = True
+        result = self.cli('protected share','share','create',path,'--expires',tomorrow,
+                          '--password-stdin','--yes',stdin=uuid.uuid4().hex[:16]+'\n')
+        assert result['protected'] is True
+        identifier = result['id']
+        links = self.links(); assert any(x['id'] == identifier for x in links)
+        self.cli('revoke dry run','share','revoke',identifier,'--yes','--dry-run')
+        assert any(x['id'] == identifier for x in self.links())
+        self.cli('share revoke','share','revoke',identifier,'--yes')
+        assert not any(x['id'] == identifier for x in self.links())
+
+    def links(self):
+        result, cursor = [], None
+        while True:
+            args = ('--cursor',cursor) if cursor else ()
+            page = self.cli('sharing inventory','share','list','--limit','1000',*args)
+            result += page['items']; cursor = page['next_cursor']
+            if not cursor:
+                return result
+
+    def cleanup(self):
+        from connectonion.useful_tools.synology import Synology
+        if not self.created:
+            return
+        if self.sharing_attempted:
+            for link in self.links():
+                if link['path'].startswith(self.root+'/'):
+                    self.cli('cleanup owned share','share','revoke',link['id'],'--yes')
+        client = Synology(nas=self.nas,timeout=90)
+        client.info(self.root)
+        result = client._request('SYNO.FileStation.Delete','delete',version=2,path=[self.root],recursive=True)
+        assert not result.get('errors')
+        assert client._maybe_info(self.root) is None
+        self.report['cleanup'].append({'owned_directory_removed':True})
+
+
+def file_bytes(root):
+    return {p.relative_to(root).as_posix():p.read_bytes() for p in root.rglob('*') if p.is_file()}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--nas',required=True)
+    parser.add_argument('--parent',required=True,help='An existing writable NAS directory, such as /home.')
+    parser.add_argument('--allow-fixture-writes',action='store_true')
+    parser.add_argument('--allow-test-share',action='store_true')
+    args = parser.parse_args()
+    if not args.allow_fixture_writes:
+        parser.error('Pass --allow-fixture-writes for disposable writes and exact cleanup.')
+    from connectonion.useful_tools.synology_files import nas_path
+    parent = nas_path(args.parent,root=False)
+    with tempfile.TemporaryDirectory(prefix='co-nas-acceptance-') as temporary:
+        journey = Journey(args.nas,parent,Path(temporary).resolve())
+        try:
+            journey.inspect(); journey.transfer(); journey.browse(); journey.operations()
+            if args.allow_test_share:
+                journey.sharing()
+            else:
+                journey.report['unverified'].append('sharing: opt-in flag omitted')
+            journey.report['passed'] = True
+        except Exception as error:
+            journey.report['failure'] = str(error)
+        finally:
+            try:
+                journey.cleanup()
+            except Exception as error:
+                journey.report['passed'] = False
+                journey.report['cleanup'].append({'failed':str(error),'owned_path':journey.root})
+        print(json.dumps(journey.report,indent=2))
+        return 0 if journey.report['passed'] else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/unit/test_synology_files.py
+++ b/tests/unit/test_synology_files.py
@@ -94,3 +94,32 @@ def test_mkdir_dry_run_plans_missing_directories_without_writes(nas):
     result = nas.mkdir('/home/docs/new/empty', parents=True, dry_run=True)
     assert result['create'] == ['/home/docs/new','/home/docs/new/empty']
     nas._request.assert_not_called()
+
+
+@pytest.mark.parametrize('entry', [
+    {'path':'/other/private','isdir':False},
+    {'path':'/home/sub/a','isdir':False},
+])
+def test_listing_refuses_provider_rows_outside_the_requested_directory(nas, entry):
+    nas._request.return_value={'total':1,'files':[entry]}
+    with pytest.raises(SynologyError) as error:
+        nas.list_page('/home')
+    assert error.value.code=='path_escape'
+
+
+def test_completed_search_does_not_publish_snapshot_if_cleanup_fails(nas):
+    nas._request.side_effect=[{'taskid':'task'}, {'finished':True,'total':0,'files':[]},
+                             SynologyError('Lost cleanup response','network_error')]
+    with pytest.raises(SynologyError) as error:
+        nas.search_page('missing','/home',poll_interval=0)
+    assert error.value.code=='cleanup_unconfirmed'
+    assert nas._request.call_args.args[1]=='clean'
+
+
+def test_search_preserves_primary_error_when_cleanup_also_fails(nas):
+    original=SynologyError('Search failed','permission_denied')
+    nas._request.side_effect=[{'taskid':'task'},original,SynologyError('Lost cleanup','network_error')]
+    with pytest.raises(SynologyError) as error:
+        nas.search_page('a','/home',poll_interval=0)
+    assert error.value is original
+    assert error.value.cleanup_error=='network_error'

--- a/tests/unit/test_synology_operations.py
+++ b/tests/unit/test_synology_operations.py
@@ -90,3 +90,12 @@ def test_self_descendant_and_missing_trailing_slash_are_rejected(nas):
     assert error.value.code=='path_conflict'
     with pytest.raises(SynologyError):
         nas.copy('/home/docs/a','/home/missing/')
+
+
+def test_failed_task_status_does_not_submit_another_copy(nas):
+    nas._request.side_effect=[{'taskid':'task'},SynologyError('Poll timeout','timeout')]
+    pending=nas.copy('/home/docs/a','/home/dest/')
+    nas._request=Mock(return_value={'finished':True,'errors':[{'code':402}]})
+    result=nas.operation_status(pending['operation_id'],wait=True)
+    assert result['status']=='operation_failed'
+    assert all(call.args[1]=='status' for call in nas._request.call_args_list)

--- a/tests/unit/test_synology_sharing.py
+++ b/tests/unit/test_synology_sharing.py
@@ -26,11 +26,17 @@ def test_create_requires_expiry_and_does_not_truncate_password(nas):
 
 
 def test_create_applies_exact_expiry_and_returns_only_its_url(nas):
-    nas._request.return_value = {'links':[{'id':'link','path':'/home/a','url':'https://nas.test/sharing/link','error':0}]}
+    nas._request.side_effect = [
+        {'links':[{'id':'link','path':'/home/a','url':'https://nas.test/sharing/link','error':0}]},
+        {'id':'link','path':'/home/a','url':'https://nas.test/sharing/link',
+         'has_password':True,'date_expired':'2026-09-30 23:59:59','status':'valid'},
+    ]
     result = nas.share_create('/home/a',expires='2026-09-30',password='safe-test')
     assert result['url']=='https://nas.test/sharing/link'
     assert result['nas_timezone'] is None
-    assert nas._request.call_args.kwargs['date_expired']=='"2026-09-30"'
+    assert nas._request.call_args_list[0].kwargs['date_expired']=='"2026-09-30"'
+    assert result['expires']=='2026-09-30 23:59:59'
+    assert nas._request.call_args_list[1].args[1]=='getinfo'
     assert 'safe-test' not in str(result)
 
 
@@ -57,3 +63,90 @@ def test_dry_run_does_not_create_or_revoke(nas):
     nas._request.return_value={'id':'link','path':'/home/a'}
     assert nas.share_revoke('link',dry_run=True)['dry_run']
     assert nas._request.call_args.args[1]=='getinfo'
+
+
+@pytest.mark.parametrize('changed', [{'has_password':False}, {'date_expired':'0'}])
+def test_create_rejects_and_revokes_a_link_with_wrong_protection(nas,changed):
+    info={'id':'link','path':'/home/a','url':'https://nas.test/sharing/link',
+          'has_password':True,'date_expired':'2026-09-30 23:59:59',**changed}
+    nas._request.side_effect=[{'links':[{'id':'link','path':'/home/a','url':info['url']}]},info,{}]
+    with pytest.raises(SynologyError) as error:
+        nas.share_create('/home/a',expires='2026-09-30',password='safe-test')
+    assert error.value.code=='share_verification_failed'
+    assert nas._request.call_args.args[1]=='delete'
+    assert nas._request.call_args.kwargs['id']==['link']
+
+
+def test_create_does_not_revoke_a_readback_from_another_path(nas):
+    nas._request.side_effect=[{'links':[{'id':'link','path':'/home/a','url':'https://nas.test/sharing/link'}]},
+                              {'id':'link','path':'/other/private','has_password':False,'date_expired':'0'}]
+    with pytest.raises(SynologyError) as error:
+        nas.share_create('/home/a',no_expiry=True,password='safe-test')
+    assert error.value.code=='submission_unknown'
+    assert [call.args[1] for call in nas._request.call_args_list]==['create','getinfo']
+
+
+def test_readback_failure_never_repeats_creation(nas):
+    nas._request.side_effect=[{'links':[{'id':'link','path':'/home/a','url':'https://nas.test/sharing/link'}]},
+                             SynologyError('Readback timed out','timeout')]
+    with pytest.raises(SynologyError) as error:
+        nas.share_create('/home/a',no_expiry=True)
+    assert error.value.code=='submission_unknown'
+    assert [call.args[1] for call in nas._request.call_args_list]==['create','getinfo']
+
+
+@pytest.mark.parametrize('expiry', [[], {}, ['0'], False])
+def test_malformed_no_expiry_readback_revokes_only_new_link(nas, expiry):
+    nas._request.side_effect = [
+        {'links':[{'id':'link','path':'/home/a'}]},
+        {'id':'link','path':'/home/a','has_password':False,'date_expired':expiry},
+        {},
+    ]
+    with pytest.raises(SynologyError) as error:
+        nas.share_create('/home/a',no_expiry=True)
+    assert error.value.code == 'share_verification_failed'
+    assert nas._request.call_args.kwargs['id'] == ['link']
+
+
+@pytest.mark.parametrize('cleanup', [{'errors':[{'code':105}]}, SynologyError('timeout','timeout')])
+def test_failed_protection_cleanup_never_claims_link_was_revoked(nas, cleanup):
+    nas._request.side_effect = [
+        {'links':[{'id':'link','path':'/home/a'}]},
+        {'id':'link','path':'/home/a','has_password':False,'date_expired':'0'},
+        cleanup,
+    ]
+    with pytest.raises(SynologyError) as error:
+        nas.share_create('/home/a',no_expiry=True,password='safe-test')
+    assert error.value.code == 'submission_unknown'
+    assert 'unconfirmed' in str(error.value)
+    assert [call.args[1] for call in nas._request.call_args_list] == ['create','getinfo','delete']
+
+
+@pytest.mark.parametrize('missing', ['date_expired','has_password'])
+def test_absent_security_metadata_is_not_verified(nas, missing):
+    info={'id':'link','path':'/home/a','has_password':False,'date_expired':'0'}
+    del info[missing]
+    nas._request.side_effect=[{'links':[{'id':'link','path':'/home/a'}]},info,{}]
+    with pytest.raises(SynologyError) as error:
+        nas.share_create('/home/a',no_expiry=True)
+    assert error.value.code == 'share_verification_failed'
+
+
+def test_missing_created_url_requires_inspection_not_repeated_creation(nas):
+    nas._request.side_effect=[{'links':[{'id':'link','path':'/home/a'}]},
+                             {'id':'link','path':'/home/a','has_password':False,'date_expired':'0'}]
+    with pytest.raises(SynologyError) as error:
+        nas.share_create('/home/a',no_expiry=True)
+    assert error.value.code == 'submission_unknown'
+    assert nas._request.call_count == 2
+
+
+@pytest.mark.parametrize('expiry', ['', '0', 0, None])
+def test_no_expiry_accepts_dsm_sentinel_and_reports_null(nas, expiry):
+    nas._request.side_effect=[{'links':[{'id':'link','path':'/home/a'}]},
+                             {'id':'link','path':'/home/a','has_password':False,
+                              'date_expired':expiry,'url':'https://nas.test/sharing/link'}]
+    result=nas.share_create('/home/a',no_expiry=True)
+    assert result['expires'] is None
+    assert result['settings_verified'] is True
+    assert nas._request.call_count == 2

--- a/tests/unit/test_synology_transfers.py
+++ b/tests/unit/test_synology_transfers.py
@@ -126,3 +126,29 @@ def test_recursive_download_preserves_empty_directories(nas,tmp_path):
     nas._list_raw=lambda p,*a: ([entries['/home/folder/empty']],1) if p=='/home/folder' else ([],0)
     result=nas.download('/home/folder',str(tmp_path),recursive=True)
     assert result['status']=='complete' and (tmp_path/'folder'/'empty').is_dir()
+
+
+def test_download_skip_keeps_existing_bytes_without_opening_network(nas,tmp_path):
+    target=tmp_path/'a';target.write_bytes(b'keep these bytes')
+    nas._transport=httpx.MockTransport(lambda r:pytest.fail('skip must not download'))
+    result=nas.download('/home/a',str(tmp_path),skip_existing=True)
+    assert result['status']=='complete' and not result['completed'] and result['skipped']
+    assert target.read_bytes()==b'keep these bytes'
+
+
+def test_download_successfully_overwrites_and_cleans_temporary_name(nas,tmp_path):
+    target=tmp_path/'a';target.write_bytes(b'old')
+    nas._transport=httpx.MockTransport(lambda r:httpx.Response(200,content=b'new'))
+    result=nas.download('/home/a',str(tmp_path),overwrite=True)
+    assert result['status']=='complete' and target.read_bytes()==b'new'
+    assert list(tmp_path.iterdir())==[target]
+
+
+def test_recursive_upload_rejects_symlink_before_any_transfer(nas,tmp_path):
+    tree=tmp_path/'tree';tree.mkdir();(tree/'a').write_bytes(b'ok')
+    (tree/'leak').symlink_to(tmp_path/'outside')
+    nas._maybe_info=Mock(return_value=None)
+    nas._transport=httpx.MockTransport(lambda r:pytest.fail('preflight must reject before upload'))
+    with pytest.raises(SynologyError) as error:
+        nas.upload(str(tree),'/home',recursive=True)
+    assert error.value.code=='path_escape'


### PR DESCRIPTION
## Description

Sharing creation previously echoed the requested password/expiry settings. Read the created link back from DSM and verify its exact ID, path, protection flag and expiry before returning its URL. A mismatch revokes only the identified new link; uncertain readback or cleanup returns an inspection hint instead of repeating creation. Normalize explicit no-expiry sentinels, including the empty string.

Adds synthetic regressions for mismatched/missing metadata, failed revocation, whole-path checks, transfer conflicts and interrupted operations. Includes an opt-in disposable-fixture command harness. No env implementation, version bump, real-NAS reports or internal acceptance paths are included.

Refs #1429, #1445.

## Labels and target release

- **Suggested labels:** bug, tests, documentation
- **Proposed target version:** 1.8.4
- **Estimated release window:** next 1.8.4 preview after review and current CI
- **Forward-port tracking issue (stable patches only):** N/A — mainline work

## Verification

- 96 focused Synology tests passed locally.
- Combined integration with #1467, #1468 and #1469 is tested separately; merge readiness requires the PR's own current CI.
- Default reports keep sharing URLs hidden; settings verification does not claim browser enforcement or invalidate previously downloaded bytes.
- Real-device acceptance records remain local and are excluded from this branch and its history.

## Dev Blog

Updated `docs/blog/2026-09-07-the-request-ended-the-copy-did-not.md` with the synthetic mismatched-settings case and the distinction between accepting a request and confirming its settings.

## Risks

DSM implementations that cannot confirm the requested security metadata now fail explicitly. A created link whose readback is uncertain may remain and requires inspection; the client does not blindly retry creation or delete a different link.
