### PR TITLE
Tests assert on the real executor, and the warnings they were hiding are visible

### DIFF
--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -13,6 +13,7 @@ import argparse
 import asyncio
 import atexit
 import contextlib
+from contextlib import closing
 import inspect
 import json
 import os
@@ -1454,15 +1455,18 @@ class BrowserDaemon:
     def _bind_posix(self):
         """Raw AF_UNIX bind with the original stale-vs-busy probe (unchanged)."""
         if os.path.exists(self.sock_path):
-            probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            try:
-                probe.connect(self.sock_path)
-                probe.close()
-                sys.exit(0)  # another daemon already serving
-            except OSError:
-                if _owner_alive(self.sock_path):
-                    sys.exit(0)  # owner alive, backlog full — busy, not stale
-                os.unlink(self.sock_path)  # stale socket
+            # The probe is closed on every path, refused included: a refused
+            # connect used to leave the socket to the garbage collector, which
+            # the test suite reported as `ResourceWarning: unclosed socket`.
+            with closing(socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)) as probe:
+                try:
+                    probe.connect(self.sock_path)
+                except OSError:
+                    if _owner_alive(self.sock_path):
+                        sys.exit(0)  # owner alive, backlog full — busy, not stale
+                    os.unlink(self.sock_path)  # stale socket
+                else:
+                    sys.exit(0)  # another daemon already serving
         self._srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._srv.bind(self.sock_path)
         Path(transport.pid_path(self.sock_path)).write_text(str(os.getpid()), encoding="utf-8")

--- a/connectonion/network/host/replay.py
+++ b/connectonion/network/host/replay.py
@@ -150,9 +150,17 @@ class SignatureReplayStore:
 
     def _connect(self):
         database = sqlite3.connect(self.path, timeout=SQLITE_BUSY_TIMEOUT_SECONDS)
-        database.execute(
-            f"PRAGMA busy_timeout = {int(SQLITE_BUSY_TIMEOUT_SECONDS * 1000)}"
-        )
+        try:
+            database.execute(
+                f"PRAGMA busy_timeout = {int(SQLITE_BUSY_TIMEOUT_SECONDS * 1000)}"
+            )
+        except sqlite3.Error:
+            # The caller never receives this connection, so nothing else can
+            # close it. A ledger that is a directory, or unreadable, raised
+            # here and left the handle to the garbage collector — which the
+            # test suite reported as `ResourceWarning: unclosed database`.
+            database.close()
+            raise
         return database
 
     def _expires_at(self, data: dict, seen_at: float) -> float:

