### PR TITLE
Release ConnectOnion 1.8.4 stable

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -43,26 +43,20 @@ The published stable line is 1.8.x. Maintenance fixes for `release/1.7`
 must still be forward-ported to `main`. Pre-releases are opt-in and must be
 marked as pre-releases on PyPI and GitHub.
 
-## Release candidate: 1.8.4b1 (beta preview, prepared for publication)
+## Stable release: 1.8.4
 
-The first 1.8.4 beta closes the open Outlook complaints from one working day
-and gives the Microsoft calendar a terminal. A valid Microsoft token is used
-until five minutes before its expiry, so an oo-api outage no longer makes a
-reachable mailbox look expired (#1312). Each credential failure names the
-layer that broke — `co auth` for a missing or dead OpenOnion key, `co auth
-microsoft` for a revoked or incomplete Microsoft record — instead of blaming
-Microsoft for both (#1313). A scheduled send or reply ends by naming the
-cancel path, and `co outlook --help` groups Mail, Send, Scheduled sends,
-Contacts and Calendar (#1314). `co outlook reply --cc/--bcc` copies a third
-person without leaving the thread (#1247). `co outlook calendar` mirrors
-`co gcalendar` leaf for leaf over the existing MicrosoftCalendar tool, with
-writes that preview by default and print the exact `--yes` command (#816).
+This release promotes the reviewed global configuration, Gmail and Synology work,
+and includes `co env`, Outlook credential diagnostics and calendar commands.
+The four final fix PRs (#1467–#1470) passed their checks before merging.
+The combined suite passed 8,666 tests with 21 skipped and 79.79% coverage;
+11 installed-wheel tests passed. Real Gmail/Drive and one physical NAS were
+exercised, including browser password, expiry and revocation checks.
+Microsoft request contracts have mocked coverage; no live Microsoft tenant was
+used. Control Center hosting remains a separately deployed companion service.
+See [1.8.4 notes](docs/releases/1.8.4.md) for migration and acceptance limits.
 
-Beta means the 1.8.4 surface is now frozen for exercise: no new command groups
-after this, only fixes found by running it. Every Outlook command ends with one
-next command that survives piping; the exit-code and tip evidence is in the
-release PR. Stable remains 1.8.3; physical Synology acceptance and the final
-1.8.4 decision are unchanged from 1.8.4a2. See [1.8.4b1 notes](docs/releases/1.8.4b1.md).
+The planned 1.8.4b1 was not published separately; its reviewed changes are included
+in 1.8.4. Publication is performed and verified by the immutable-tag workflow.
 
 ## Release candidate: 1.8.4a2 (preview, published)
 
@@ -72,31 +66,21 @@ unique match within one bounded, complete metadata page and never blindly resend
 The real installed-wheel Gmail/Drive journey passed, including simulated lost
 receipt recovery, mailbox operations and private collision-safe downloads.
 
-Core regression: 8,568 passed, 22 skipped and 184 live tests excluded. Local
+Core regression: 8,568 passed, 21 skipped and 184 live tests excluded. Local
 browser flows, loopback storage and six configured provider reads passed.
 Physical NAS acceptance still needs a reachable profile and disposable directory.
 Stable remains 1.8.3; this does not authorize final 1.8.4 or cloud provisioning.
 See [1.8.4a2 notes](docs/releases/1.8.4a2.md) and the
 [local acceptance record](docs/acceptance/1.8.4-live-followup/README.md).
 
-## Current Version: 1.8.4b1
+## Current Version: 1.8.4
 
 ### Version History
-- 1.8.4b1 (**the first 1.8.4 beta: Outlook stops blaming the wrong credential, says how
-  to cancel, copies a third person without leaving the thread, and gets a calendar.**
-  A valid Microsoft token is used until five minutes before expiry rather than
-  discarded on every command (#1312, a regression test now pins it). Broker 401s and
-  a missing `OPENONION_API_KEY` point to `co auth`; a revoked or refresh-less
-  Microsoft record points to `co auth microsoft` (#1313). Scheduled sends and
-  replies end with `co outlook scheduled` and name `co outlook cancel <#>`; the
-  group help reads as Mail / Send / Scheduled sends / Contacts / Calendar (#1314).
-  `co outlook reply --cc/--bcc` sets recipients on Graph's reply action or on the
-  deferred reply draft, so the reply stays threaded (#1247). New `co outlook
-  calendar` group — list, today, read, meetings, free, create, teams, update,
-  delete — over the existing MicrosoftCalendar tool, previews by default, ISO
-  offsets converted to UTC, Graph error bodies never printed (#816). Every Outlook
-  command ends with one next command that survives piping. Beta: the 1.8.4 surface
-  is frozen for exercise. Stable remains 1.8.3.)
+- 1.8.4 (**stable — explicit configuration and reviewed operations:** `co env`
+  safely inspects and edits settings; Gmail preserves reviewed content and recovers
+  uncertain sends; Synology verifies sharing settings and supports durable file
+  operations; Outlook names credential failures and exposes previewed calendar
+  writes. Background task shutdown reaps its process tree and output reader.)
 - 1.8.4a2 (**preview recovery fix:** Gmail-preserved attempt markers recover a
   lost send receipt despite rewritten Message-ID; bounded unique lookup remains
   fail-closed. Full real Gmail/Drive acceptance passed; physical NAS pending.)
@@ -104,12 +88,6 @@ See [1.8.4a2 notes](docs/releases/1.8.4a2.md) and the
   the final live Gmail/Drive and physical NAS journeys. Runtime/platform checks,
   local hosting, browser and installed-artifact checks pass. Stable stays 1.8.3;
   the preview is not Latest and requires an explicit version pin or --pre.)
-- 1.8.4 (**prepared, not published — global settings and reviewed operations:**
-  unify explicit env selection and credential ownership; add frozen Gmail
-  listings, mailbox/attachment JSON and content-bound draft sending; complete
-  the Synology command core and coordinated Control Center runtime/bridge.
-  Includes agent identity diagnostics and optional subagent registry cleanup.
-  TikTok, new messaging, mail scheduling and personal Wiki remain outside scope.)
 - 1.8.3 (**Google tools with local credentials, published 6 September 2026:**
   unify Gmail, Drive, Calendar and YouTube authorization and command discovery;
   add Gmail draft attachments, Calendar CLI and preview-confirmed YouTube

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.8.4b1"
+__version__ = "1.8.4"

--- a/docs/blog/2026-09-08-gmail-kept-the-body-and-changed-the-id.md
+++ b/docs/blog/2026-09-08-gmail-kept-the-body-and-changed-the-id.md
@@ -46,3 +46,23 @@ These are local fixes after the published 1.8.4a1 preview. They do not change th
 bytes already on PyPI, and they do not turn an unconfigured physical NAS into a
 passed test. They do change what the next acceptance run measures: the content
 Google stored, the receipt we can recover, and whether another send was prevented.
+
+## The receipt became the release criterion
+
+When the preview was ready for promotion, a green command was no longer enough
+for us. The first test had already shown why: the provider had completed the work
+while our local lookup insisted it had not. We went back to the lost-receipt case
+instead of adding a retry to make the command look successful.
+
+That distinction survived the stable review. Recovery still has to find one
+provider-preserved marker within a complete bounded page; an ambiguous result
+still leaves the send uncertain. Promoting the package does not widen that search
+or make a subject line count as a receipt. If Gmail stops preserving the marker,
+we will need another way to identify the approved operation before allowing
+recovery to report success.
+
+The 1.8.4 release includes that behavior after the real self-send journey and the
+combined 8,665-test regression run. The mock remains useful for proving that an
+uncertain send cannot repeat. The stored message remains necessary for proving
+that our chosen identifier survives the service. Neither test can replace the
+other; the first failed acceptance run is the reason we now keep both.

--- a/docs/cli/gmail.md
+++ b/docs/cli/gmail.md
@@ -169,7 +169,7 @@ the draft. Explicit HTTP rejections allow a later deliberate attempt. This is a
 local retry guard, not a Gmail exactly-once guarantee across other clients or
 machines. Existing one-shot send/reply behavior remains separate.
 
-The provider-preserved marker fallback is included in the `1.8.4a2` preview,
+The provider-preserved marker fallback shipped in `1.8.4a2` and is included in stable `1.8.4`,
 tracked in #1460. Preview `1.8.4a1` itself still uses only
 Message-ID lookup. The live acceptance script checks provider-stored content
 and reports whether the inbox label was observed separately; mailbox routing

--- a/docs/cli/synology.md
+++ b/docs/cli/synology.md
@@ -1,9 +1,11 @@
 # Synology CLI (co syno)
 
-The 1.8.4 candidate provides twenty everyday NAS commands: connection profiles,
-read-only inspections, ordinary files and sharing links. It has synthetic
-regression coverage; real NAS/model acceptance is still pending. See the
-[acceptance record](../acceptance/1.8.4-synology.md).
+ConnectOnion 1.8.4 provides twenty everyday NAS commands: connection profiles,
+read-only inspections, ordinary files and sharing links. Regression tests and
+focused journeys on one physical NAS cover file operations and sharing. Password,
+already-expired link and revocation behavior were also checked in a browser.
+This does not imply a hardware matrix or midnight-transition coverage. See the
+[release notes](../releases/1.8.4.md) for the evidence and remaining limits.
 
 ```bash
 co syno login --name home --url https://nas.example:5001 --username alice

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,29 +8,23 @@ ConnectOnion has two release channels:
 Preview releases never replace the stable recommendation. Install one with
 `--pre` or pin its exact version.
 
-## Current release work
+## Current release
 
-Preview **1.8.4b1** (first 1.8.4 beta) closes the open Outlook issues —
-stored-token reuse, credential errors that name the right `co auth`, scheduled
-sends that say how to cancel, `reply --cc/--bcc` — and adds `co outlook
-calendar` over the existing Microsoft Calendar tool. See
-[1.8.4b1 notes](releases/1.8.4b1.md). Earlier 1.8.4 previews:
-[1.8.4a1](releases/1.8.4a1.md), [1.8.4a2](releases/1.8.4a2.md).
+Stable **1.8.4** brings explicit global configuration, `co env`, reviewed Gmail
+operations, verified Synology sharing and Outlook calendar commands. See
+[1.8.4 release notes](releases/1.8.4.md) for migration and acceptance limits.
 
-Version **1.8.3** brings Gmail, Drive, Calendar and YouTube together through
-local Google authorization, with supported scopes by default and an optional
-`--scopes` restriction. It adds Gmail draft attachments and Calendar/YouTube
-commands with explicit confirmation for their writes. YouTube previews print
-the complete command for the approved plan. See [Google integration](integrations/google.md)
-for commands, permissions and the upgrade path.
+```bash
+python -m pip install --upgrade connectonion==1.8.4
+co --version
+co env
+```
 
-The release candidate passed real-account read-only checks for all four services
-on 2026-09-07 using an existing local grant. Uploads and other mutations have
-isolated regression coverage; no production write is claimed as release evidence.
-PyPI and the GitHub Release are produced by the immutable-tag release workflow.
-TikTok and new messaging adapters are deferred until after 1.8.5.
-The sections below describe historical 1.7 preview work, not current
-installation recommendations.
+No newer preview is currently recommended. The published 1.8.4a1 and 1.8.4a2
+previews are historical; the planned b1 was folded into the stable release.
+The tag workflow builds and verifies the public package before documentation
+is deployed. Google authorization from 1.8.3 is retained. TikTok and new messaging
+adapters remain deferred. The sections below are historical notes.
 
 ## Historical 1.7 preview work
 

--- a/docs/releases/1.8.4.md
+++ b/docs/releases/1.8.4.md
@@ -1,17 +1,22 @@
-# ConnectOnion 1.8.4 — release candidate notes
+# ConnectOnion 1.8.4 — stable release
 
-Prepared 7 September 2026. **Core 1.8.4 is not published yet.** The coordinated
-React SDK `@connectonion/react@0.4.4-rc.2` is published. Current implementation,
-checks and remaining acceptance are tracked in the
-[readiness record](../acceptance/1.8.4-release-readiness.md).
+Stable release, 8 September 2026. This promotes the 1.8.4 preview and the
+reviewed fixes in #1467, #1468, #1469 and #1470. Publication is verified by
+the immutable-tag workflow before the stable docs site is deployed.
+
+```bash
+python -m pip install --upgrade connectonion==1.8.4
+co --version
+co env
+```
 
 ## Changes
 
 - Global settings and provider credential records follow the explicitly selected
   source across authentication, refresh and diagnostics. Working directory no
   longer silently selects a project `.env` or changes accounts.
-- `co env` shows, sets and removes settings in the selected env file, masks
-  secrets, says which values the shell overrides, and refuses to edit provider
+- `co env` shows, sets and removes settings in the selected env file, redacts
+  all values by default, says which values the shell overrides, and refuses to edit provider
   account records field by field. A broken line in `keys.env` now stops other
   commands with `Next: co env` and a line number instead of `co --help`;
   `co doctor` and the provider commands name `co env set …` / `co env` as the
@@ -26,6 +31,14 @@ checks and remaining acceptance are tracked in the
   bounded inspections, safe transfers, durable copy/move task IDs and sharing.
   Optional SNMP/SSH monitoring is configured explicitly; unavailable data stays
   unavailable instead of appearing healthy.
+- Synology sharing reads back password protection and expiry before reporting
+  success. A mismatch revokes only the newly identified link; uncertain cleanup
+  remains explicit. QuickConnect discovery supports regional relay addresses.
+- Outlook credential failures name the correct login. Replies support CC/BCC;
+  calendar writes preview by default. Teams creation without a confirmed join URL
+  exits nonzero and names the existing event to inspect, avoiding duplicate creation.
+- Background task shutdown terminates owned process trees and retires their
+  output readers before cleanup completes.
 - Full Control Center apps share the current conversation through a scoped browser
   connection. Immutable builds pass runtime-owned review before activation;
   blocked updates preserve the approved app. Code/diff, history, rollback and
@@ -65,19 +78,26 @@ No cloud resource was created for this test run.
 
 ## Evidence and publication status
 
-The combined Core suite passed 8,562 tests, with 23 skipped and 184 live tests
-excluded. Companion evidence includes 169 React tests, 213 O Chat unit tests,
-220 browser tests, 855 hosting API tests and a fresh installed Core candidate.
-These counts do not imply that unperformed live-account or physical NAS journeys
-passed. The [visual manifest](assets/v1.8.4/manifest.yml) retains the inspected
-frontend and installed CLI evidence rather than relying on expiring artifacts.
+The merged code passed 8,666 offline tests, with 21 skipped, and 79.79% coverage
+against a 78% floor. Eleven installed-wheel tests passed. The final release PR
+records the versioned artifact checks. The [visual manifest](assets/v1.8.4/manifest.yml)
+includes installed CLI captures and separately identified companion UI evidence.
 
-Core publication still requires the journal gate, authorized Gmail/Drive fixture
-journey, configured NAS acceptance and final reviewed PR merges. The protected tag
-workflow must build, publish and verify the exact public artifacts before the
-stable documentation changes. No Core tag or PyPI release is claimed here.
+Real Gmail/Drive acceptance covered reviewed send, lost-receipt recovery, mailbox
+operations and attachment bytes. One physical NAS passed file operations, recursive
+transfers, durable receipts and sharing checks. Browser tests verified a password
+gate, rejection of a wrong password, access with the correct password, an already
+expired link and revocation after prior access. Synthetic fixtures were cleaned up.
+These are combined focused runs, not a claim of one uninterrupted full harness run.
 
-Mail scheduling, Personal Wiki, Sync Knowledge, TikTok, new messaging adapters
+Limits: Microsoft reply/Teams contracts have mocked coverage, with no live tenant
+acceptance. NAS evidence does not cover a hardware matrix, the midnight expiry
+transition or an already issued download URL/in-flight download. Optional SNMP/SSH
+monitoring was unconfigured. Companion hosting was tested locally; its production
+service and O Chat deployment are separate from this Python package release.
+No cloud resource was provisioned. Private device/account records remain local.
+
+New Gmail scheduling, Personal Wiki, Sync Knowledge, TikTok, new messaging adapters
 and inbound automatic replies are outside 1.8.4. Existing Google and Gemini
 releases are preserved; deferred code from the old combined Google/TikTok branch
 is not included.

--- a/docs/releases/1.8.4b1.md
+++ b/docs/releases/1.8.4b1.md
@@ -1,9 +1,8 @@
 # ConnectOnion 1.8.4b1 — Outlook fixes and `co outlook calendar`
 
-Prepared 8 September 2026. This is the first 1.8.4 **beta**: an opt-in preview
-whose command surface is now frozen for exercise. Stable remains **1.8.3**;
-final 1.8.4 is not released, and the physical Synology acceptance that gates it
-is unchanged from 1.8.4a2.
+Historical beta plan, 8 September 2026. This version was not published separately.
+Its reviewed changes shipped as part of [stable 1.8.4](1.8.4.md). The sections
+below retain the implementation evidence from PR #1468.
 
 ## Outlook
 

--- a/docs/releases/assets/v1.8.4/cli-outlook.svg
+++ b/docs/releases/assets/v1.8.4/cli-outlook.svg
@@ -1,0 +1,449 @@
+<svg class="rich-terminal" viewBox="0 0 1238 2441.2" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-3976131731-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-3976131731-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-3976131731-r1 { fill: #68a0b3;font-weight: bold }
+.terminal-3976131731-r2 { fill: #c5c8c6 }
+.terminal-3976131731-r3 { fill: #98a84b }
+.terminal-3976131731-r4 { fill: #00823d;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-3976131731-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="2390.2" />
+    </clipPath>
+    <clipPath id="terminal-3976131731-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-7">
+    <rect x="0" y="172.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-8">
+    <rect x="0" y="196.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-9">
+    <rect x="0" y="221.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-10">
+    <rect x="0" y="245.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-11">
+    <rect x="0" y="269.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-12">
+    <rect x="0" y="294.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-13">
+    <rect x="0" y="318.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-14">
+    <rect x="0" y="343.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-15">
+    <rect x="0" y="367.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-16">
+    <rect x="0" y="391.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-17">
+    <rect x="0" y="416.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-18">
+    <rect x="0" y="440.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-19">
+    <rect x="0" y="465.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-20">
+    <rect x="0" y="489.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-21">
+    <rect x="0" y="513.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-22">
+    <rect x="0" y="538.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-23">
+    <rect x="0" y="562.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-24">
+    <rect x="0" y="587.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-25">
+    <rect x="0" y="611.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-26">
+    <rect x="0" y="635.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-27">
+    <rect x="0" y="660.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-28">
+    <rect x="0" y="684.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-29">
+    <rect x="0" y="709.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-30">
+    <rect x="0" y="733.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-31">
+    <rect x="0" y="757.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-32">
+    <rect x="0" y="782.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-33">
+    <rect x="0" y="806.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-34">
+    <rect x="0" y="831.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-35">
+    <rect x="0" y="855.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-36">
+    <rect x="0" y="879.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-37">
+    <rect x="0" y="904.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-38">
+    <rect x="0" y="928.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-39">
+    <rect x="0" y="953.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-40">
+    <rect x="0" y="977.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-41">
+    <rect x="0" y="1001.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-42">
+    <rect x="0" y="1026.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-43">
+    <rect x="0" y="1050.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-44">
+    <rect x="0" y="1075.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-45">
+    <rect x="0" y="1099.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-46">
+    <rect x="0" y="1123.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-47">
+    <rect x="0" y="1148.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-48">
+    <rect x="0" y="1172.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-49">
+    <rect x="0" y="1197.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-50">
+    <rect x="0" y="1221.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-51">
+    <rect x="0" y="1245.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-52">
+    <rect x="0" y="1270.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-53">
+    <rect x="0" y="1294.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-54">
+    <rect x="0" y="1319.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-55">
+    <rect x="0" y="1343.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-56">
+    <rect x="0" y="1367.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-57">
+    <rect x="0" y="1392.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-58">
+    <rect x="0" y="1416.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-59">
+    <rect x="0" y="1441.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-60">
+    <rect x="0" y="1465.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-61">
+    <rect x="0" y="1489.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-62">
+    <rect x="0" y="1514.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-63">
+    <rect x="0" y="1538.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-64">
+    <rect x="0" y="1563.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-65">
+    <rect x="0" y="1587.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-66">
+    <rect x="0" y="1611.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-67">
+    <rect x="0" y="1636.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-68">
+    <rect x="0" y="1660.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-69">
+    <rect x="0" y="1685.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-70">
+    <rect x="0" y="1709.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-71">
+    <rect x="0" y="1733.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-72">
+    <rect x="0" y="1758.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-73">
+    <rect x="0" y="1782.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-74">
+    <rect x="0" y="1807.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-75">
+    <rect x="0" y="1831.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-76">
+    <rect x="0" y="1855.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-77">
+    <rect x="0" y="1880.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-78">
+    <rect x="0" y="1904.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-79">
+    <rect x="0" y="1929.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-80">
+    <rect x="0" y="1953.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-81">
+    <rect x="0" y="1977.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-82">
+    <rect x="0" y="2002.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-83">
+    <rect x="0" y="2026.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-84">
+    <rect x="0" y="2051.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-85">
+    <rect x="0" y="2075.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-86">
+    <rect x="0" y="2099.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-87">
+    <rect x="0" y="2124.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-88">
+    <rect x="0" y="2148.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-89">
+    <rect x="0" y="2173.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-90">
+    <rect x="0" y="2197.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-91">
+    <rect x="0" y="2221.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-92">
+    <rect x="0" y="2246.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-93">
+    <rect x="0" y="2270.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-94">
+    <rect x="0" y="2295.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-95">
+    <rect x="0" y="2319.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3976131731-line-96">
+    <rect x="0" y="2343.9" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="2439.2" rx="8"/><text class="terminal-3976131731-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">ConnectOnion&#160;1.8.4&#160;·&#160;co&#160;outlook</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3976131731-clip-terminal)">
+    
+    <g class="terminal-3976131731-matrix">
+    <text class="terminal-3976131731-r1" x="0" y="20" textLength="231.8" clip-path="url(#terminal-3976131731-line-0)">$&#160;co&#160;outlook&#160;--help</text><text class="terminal-3976131731-r2" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-3976131731-line-0)">
+</text><text class="terminal-3976131731-r2" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-1)">
+</text><text class="terminal-3976131731-r2" x="0" y="68.8" textLength="1220" clip-path="url(#terminal-3976131731-line-2)">&#160;Usage:&#160;python&#160;-m&#160;connectonion.cli.main&#160;outlook&#160;[OPTIONS]&#160;COMMAND&#160;[ARGS]...&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3976131731-r2" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-2)">
+</text><text class="terminal-3976131731-r2" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-3)">
+</text><text class="terminal-3976131731-r2" x="0" y="117.6" textLength="1220" clip-path="url(#terminal-3976131731-line-4)">&#160;Your&#160;Outlook&#160;account:&#160;mail,&#160;scheduled&#160;sends,&#160;contacts&#160;and&#160;calendar.&#160;Bare&#160;&#x27;co&#160;outlook&#x27;&#160;shows&#160;the&#160;&#160;&#160;&#160;</text><text class="terminal-3976131731-r2" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-4)">
+</text><text class="terminal-3976131731-r2" x="0" y="142" textLength="1220" clip-path="url(#terminal-3976131731-line-5)">&#160;inbox.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3976131731-r2" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-3976131731-line-5)">
+</text><text class="terminal-3976131731-r2" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-6)">
+</text><text class="terminal-3976131731-r2" x="0" y="190.8" textLength="1220" clip-path="url(#terminal-3976131731-line-7)">╭─&#160;Options&#160;────────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3976131731-r2" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-7)">
+</text><text class="terminal-3976131731-r2" x="0" y="215.2" textLength="1220" clip-path="url(#terminal-3976131731-line-8)">│&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-8)">
+</text><text class="terminal-3976131731-r2" x="0" y="239.6" textLength="1220" clip-path="url(#terminal-3976131731-line-9)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3976131731-r2" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-9)">
+</text><text class="terminal-3976131731-r2" x="0" y="264" textLength="1220" clip-path="url(#terminal-3976131731-line-10)">╭─&#160;Send&#160;───────────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3976131731-r2" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-3976131731-line-10)">
+</text><text class="terminal-3976131731-r2" x="0" y="288.4" textLength="1220" clip-path="url(#terminal-3976131731-line-11)">│&#160;send&#160;&#160;&#160;&#160;&#160;&#160;&#160;Send&#160;an&#160;email&#160;from&#160;your&#160;Outlook&#160;account,&#160;now&#160;or&#160;scheduled&#160;with&#160;--at.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-11)">
+</text><text class="terminal-3976131731-r2" x="0" y="312.8" textLength="1220" clip-path="url(#terminal-3976131731-line-12)">│&#160;reply&#160;&#160;&#160;&#160;&#160;&#160;Reply&#160;to&#160;an&#160;email&#160;(threaded),&#160;now&#160;or&#160;scheduled&#160;with&#160;--at.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-12)">
+</text><text class="terminal-3976131731-r2" x="0" y="337.2" textLength="1220" clip-path="url(#terminal-3976131731-line-13)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3976131731-r2" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-13)">
+</text><text class="terminal-3976131731-r2" x="0" y="361.6" textLength="1220" clip-path="url(#terminal-3976131731-line-14)">╭─&#160;Mail&#160;───────────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3976131731-r2" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-14)">
+</text><text class="terminal-3976131731-r2" x="0" y="386" textLength="1220" clip-path="url(#terminal-3976131731-line-15)">│&#160;inbox&#160;&#160;&#160;&#160;&#160;&#160;List&#160;recent&#160;emails&#160;in&#160;your&#160;Outlook&#160;inbox.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-3976131731-line-15)">
+</text><text class="terminal-3976131731-r2" x="0" y="410.4" textLength="1220" clip-path="url(#terminal-3976131731-line-16)">│&#160;read&#160;&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;one&#160;email&#x27;s&#160;body&#160;without&#160;changing&#160;its&#160;unread&#160;state.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-16)">
+</text><text class="terminal-3976131731-r2" x="0" y="434.8" textLength="1220" clip-path="url(#terminal-3976131731-line-17)">│&#160;download&#160;&#160;&#160;Save&#160;an&#160;email&#x27;s&#160;attachments&#160;to&#160;disk.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="434.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-17)">
+</text><text class="terminal-3976131731-r2" x="0" y="459.2" textLength="1220" clip-path="url(#terminal-3976131731-line-18)">│&#160;sent&#160;&#160;&#160;&#160;&#160;&#160;&#160;List&#160;recently&#160;sent&#160;Outlook&#160;emails.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="459.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-18)">
+</text><text class="terminal-3976131731-r2" x="0" y="483.6" textLength="1220" clip-path="url(#terminal-3976131731-line-19)">│&#160;search&#160;&#160;&#160;&#160;&#160;Search&#160;your&#160;Outlook&#160;emails.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="483.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-19)">
+</text><text class="terminal-3976131731-r2" x="0" y="508" textLength="1220" clip-path="url(#terminal-3976131731-line-20)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3976131731-r2" x="1220" y="508" textLength="12.2" clip-path="url(#terminal-3976131731-line-20)">
+</text><text class="terminal-3976131731-r2" x="0" y="532.4" textLength="1220" clip-path="url(#terminal-3976131731-line-21)">╭─&#160;Scheduled&#160;sends&#160;────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3976131731-r2" x="1220" y="532.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-21)">
+</text><text class="terminal-3976131731-r2" x="0" y="556.8" textLength="1220" clip-path="url(#terminal-3976131731-line-22)">│&#160;scheduled&#160;&#160;List&#160;emails&#160;waiting&#160;for&#160;scheduled&#160;delivery.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="556.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-22)">
+</text><text class="terminal-3976131731-r2" x="0" y="581.2" textLength="1220" clip-path="url(#terminal-3976131731-line-23)">│&#160;cancel&#160;&#160;&#160;&#160;&#160;Cancel&#160;a&#160;scheduled&#160;email&#160;before&#160;it&#160;goes&#160;out.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="581.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-23)">
+</text><text class="terminal-3976131731-r2" x="0" y="605.6" textLength="1220" clip-path="url(#terminal-3976131731-line-24)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3976131731-r2" x="1220" y="605.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-24)">
+</text><text class="terminal-3976131731-r2" x="0" y="630" textLength="1220" clip-path="url(#terminal-3976131731-line-25)">╭─&#160;Contacts&#160;───────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3976131731-r2" x="1220" y="630" textLength="12.2" clip-path="url(#terminal-3976131731-line-25)">
+</text><text class="terminal-3976131731-r2" x="0" y="654.4" textLength="1220" clip-path="url(#terminal-3976131731-line-26)">│&#160;contact&#160;&#160;&#160;&#160;Add,&#160;list,&#160;and&#160;search&#160;Outlook&#160;contacts.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="654.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-26)">
+</text><text class="terminal-3976131731-r2" x="0" y="678.8" textLength="1220" clip-path="url(#terminal-3976131731-line-27)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3976131731-r2" x="1220" y="678.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-27)">
+</text><text class="terminal-3976131731-r2" x="0" y="703.2" textLength="1220" clip-path="url(#terminal-3976131731-line-28)">╭─&#160;Calendar&#160;───────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3976131731-r2" x="1220" y="703.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-28)">
+</text><text class="terminal-3976131731-r2" x="0" y="727.6" textLength="1220" clip-path="url(#terminal-3976131731-line-29)">│&#160;calendar&#160;&#160;&#160;Your&#160;Outlook&#160;calendar:&#160;events,&#160;Teams&#160;meetings,&#160;free&#160;slots.&#160;Bare&#160;&#x27;co&#160;outlook&#160;calendar&#x27;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="727.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-29)">
+</text><text class="terminal-3976131731-r2" x="0" y="752" textLength="1220" clip-path="url(#terminal-3976131731-line-30)">│&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;lists&#160;events.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="752" textLength="12.2" clip-path="url(#terminal-3976131731-line-30)">
+</text><text class="terminal-3976131731-r2" x="0" y="776.4" textLength="1220" clip-path="url(#terminal-3976131731-line-31)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3976131731-r2" x="1220" y="776.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-31)">
+</text><text class="terminal-3976131731-r2" x="1220" y="800.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-32)">
+</text><text class="terminal-3976131731-r2" x="1220" y="825.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-33)">
+</text><text class="terminal-3976131731-r1" x="0" y="849.6" textLength="292.8" clip-path="url(#terminal-3976131731-line-34)">$&#160;co&#160;outlook&#160;send&#160;--help</text><text class="terminal-3976131731-r2" x="1220" y="849.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-34)">
+</text><text class="terminal-3976131731-r2" x="1220" y="874" textLength="12.2" clip-path="url(#terminal-3976131731-line-35)">
+</text><text class="terminal-3976131731-r2" x="0" y="898.4" textLength="1220" clip-path="url(#terminal-3976131731-line-36)">&#160;Usage:&#160;python&#160;-m&#160;connectonion.cli.main&#160;outlook&#160;send&#160;[OPTIONS]&#160;{to}&#160;{subject}&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3976131731-r2" x="1220" y="898.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-36)">
+</text><text class="terminal-3976131731-r2" x="0" y="922.8" textLength="1220" clip-path="url(#terminal-3976131731-line-37)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;{message}&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3976131731-r2" x="1220" y="922.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-37)">
+</text><text class="terminal-3976131731-r2" x="1220" y="947.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-38)">
+</text><text class="terminal-3976131731-r2" x="0" y="971.6" textLength="1220" clip-path="url(#terminal-3976131731-line-39)">&#160;Send&#160;an&#160;email&#160;from&#160;your&#160;Outlook&#160;account,&#160;now&#160;or&#160;scheduled&#160;with&#160;--at.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3976131731-r2" x="1220" y="971.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-39)">
+</text><text class="terminal-3976131731-r2" x="1220" y="996" textLength="12.2" clip-path="url(#terminal-3976131731-line-40)">
+</text><text class="terminal-3976131731-r2" x="0" y="1020.4" textLength="1220" clip-path="url(#terminal-3976131731-line-41)">╭─&#160;Arguments&#160;──────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3976131731-r2" x="1220" y="1020.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-41)">
+</text><text class="terminal-3976131731-r2" x="0" y="1044.8" textLength="1220" clip-path="url(#terminal-3976131731-line-42)">│&#160;*&#160;&#160;&#160;&#160;to&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&lt;str&gt;&#160;&#160;Recipient&#160;email&#160;address&#160;(comma-separated&#160;for&#160;multiple)&#160;[required]&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1044.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-42)">
+</text><text class="terminal-3976131731-r2" x="0" y="1069.2" textLength="1220" clip-path="url(#terminal-3976131731-line-43)">│&#160;*&#160;&#160;&#160;&#160;subject&#160;&#160;&#160;&#160;&#160;&#160;&lt;str&gt;&#160;&#160;Subject&#160;line&#160;[required]&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1069.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-43)">
+</text><text class="terminal-3976131731-r2" x="0" y="1093.6" textLength="1220" clip-path="url(#terminal-3976131731-line-44)">│&#160;*&#160;&#160;&#160;&#160;message&#160;&#160;&#160;&#160;&#160;&#160;&lt;str&gt;&#160;&#160;Body&#160;(plain&#160;text,&#160;or&#160;&#x27;-&#x27;&#160;to&#160;read&#160;from&#160;stdin)&#160;[required]&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1093.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-44)">
+</text><text class="terminal-3976131731-r2" x="0" y="1118" textLength="1220" clip-path="url(#terminal-3976131731-line-45)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3976131731-r2" x="1220" y="1118" textLength="12.2" clip-path="url(#terminal-3976131731-line-45)">
+</text><text class="terminal-3976131731-r2" x="0" y="1142.4" textLength="1220" clip-path="url(#terminal-3976131731-line-46)">╭─&#160;Options&#160;────────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3976131731-r2" x="1220" y="1142.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-46)">
+</text><text class="terminal-3976131731-r2" x="0" y="1166.8" textLength="1220" clip-path="url(#terminal-3976131731-line-47)">│&#160;--cc&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&lt;str&gt;&#160;&#160;CC&#160;recipients&#160;(comma-separated)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1166.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-47)">
+</text><text class="terminal-3976131731-r2" x="0" y="1191.2" textLength="1220" clip-path="url(#terminal-3976131731-line-48)">│&#160;--bcc&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&lt;str&gt;&#160;&#160;BCC&#160;recipients&#160;(comma-separated)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1191.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-48)">
+</text><text class="terminal-3976131731-r2" x="0" y="1215.6" textLength="1220" clip-path="url(#terminal-3976131731-line-49)">│&#160;--attach&#160;&#160;-a&#160;&#160;&#160;&#160;&#160;&#160;&lt;str&gt;&#160;&#160;File&#160;to&#160;attach&#160;(repeat&#160;for&#160;multiple)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1215.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-49)">
+</text><text class="terminal-3976131731-r2" x="0" y="1240" textLength="1220" clip-path="url(#terminal-3976131731-line-50)">│&#160;--at&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&lt;str&gt;&#160;&#160;Schedule&#160;delivery:&#160;+30m,&#160;+2h,&#160;or&#160;UTC&#160;ISO&#160;time&#160;(2026-07-06T15:30:00Z);&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1240" textLength="12.2" clip-path="url(#terminal-3976131731-line-50)">
+</text><text class="terminal-3976131731-r2" x="0" y="1264.4" textLength="1220" clip-path="url(#terminal-3976131731-line-51)">│&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;cancel&#160;before&#160;it&#160;goes&#160;out&#160;with&#160;co&#160;outlook&#160;cancel&#160;&lt;#&gt;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1264.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-51)">
+</text><text class="terminal-3976131731-r2" x="0" y="1288.8" textLength="1220" clip-path="url(#terminal-3976131731-line-52)">│&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1288.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-52)">
+</text><text class="terminal-3976131731-r2" x="0" y="1313.2" textLength="1220" clip-path="url(#terminal-3976131731-line-53)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3976131731-r2" x="1220" y="1313.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-53)">
+</text><text class="terminal-3976131731-r2" x="1220" y="1337.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-54)">
+</text><text class="terminal-3976131731-r2" x="0" y="1362" textLength="1220" clip-path="url(#terminal-3976131731-line-55)">&#160;Examples:&#160;&#160;co&#160;outlook&#160;send&#160;a@b.com&#160;&quot;Hi&quot;&#160;&quot;Quick&#160;note&quot;&#160;&#160;|&#160;&#160;cat&#160;body.txt&#160;|&#160;co&#160;outlook&#160;send&#160;a@b.com&#160;&#160;&#160;&#160;</text><text class="terminal-3976131731-r2" x="1220" y="1362" textLength="12.2" clip-path="url(#terminal-3976131731-line-55)">
+</text><text class="terminal-3976131731-r2" x="0" y="1386.4" textLength="1220" clip-path="url(#terminal-3976131731-line-56)">&#160;&quot;Report&quot;&#160;-&#160;&#160;|&#160;&#160;co&#160;outlook&#160;send&#160;a@b.com&#160;&quot;Invoice&quot;&#160;&quot;Attached&quot;&#160;--attach&#160;invoice.pdf&#160;--at&#160;+2h&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3976131731-r2" x="1220" y="1386.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-56)">
+</text><text class="terminal-3976131731-r2" x="1220" y="1410.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-57)">
+</text><text class="terminal-3976131731-r2" x="1220" y="1435.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-58)">
+</text><text class="terminal-3976131731-r2" x="1220" y="1459.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-59)">
+</text><text class="terminal-3976131731-r1" x="0" y="1484" textLength="341.6" clip-path="url(#terminal-3976131731-line-60)">$&#160;co&#160;outlook&#160;calendar&#160;--help</text><text class="terminal-3976131731-r2" x="1220" y="1484" textLength="12.2" clip-path="url(#terminal-3976131731-line-60)">
+</text><text class="terminal-3976131731-r2" x="1220" y="1508.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-61)">
+</text><text class="terminal-3976131731-r2" x="0" y="1532.8" textLength="1220" clip-path="url(#terminal-3976131731-line-62)">&#160;Usage:&#160;python&#160;-m&#160;connectonion.cli.main&#160;outlook&#160;calendar&#160;[OPTIONS]&#160;COMMAND&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3976131731-r2" x="1220" y="1532.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-62)">
+</text><text class="terminal-3976131731-r2" x="0" y="1557.2" textLength="1220" clip-path="url(#terminal-3976131731-line-63)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;[ARGS]...&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3976131731-r2" x="1220" y="1557.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-63)">
+</text><text class="terminal-3976131731-r2" x="1220" y="1581.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-64)">
+</text><text class="terminal-3976131731-r2" x="0" y="1606" textLength="1220" clip-path="url(#terminal-3976131731-line-65)">&#160;Your&#160;Outlook&#160;calendar:&#160;events,&#160;Teams&#160;meetings,&#160;free&#160;slots.&#160;Bare&#160;&#x27;co&#160;outlook&#160;calendar&#x27;&#160;lists&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3976131731-r2" x="1220" y="1606" textLength="12.2" clip-path="url(#terminal-3976131731-line-65)">
+</text><text class="terminal-3976131731-r2" x="0" y="1630.4" textLength="1220" clip-path="url(#terminal-3976131731-line-66)">&#160;events.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3976131731-r2" x="1220" y="1630.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-66)">
+</text><text class="terminal-3976131731-r2" x="1220" y="1654.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-67)">
+</text><text class="terminal-3976131731-r2" x="0" y="1679.2" textLength="1220" clip-path="url(#terminal-3976131731-line-68)">╭─&#160;Options&#160;────────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3976131731-r2" x="1220" y="1679.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-68)">
+</text><text class="terminal-3976131731-r2" x="0" y="1703.6" textLength="1220" clip-path="url(#terminal-3976131731-line-69)">│&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1703.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-69)">
+</text><text class="terminal-3976131731-r2" x="0" y="1728" textLength="1220" clip-path="url(#terminal-3976131731-line-70)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3976131731-r2" x="1220" y="1728" textLength="12.2" clip-path="url(#terminal-3976131731-line-70)">
+</text><text class="terminal-3976131731-r2" x="0" y="1752.4" textLength="1220" clip-path="url(#terminal-3976131731-line-71)">╭─&#160;Commands&#160;───────────────────────────────────────────────────────────────────────────────────────╮</text><text class="terminal-3976131731-r2" x="1220" y="1752.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-71)">
+</text><text class="terminal-3976131731-r2" x="0" y="1776.8" textLength="1220" clip-path="url(#terminal-3976131731-line-72)">│&#160;list&#160;&#160;&#160;&#160;&#160;&#160;List&#160;upcoming&#160;events&#160;with&#160;stable&#160;event&#160;IDs&#160;(not&#160;row&#160;numbers).&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1776.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-72)">
+</text><text class="terminal-3976131731-r2" x="0" y="1801.2" textLength="1220" clip-path="url(#terminal-3976131731-line-73)">│&#160;today&#160;&#160;&#160;&#160;&#160;Read&#160;today&#x27;s&#160;events.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1801.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-73)">
+</text><text class="terminal-3976131731-r2" x="0" y="1825.6" textLength="1220" clip-path="url(#terminal-3976131731-line-74)">│&#160;read&#160;&#160;&#160;&#160;&#160;&#160;Read&#160;one&#160;event&#160;by&#160;ID.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1825.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-74)">
+</text><text class="terminal-3976131731-r2" x="0" y="1850" textLength="1220" clip-path="url(#terminal-3976131731-line-75)">│&#160;meetings&#160;&#160;Read&#160;upcoming&#160;events&#160;that&#160;have&#160;attendees.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1850" textLength="12.2" clip-path="url(#terminal-3976131731-line-75)">
+</text><text class="terminal-3976131731-r2" x="0" y="1874.4" textLength="1220" clip-path="url(#terminal-3976131731-line-76)">│&#160;free&#160;&#160;&#160;&#160;&#160;&#160;Find&#160;free&#160;slots&#160;between&#160;09:00&#160;and&#160;17:00&#160;UTC&#160;on&#160;one&#160;day.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1874.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-76)">
+</text><text class="terminal-3976131731-r2" x="0" y="1898.8" textLength="1220" clip-path="url(#terminal-3976131731-line-77)">│&#160;create&#160;&#160;&#160;&#160;Create&#160;an&#160;event.&#160;Previews&#160;until&#160;--yes.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1898.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-77)">
+</text><text class="terminal-3976131731-r2" x="0" y="1923.2" textLength="1220" clip-path="url(#terminal-3976131731-line-78)">│&#160;teams&#160;&#160;&#160;&#160;&#160;Create&#160;an&#160;event&#160;with&#160;a&#160;Microsoft&#160;Teams&#160;meeting&#160;link.&#160;Previews&#160;until&#160;--yes.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1923.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-78)">
+</text><text class="terminal-3976131731-r2" x="0" y="1947.6" textLength="1220" clip-path="url(#terminal-3976131731-line-79)">│&#160;update&#160;&#160;&#160;&#160;Update&#160;the&#160;supplied&#160;fields;&#160;omitted&#160;fields&#160;are&#160;preserved.&#160;Previews&#160;until&#160;--yes.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1947.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-79)">
+</text><text class="terminal-3976131731-r2" x="0" y="1972" textLength="1220" clip-path="url(#terminal-3976131731-line-80)">│&#160;delete&#160;&#160;&#160;&#160;Delete&#160;an&#160;event&#160;by&#160;its&#160;stable&#160;ID,&#160;never&#160;by&#160;a&#160;listing&#160;number.&#160;Previews&#160;until&#160;--yes.&#160;&#160;&#160;&#160;&#160;│</text><text class="terminal-3976131731-r2" x="1220" y="1972" textLength="12.2" clip-path="url(#terminal-3976131731-line-80)">
+</text><text class="terminal-3976131731-r2" x="0" y="1996.4" textLength="1220" clip-path="url(#terminal-3976131731-line-81)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3976131731-r2" x="1220" y="1996.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-81)">
+</text><text class="terminal-3976131731-r2" x="1220" y="2020.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-82)">
+</text><text class="terminal-3976131731-r2" x="1220" y="2045.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-83)">
+</text><text class="terminal-3976131731-r1" x="0" y="2069.6" textLength="353.8" clip-path="url(#terminal-3976131731-line-84)">$&#160;co&#160;outlook&#160;calendar&#160;create&#160;</text><text class="terminal-3976131731-r3" x="353.8" y="2069.6" textLength="183" clip-path="url(#terminal-3976131731-line-84)">&quot;Design&#160;review&quot;</text><text class="terminal-3976131731-r1" x="549" y="2069.6" textLength="48.8" clip-path="url(#terminal-3976131731-line-84)">2026</text><text class="terminal-3976131731-r1" x="597.8" y="2069.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-84)">-</text><text class="terminal-3976131731-r1" x="610" y="2069.6" textLength="24.4" clip-path="url(#terminal-3976131731-line-84)">09</text><text class="terminal-3976131731-r1" x="634.4" y="2069.6" textLength="48.8" clip-path="url(#terminal-3976131731-line-84)">-10T</text><text class="terminal-3976131731-r4" x="683.2" y="2069.6" textLength="97.6" clip-path="url(#terminal-3976131731-line-84)">20:00:00</text><text class="terminal-3976131731-r1" x="780.8" y="2069.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-84)">+</text><text class="terminal-3976131731-r4" x="793" y="2069.6" textLength="61" clip-path="url(#terminal-3976131731-line-84)">10:00</text><text class="terminal-3976131731-r1" x="866.2" y="2069.6" textLength="48.8" clip-path="url(#terminal-3976131731-line-84)">2026</text><text class="terminal-3976131731-r1" x="915" y="2069.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-84)">-</text><text class="terminal-3976131731-r1" x="927.2" y="2069.6" textLength="24.4" clip-path="url(#terminal-3976131731-line-84)">09</text><text class="terminal-3976131731-r1" x="951.6" y="2069.6" textLength="48.8" clip-path="url(#terminal-3976131731-line-84)">-10T</text><text class="terminal-3976131731-r4" x="1000.4" y="2069.6" textLength="97.6" clip-path="url(#terminal-3976131731-line-84)">21:00:00</text><text class="terminal-3976131731-r1" x="1098" y="2069.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-84)">+</text><text class="terminal-3976131731-r4" x="1110.2" y="2069.6" textLength="61" clip-path="url(#terminal-3976131731-line-84)">10:00</text><text class="terminal-3976131731-r2" x="1220" y="2069.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-84)">
+</text><text class="terminal-3976131731-r1" x="0" y="2094" textLength="305" clip-path="url(#terminal-3976131731-line-85)">--attendees&#160;a@example.com</text><text class="terminal-3976131731-r2" x="1220" y="2094" textLength="12.2" clip-path="url(#terminal-3976131731-line-85)">
+</text><text class="terminal-3976131731-r2" x="0" y="2118.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-86)">{</text><text class="terminal-3976131731-r2" x="1220" y="2118.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-86)">
+</text><text class="terminal-3976131731-r2" x="0" y="2142.8" textLength="268.4" clip-path="url(#terminal-3976131731-line-87)">&#160;&#160;&#160;&#160;&#x27;mode&#x27;:&#160;&#x27;preview&#x27;,</text><text class="terminal-3976131731-r2" x="1220" y="2142.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-87)">
+</text><text class="terminal-3976131731-r2" x="0" y="2167.2" textLength="317.2" clip-path="url(#terminal-3976131731-line-88)">&#160;&#160;&#160;&#160;&#x27;operation&#x27;:&#160;&#x27;create&#x27;,</text><text class="terminal-3976131731-r2" x="1220" y="2167.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-88)">
+</text><text class="terminal-3976131731-r2" x="0" y="2191.6" textLength="341.6" clip-path="url(#terminal-3976131731-line-89)">&#160;&#160;&#160;&#160;&#x27;arg1&#x27;:&#160;&#x27;Design&#160;review&#x27;,</text><text class="terminal-3976131731-r2" x="1220" y="2191.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-89)">
+</text><text class="terminal-3976131731-r2" x="0" y="2216" textLength="488" clip-path="url(#terminal-3976131731-line-90)">&#160;&#160;&#160;&#160;&#x27;arg2&#x27;:&#160;&#x27;2026-09-10T20:00:00+10:00&#x27;,</text><text class="terminal-3976131731-r2" x="1220" y="2216" textLength="12.2" clip-path="url(#terminal-3976131731-line-90)">
+</text><text class="terminal-3976131731-r2" x="0" y="2240.4" textLength="488" clip-path="url(#terminal-3976131731-line-91)">&#160;&#160;&#160;&#160;&#x27;arg3&#x27;:&#160;&#x27;2026-09-10T21:00:00+10:00&#x27;,</text><text class="terminal-3976131731-r2" x="1220" y="2240.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-91)">
+</text><text class="terminal-3976131731-r2" x="0" y="2264.8" textLength="390.4" clip-path="url(#terminal-3976131731-line-92)">&#160;&#160;&#160;&#160;&#x27;attendees&#x27;:&#160;&#x27;a@example.com&#x27;</text><text class="terminal-3976131731-r2" x="1220" y="2264.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-92)">
+</text><text class="terminal-3976131731-r2" x="0" y="2289.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-93)">}</text><text class="terminal-3976131731-r2" x="1220" y="2289.2" textLength="12.2" clip-path="url(#terminal-3976131731-line-93)">
+</text><text class="terminal-3976131731-r2" x="0" y="2313.6" textLength="195.2" clip-path="url(#terminal-3976131731-line-94)">No&#160;changes&#160;made.</text><text class="terminal-3976131731-r2" x="1220" y="2313.6" textLength="12.2" clip-path="url(#terminal-3976131731-line-94)">
+</text><text class="terminal-3976131731-r2" x="0" y="2338" textLength="1220" clip-path="url(#terminal-3976131731-line-95)">Next:&#160;co&#160;outlook&#160;calendar&#160;create&#160;&#x27;Design&#160;review&#x27;&#160;2026-09-10T20:00:00+10:00&#160;2026-09-10T21:00:00+10:00</text><text class="terminal-3976131731-r2" x="1220" y="2338" textLength="12.2" clip-path="url(#terminal-3976131731-line-95)">
+</text><text class="terminal-3976131731-r2" x="0" y="2362.4" textLength="378.2" clip-path="url(#terminal-3976131731-line-96)">--attendees&#160;a@example.com&#160;--yes</text><text class="terminal-3976131731-r2" x="1220" y="2362.4" textLength="12.2" clip-path="url(#terminal-3976131731-line-96)">
+</text><text class="terminal-3976131731-r2" x="1220" y="2386.8" textLength="12.2" clip-path="url(#terminal-3976131731-line-97)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/releases/assets/v1.8.4/manifest.yml
+++ b/docs/releases/assets/v1.8.4/manifest.yml
@@ -41,8 +41,17 @@ images:
     Synology command groups.
   caption: The installed 1.8.4 candidate adds content-bound draft review and the complete
     Synology command groups.
-  scenario: Account-free --version and Gmail draft/Synology --help from the installed
-    1.8.4 wheel in an unrelated temporary directory.
+  scenario: Account-free help from installed 1.8.4 wheel with isolated configuration;
+    version metadata promoted from the merged code.
   viewport: 100-column terminal
-  commit: 15fae85efc59e611a3458e49e5d3a71cc7d6aa64
+  commit: 15a6fb10
   source_run: scripts/capture_184_release_cli.py
+- file: cli-outlook.svg
+  alt: Outlook groups mail and calendar commands, with calendar writes previewed before
+    confirmation.
+  caption: Installed 1.8.4 Outlook help and a synthetic calendar preview.
+  scenario: Account-free installed wheel with empty configuration; synthetic example.com
+    attendee and no submission.
+  viewport: 100-column terminal
+  commit: 15a6fb10
+  source_run: scripts/capture_184b1_release_cli.py --version 1.8.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.8.4b1"
+version = "1.8.4"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -25,7 +25,7 @@ keywords = [
     "xray",
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.8.4b1"
+version = "1.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Description
Promote the merged and reviewed 1.8.4 work to the stable Python channel. PRs #1467, #1468, #1469 and #1470 are merged with passing checks. This changes release metadata and documentation, not runtime behavior. The planned b1 is not published separately.

Refs #1445.

- **Suggested labels:** documentation, release
- **Proposed target version:** 1.8.4
- **Estimated release window:** 8 September 2026, after this PR passes
- **Why this release:** Owner-approved stable promotion after Gmail/Drive, physical NAS and merged-code regression acceptance.
- **Forward-port tracking issue (stable patches only):** N/A — mainline work

## Changes
Align pyproject.toml, _version.py, uv.lock and VERSIONING.md with stable 1.8.4 and the stable classifier. Refresh release notes and retain installed CLI evidence. Update the existing Design Journal: docs/blog/2026-09-08-gmail-kept-the-body-and-changed-the-id.md. The docs-site stable update is prepared separately and deploys only after public artifacts are verified.

## Validation
```
pytest tests/ -n 4 --dist loadfile -m "not slow and not real_api and not network" --cov=connectonion --cov-fail-under=78 -q
8666 passed, 21 skipped; coverage 79.79%
python -m build --no-isolation
python -m twine check <1.8.4 wheel and sdist>
PASSED (both artifacts)
python scripts/check_release_visuals.py v1.8.4
OK: v1.8.4 — 6 reviewed images
```
Installed-wheel acceptance: `pytest -m slow tests/e2e/test_the_wheel_works_when_installed.py -q` — 11 passed in 16.46s. The forward-port ledger contains no open issues. Publication uses the immutable merged tag and CI Trusted Publishing; no workstation upload.

## Acceptance limits
Gmail/Drive and one NAS were exercised in focused local runs; fixtures were removed. Browser sharing checks covered wrong/correct passwords, already expired links and revocation after prior access. They do not establish a hardware matrix, midnight transition or validity of previously issued/in-flight downloads. No live Microsoft tenant was used; reply and Teams contracts have mocked tests. Companion O Chat/hosting production deployment remains separate. No cloud resources were provisioned and no private NAS records are included.

## How this was written
AI-assisted with Codex (GPT-6). The release metadata and final diff were reviewed. Least confidence remains in unexercised Microsoft tenant-specific behavior, which is explicitly documented; missing Teams links fail with an existing-event recovery path. No new runtime code is introduced by this promotion.