--- a/connectonion/useful_tools/browser_tools/scroll.py
+++ b/connectonion/useful_tools/browser_tools/scroll.py
@@ -153,14 +153,16 @@ def _screenshots_different(
 
         from PIL import Image
 
-        img1 = Image.open(os.path.join(base_dir, file1)).convert('RGB')
-        img2 = Image.open(os.path.join(base_dir, file2)).convert('RGB')
+        with Image.open(os.path.join(base_dir, file1)) as opened1, \
+                Image.open(os.path.join(base_dir, file2)) as opened2:
+            img1 = opened1.convert('RGB')
+            img2 = opened2.convert('RGB')
 
-        diff = sum(
-            abs(a - b)
-            for p1, p2 in zip(img1.getdata(), img2.getdata())
-            for a, b in zip(p1, p2)
-        )
+        # Raw RGB bytes, one per channel: the same per-channel sum as the
+        # old per-pixel loop, without `Image.getdata`, which Pillow removes
+        # in 14 (2027-10-15) and which every run had been warning about
+        # under a blanket DeprecationWarning ignore.
+        diff = sum(abs(a - b) for a, b in zip(img1.tobytes(), img2.tobytes()))
         threshold = img1.size[0] * img1.size[1] * 3 * 0.01  # 1%
         return diff > threshold
     except Exception:

--- a/docs/blog/2026-09-10-the-fake-that-asserted-on-itself.md
+++ b/docs/blog/2026-09-10-the-fake-that-asserted-on-itself.md
@@ -1,0 +1,68 @@
+# The fake that asserted on itself
+
+`tests/unit/test_events.py` has thirty-eight tests and every one of them was
+green. They check the thing the event system exists for: that `before_tools`
+fires once before the batch, `before_each_tool` before each call, `on_error`
+when a tool fails, `after_tools` once at the end, in that order. If the tool
+executor ever dropped one of those or fired them in the wrong sequence, this
+was the file that would say so.
+
+It could not have. Its autouse fixture replaced `Agent._execute_and_record_tools`
+with a forty-line fake that fired `before_each_tool`, then `on_error` if the
+tool's name was `failing_tool`, then `after_each_tool`, then `after_tools`, and
+appended a hand-built trace entry. The tests then asserted that those events
+had fired in that order. They were checking the fixture. The real executor in
+`tool_executor.py` could have stopped emitting `on_error` in 2025 and this file
+would have kept passing.
+
+The audit in #210 had flagged it in July. Two months later I deleted the fake,
+stubbed only the model, and ran the file. Thirty-eight passed. The real path
+produced the same trace shape, the same error string, the same order — which
+is good news about the executor and a small indictment of the fake, which had
+been faithfully reimplementing forty lines of production code so that the
+tests would not have to run them.
+
+## The same shape, three more times
+
+Once you have seen a test that asserts on itself you start seeing the family.
+
+Two tests in `test_tui_components.py` imported `SmartInput` and `Pick` inside a
+`try`, and skipped on `ImportError`. Neither name exists. The widget is `Input`
+and the picker is a function called `pick`. The tests had skipped on every run
+since they were written, and would have gone on skipping through any breakage
+of the modules they were meant to guard. A required import that fails is a
+failure; they now import the real names and assert.
+
+`pytest.ini` ignored every `DeprecationWarning` and `PendingDeprecationWarning`
+in the process. The warning count at the bottom of a run therefore said
+nothing about upgrade debt. I took the ignore out, expecting a wall. The full
+run surfaced exactly one: Pillow's `Image.getdata`, which the scroll code used
+to compare two screenshots pixel by pixel, is going away in Pillow 14 on
+2027-10-15. That is a date the blanket had been keeping from us. The
+comparison now reads raw bytes, which every Pillow has, and the filter is
+gone for good; a third-party warning that must be silenced gets a line with
+its message, its owner and the condition for deleting the line.
+
+The run also surfaced `ResourceWarning`, which nobody had asked to hide and
+nobody had looked at either: a sqlite handle in the replay ledger
+that leaked when its first pragma failed, a probe socket in the browser daemon
+left open on the refused path, and four tests reading `host.yaml` through a
+bare `open()` with no close. Each is a file and a line in the summary now, and
+each of those is fixed.
+
+## The test that depended on the shell
+
+The last one was not a fake. `test_co_command_works` ran `co --version` from
+`PATH` and asserted it exited zero. On a machine where `PATH` finds a `co` from
+some other interpreter, it fails with `No module named connectonion`, and on
+CI, where the only `co` is the one just installed, it passes. That is the local
+run disagreeing with CI for a reason that is not a bug, the same disease as
+`FORCE_COLOR` two days ago. It now runs the console script beside the
+interpreter that is running the tests, which is the installation the test
+claims to check.
+
+None of these changes made a test go red. That is the point. The suite had
+thirty-eight tests that could not fail, two that could not run, a warning
+filter that could not report, and one that failed for the wrong reason. It
+looked exactly the same as a suite that had none of those. The only way to
+tell was to take each shortcut away and see whether anything changed.

--- a/pytest.ini
+++ b/pytest.ini
@@ -41,10 +41,17 @@ addopts =
 # longer tests what it claims. Either way it should surface.
 xfail_strict = true
 
-# Filtering options
+# Warnings are left visible. DeprecationWarning used to be ignored wholesale,
+# which meant the summary's warning count said nothing about upgrade debt;
+# with the ignore removed the full run surfaced none from our code or our
+# dependencies, so there was nothing to hide. ResourceWarning stays on too:
+# an unclosed file or socket in the summary is a leak with a file and line.
+# Silence a specific third-party warning here, by message, with the owner
+# and the condition for removing the line — never a whole category.
 filterwarnings =
-    ignore::DeprecationWarning
-    ignore::PendingDeprecationWarning
+    # google-api-core warns about Python 3.10 reaching end of life on
+    # 2026-10-04. Remove when 3.10 leaves the CI matrix (planned for 1.9.0).
+    ignore:You are using a Python version .* which Google will stop supporting:FutureWarning
 
 # Minimum version
 minversion = 6.0

--- a/tests/e2e/cli/test_cli.py
+++ b/tests/e2e/cli/test_cli.py
@@ -138,12 +138,26 @@ class TestCliInit:
                 assert '__pycache__' in content
 
 
+def _installed_co():
+    """The `co` console script that belongs to the interpreter running the tests.
+
+    Not `shutil.which('co')`: on a developer machine PATH can find a `co` from
+    some other interpreter (a stale user-site install, another venv), and then
+    this test fails with `No module named connectonion` while CI — where the
+    only `co` is the one just installed — passes. The installation this test
+    claims to check is the one beside `sys.executable`.
+    """
+    import sys
+    return shutil.which('co', path=str(Path(sys.executable).parent))
+
+
 def _co_cli_works():
-    """Check if 'co --version' actually runs successfully."""
+    """Check if the installed 'co --version' actually runs successfully."""
     import subprocess
-    if shutil.which('co') is None:
+    co = _installed_co()
+    if co is None:
         return False
-    result = subprocess.run(['co', '--version'], capture_output=True, text=True)
+    result = subprocess.run([co, '--version'], capture_output=True, text=True)
     return result.returncode == 0
 
 
@@ -157,7 +171,7 @@ class TestCliCommands:
     def test_co_command_works(self):
         """Test that 'co' command is available after installation."""
         import subprocess
-        result = subprocess.run(['co', '--version'], capture_output=True, text=True)
+        result = subprocess.run([_installed_co(), '--version'], capture_output=True, text=True)
         assert result.returncode == 0
         # Check for version in output (not specific version number)
         assert any(c.isdigit() for c in result.stdout)

--- a/tests/e2e/cli/test_cli_create.py
+++ b/tests/e2e/cli/test_cli_create.py
@@ -353,7 +353,7 @@ class TestCliCreate:
                                                 '--yes', '--template', 'co-ai'])
             assert result.exit_code == 0
 
-            config = yaml.safe_load(open("perm-agent/.co/host.yaml"))
+            config = yaml.safe_load(Path("perm-agent/.co/host.yaml").read_text())
             permissions = config.get("permissions", {})
             assert permissions.get("read", {}).get("allowed") is True
             assert permissions.get("glob", {}).get("allowed") is True

--- a/tests/e2e/cli/test_cli_init.py
+++ b/tests/e2e/cli/test_cli_init.py
@@ -406,7 +406,7 @@ class TestCliInit:
             result = self.runner.invoke(cli, ['init', './'])
             assert result.exit_code == 0
 
-            config = yaml.safe_load(open(".co/host.yaml"))
+            config = yaml.safe_load(Path(".co/host.yaml").read_text())
             permissions = config.get("permissions", {})
 
             # Check key permissions from template
@@ -422,7 +422,7 @@ class TestCliInit:
             result = self.runner.invoke(cli, ['init', './'])
             assert result.exit_code == 0
 
-            config = yaml.safe_load(open(".co/host.yaml"))
+            config = yaml.safe_load(Path(".co/host.yaml").read_text())
             assert "relay_url" not in config
 
     def test_init_copies_all_docs_to_co_docs(self):

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -20,6 +20,14 @@ from connectonion.core.usage import TokenUsage
 
 @pytest.fixture(autouse=True)
 def _mock_llm(monkeypatch):
+    """Stub only the model. Tool execution runs the real Agent → ToolExecutor path.
+
+    An earlier version of this fixture also replaced `_execute_and_record_tools`
+    with a fake that fired before_each_tool / on_error / after_each_tool /
+    after_tools by hand. Every test below then passed no matter what the real
+    executor emitted, or in what order — the fake was asserting on itself
+    (#210). Now a dropped or reordered event in tool_executor.py fails here.
+    """
     class FakeLLM:
         model = "test-model"
 
@@ -33,31 +41,6 @@ def _mock_llm(monkeypatch):
             return LLMResponse(content="mock", tool_calls=tool_calls, raw_response=None, usage=TokenUsage())
 
     monkeypatch.setattr("connectonion.core.agent.create_llm", lambda *args, **kwargs: FakeLLM())
-
-    def fake_exec(self, tool_calls):
-        for tc in tool_calls:
-            self._invoke_events('before_each_tool')
-            is_error = tc.name == 'failing_tool'
-            result_text = f"Results for {tc.arguments.get('query', '')}" if not is_error else 'Error executing tool'
-            status = 'error' if is_error else 'success'
-            trace_entry = {
-                'id': self._next_trace_id(),
-                'type': 'tool_result',
-                'name': tc.name,
-                'args': tc.arguments,
-                'status': status,
-                'result': result_text,
-                'ts': 0,
-            }
-            if is_error:
-                trace_entry['error'] = 'Intentional failure'
-            self.current_session['trace'].append(trace_entry)
-            if is_error:
-                self._invoke_events('on_error')
-            self._invoke_events('after_each_tool')
-        self._invoke_events('after_tools')
-
-    monkeypatch.setattr("connectonion.core.agent.Agent._execute_and_record_tools", fake_exec)
 
 
 def search(query: str) -> str:

--- a/tests/unit/test_remote_browser_egress_gateway.py
+++ b/tests/unit/test_remote_browser_egress_gateway.py
@@ -765,9 +765,12 @@ async def test_gateway_refusals_do_not_retain_parser_dns_or_body_payloads():
     body_reader = asyncio.StreamReader()
     body_reader.feed_data(b"secret-partial-body")
     body_reader.feed_eof()
-    _, sink = await asyncio.open_connection(sock=socket.socketpair()[0])
+    ours, theirs = socket.socketpair()
+    _, sink = await asyncio.open_connection(sock=ours)
     with pytest.raises(GatewayRefusal) as body_refusal:
         await gateway._stream_body(body_reader, sink, 100)
+    sink.close()
+    theirs.close()
     sink.close()
     assert body_refusal.value.__context__ is None
     assert "secret-partial" not in repr(body_refusal.value)

--- a/tests/unit/test_tui_components.py
+++ b/tests/unit/test_tui_components.py
@@ -295,27 +295,26 @@ class TestProviders:
 
 
 class TestInput:
-    """Tests for Input class (if importable)."""
+    """The input widget is importable under its real name.
+
+    This used to import `SmartInput` inside a try/except that skipped on
+    ImportError. No such class exists — the widget is `Input` — so the test
+    skipped on every run since it was written and would have gone on skipping
+    through any breakage of the real module. A required import that fails is
+    a failure.
+    """
 
     def test_input_import(self):
-        """Test Input can be imported."""
-        try:
-            from connectonion.tui.input import SmartInput
-            assert SmartInput is not None
-        except ImportError:
-            pytest.skip("SmartInput not available")
+        from connectonion.tui.input import Input
+        assert callable(Input)
 
 
 class TestPick:
-    """Tests for Pick class (if importable)."""
+    """Same story: the picker is the function `pick`, never a class `Pick`."""
 
     def test_pick_import(self):
-        """Test Pick can be imported."""
-        try:
-            from connectonion.tui.pick import Pick
-            assert Pick is not None
-        except ImportError:
-            pytest.skip("Pick not available")
+        from connectonion.tui.pick import pick
+        assert callable(pick)
 
 
 class TestTriggerAutoComplete:


### PR DESCRIPTION
## Description

Second wave of the test-suite work after #1467 (shipped in 1.8.4). #1467 made the suite fast and gave it guards against hangs, leaks and network. This one goes after the other way a green suite lies: tests that cannot fail, tests that cannot run, and a warning filter that could not report. Nothing here changes user-facing behaviour; three product files are touched to close leaks the newly visible `ResourceWarning`s named and to drop a Pillow call that is being removed.

Refs #210 (P0 signal integrity, P1 deprecation filter). Rides in 1.8.5 with #1472.

## What changed and why

| Where | Before | After |
|---|---|---|
| `tests/unit/test_events.py` | autouse fixture replaced `Agent._execute_and_record_tools` with a 40-line fake that fired the events by hand; 38 tests asserted on the fake | only the model is stubbed; the same 38 pass against the real Agent → ToolExecutor path, so a dropped or reordered event in `tool_executor.py` now fails here |
| `tests/unit/test_tui_components.py` | two tests imported `SmartInput` / `Pick` in a try/except and skipped on ImportError — names that have never existed, so they skipped on every run | import the real `Input` / `pick` and assert |
| `pytest.ini` | `ignore::DeprecationWarning`, `ignore::PendingDeprecationWarning` | no category-wide ignores; one third-party warning filtered by message with owner and removal condition |
| `useful_tools/browser_tools/scroll.py` | `Image.getdata` (removed in Pillow 14, 2027-10-15 — the one deprecation the blanket was hiding) | raw `tobytes()` comparison, same per-channel sum; images opened with `with` |
| `network/host/replay.py` | sqlite handle leaked when the first pragma failed | closed on that path |
| `cli/browser_agent/daemon.py` | probe socket left open on the refused path | `closing()` |
| four tests | `yaml.safe_load(open(...))`, a `socketpair()` half dropped | closed |
| `tests/e2e/cli/test_cli.py` | ran whatever `co` PATH found (fails locally with "No module named connectonion" when PATH has a stale install; passes on CI) | runs the console script beside `sys.executable` |

## Labels and target release (required)

- **Suggested labels:** tests
- **Proposed target version:** 1.8.5
- **Estimated release window:** next alpha (1.8.5a1, with #1472)
- **Milestone:** maintainer assigns
- **Why this release:** test infrastructure plus three leak fixes in product code with no behavioural change; rollback is a revert. Nothing in it blocks or depends on the Feishu/Lark work.
- **Forward-port tracking issue (stable patches only):** N/A — mainline work

## How this was written

- [x] Mostly AI-generated — Claude Fable 5.1 via Claude Code, continuing the maintainer's request to make the suite able to surface problems.

**Least confident about:** whether any downstream code relied on `_screenshots_different` tolerating a non-RGB image the old loop would have zipped anyway. Both paths convert to RGB first, so I believe not.

**Not verified:** the Windows branch of the daemon (`_bind_windows`) is untouched; the POSIX probe change is covered by `test_browser_daemon.py`, which the Windows CI job also runs against the stub browser.

**If this is wrong, what breaks first:** `test_events.py` — it is now the first file that would go red if the executor's event order changed, which is exactly what it is for.

## Dev Blog

> docs/blog/2026-09-10-the-fake-that-asserted-on-itself.md

## Testing

```
$ make test
8666 passed, 21 skipped, 10 warnings in 39.49s
```

Python 3.10, 8 workers. Skips are down from 23 to 21 (the two forever-skipping TUI imports). The remaining 10 warnings are 6 `UserWarning`s from `test_prompts.py` that are the behaviour under test, and the google-api-core notice is now filtered by message.

Run with `-W error::DeprecationWarning` on `tests/unit/test_scroll.py`: 10 passed.

## Scope

- `tests/unit/test_events.py`, `tests/unit/test_tui_components.py` — the tests that could not fail or run
- `pytest.ini` — the filter
- `connectonion/useful_tools/browser_tools/scroll.py`, `connectonion/network/host/replay.py`, `connectonion/cli/browser_agent/daemon.py` — the deprecation and the two product leaks the warnings named
- `tests/e2e/cli/test_cli.py`, `test_cli_create.py`, `test_cli_init.py`, `tests/unit/test_remote_browser_egress_gateway.py` — test-side leaks and the PATH dependence

## Checklist
- [x] I proposed at least one label and a target version above
- [x] I have read every line of this diff and can defend each change
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings (they remove the filter that hid them and fix what surfaced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLqqyEND1RpEtSPTe86NsK
