### PR TITLE
Give the Control Center starter's content room to be read

### DIFF
--- a/connectonion/cli/assets/control-center/index.html
+++ b/connectonion/cli/assets/control-center/index.html
@@ -54,15 +54,15 @@
     }
     html, body { max-width: 100%; overflow-x: clip; }
     main, .grid, .card, .quick { width: 100%; min-width: 0; max-width: 100%; }
-    main { width: min(100%, 860px); margin: 0 auto; }
+    main { width: min(100%, 920px); margin: 0 auto; }
     button, input, textarea, summary { font: inherit; }
     button, input, summary { min-height: 48px; }
     :focus-visible { outline: 3px solid var(--cc-focus); outline-offset: 2px; }
     [hidden] { display: none !important; }
 
-    .masthead { display: grid; gap: 18px; margin-bottom: 18px; }
+    .masthead { display: grid; gap: 14px; margin-bottom: 22px; }
     .eyebrow {
-      margin: 0 0 5px; color: var(--cc-subtle); font-size: 11px; font-weight: 760;
+      margin: 0 0 6px; color: var(--cc-subtle); font-size: 11px; font-weight: 760;
       letter-spacing: .11em; text-transform: uppercase;
     }
     .identity { display: flex; align-items: center; gap: 12px; min-width: 0; }
@@ -72,20 +72,29 @@
       font-size: 18px; font-weight: 800; text-transform: uppercase; user-select: none;
     }
     h1 { margin: 0; font-size: clamp(23px, 6vw, 31px); line-height: 1.12; letter-spacing: -.03em; }
-    .tagline { margin: 9px 0 0; max-width: 64ch; font-size: 14px; color: var(--cc-muted); }
-    .sub { display: flex; align-items: center; gap: 7px; margin: 7px 0 0; color: var(--cc-subtle); font-size: 12px; }
-    .connection-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--cc-subtle); }
+    .tagline { margin: 8px 0 0; max-width: 58ch; font-size: 14px; color: var(--cc-muted); }
+    /* The connection state is the one live fact in the header, so it sits in the
+       masthead's second column as a pill rather than as a fourth stacked line of
+       text under the tagline. */
+    .sub {
+      display: inline-flex; align-items: center; gap: 8px; margin: 0; padding: 7px 12px;
+      border: 1px solid var(--cc-border); border-radius: 999px; background: var(--cc-surface);
+      color: var(--cc-muted); font-size: 12px; font-weight: 620; white-space: nowrap;
+      justify-self: start;  /* a grid item would otherwise stretch the pill to the column */
+    }
+    .connection-dot { flex: none; width: 7px; height: 7px; border-radius: 50%; background: var(--cc-subtle); }
+    .sub.connected { border-color: color-mix(in srgb, var(--cc-accent) 38%, var(--cc-border)); color: var(--cc-text); }
     .sub.connected .connection-dot { background: var(--cc-accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--cc-accent) 16%, transparent); }
 
     .grid { display: grid; gap: 14px; }
-    .stack { margin-top: 14px; }
+    .stack { margin-top: 22px; gap: 8px; }
     .card {
       border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md);
       background: var(--cc-surface); box-shadow: var(--cc-shadow);
     }
-    .card-pad { padding: 16px; }
+    .card-pad { padding: 18px; }
     .section-title {
-      margin: 0 0 10px; color: var(--cc-subtle); font-size: 11px; font-weight: 760;
+      margin: 0 0 12px; color: var(--cc-subtle); font-size: 11px; font-weight: 760;
       letter-spacing: .09em; text-transform: uppercase;
     }
 
@@ -111,12 +120,21 @@
     .status[data-state="success"] { color: var(--cc-accent); }
     .status[data-state="error"] { color: var(--cc-danger); }
 
-    .quick { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
+    /* One action per row, not three across. This card is about 460px wide, so
+       three columns gave each action ~150px: every name wrapped ("reconcile-
+       payments") and every description was cut mid-word, the ellipsis landing
+       wherever the pixel budget ran out. A full-width row fits the name and a
+       readable line of its description, and it fills the card instead of leaving
+       a dead band under three short tiles. */
+    .quick { display: grid; gap: 6px; }
     .quick .skill {
-      min-height: 72px; padding: 12px 30px 12px 12px;
+      min-height: 62px; padding: 11px 32px 11px 13px;
       border: 1px solid var(--cc-border); background: var(--cc-surface-raised);
     }
-    .quick .skill::after { right: 13px; }
+    .quick .skill::after { right: 14px; }
+    .quick .skill .desc {
+      white-space: normal; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+    }
 
     .skill {
       position: relative; display: flex; flex-direction: column; justify-content: center;
@@ -133,16 +151,21 @@
     .skill:active { background: var(--cc-accent-soft); }
     .skill .name { font-size: 13.5px; font-weight: 700; overflow-wrap: anywhere; }
     .skill .desc {
-      min-width: 0; max-width: 100%; margin-top: 2px; color: var(--cc-muted); font-size: 12px;
-      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      min-width: 0; max-width: 100%; margin-top: 3px; color: var(--cc-muted); font-size: 12px;
+      line-height: 1.4; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     }
     .skill .desc:empty { display: none; }
 
-    details.card { overflow: clip; }
+    /* The three closed panels are reference, not the task. They share one quieter
+       surface so the eye goes to the workspace above them, and the group reads as
+       one block instead of three identical bars competing with it. */
+    details.card { overflow: clip; box-shadow: none; background: var(--cc-surface); }
     details.card > summary {
       display: flex; align-items: center; justify-content: space-between; gap: 12px;
-      padding: 12px 16px; list-style: none; cursor: pointer; font-size: 13px; font-weight: 750;
+      padding: 13px 16px; list-style: none; cursor: pointer; font-size: 13px; font-weight: 750;
     }
+    details.card > summary:hover { background: var(--cc-surface-raised); }
+    details[open].card { box-shadow: var(--cc-shadow); }
     details.card > summary::-webkit-details-marker { display: none; }
     details.card > summary::after {
       content: ""; flex: none; width: 8px; height: 8px;
@@ -170,13 +193,21 @@
 
     @media (min-width: 640px) {
       .masthead { grid-template-columns: 1fr auto; align-items: end; }
-      .overview { grid-template-columns: minmax(0, .8fr) minmax(0, 1.2fr); }
+      #connection { justify-self: end; }
+      .overview { grid-template-columns: minmax(0, .9fr) minmax(0, 1.1fr); }
       .overview.single { grid-template-columns: 1fr; }
+      /* The two cards stay the same height and the composer spends the
+         difference on the textarea. Letting them find their own heights left an
+         L-shaped hole beside the shorter one; padding the shorter one out with
+         empty space would have been worse. The quick list keeps its rows at
+         their natural height, so a card with one skill does not stretch it. */
+      .overview > .card { display: flex; flex-direction: column; }
+      .overview .composer { flex: 1; grid-template-rows: minmax(88px, 1fr) auto; }
+      .quick { align-content: start; }
       .capability-rows { grid-template-columns: 1fr 1fr; gap: 4px; }
     }
     @media (max-width: 520px) {
       body { padding-inline: 10px; }
-      .quick { grid-template-columns: 1fr; }
       .quick .skill { min-height: 56px; }
       .composer-actions { align-items: stretch; flex-direction: column; }
       .send { width: 100%; }
@@ -197,8 +228,8 @@
         <p class="eyebrow">Control Center</p>
         <div class="identity"><span id="agent-initial" class="mark" aria-hidden="true">C</span><h1 id="agent-name">Connect AI</h1></div>
         <p class="tagline">Message this Agent or run one of its published skills.</p>
-        <p id="connection" class="sub"><span class="connection-dot" aria-hidden="true"></span><span id="connection-label">Open through O Chat to connect</span></p>
       </div>
+      <p id="connection" class="sub"><span class="connection-dot" aria-hidden="true"></span><span id="connection-label">Open through O Chat to connect</span></p>
     </header>
 
     <div id="overview" class="grid overview single">

--- a/connectonion/network/host/ws_router/starter.html
+++ b/connectonion/network/host/ws_router/starter.html
@@ -91,12 +91,21 @@
   .now strong { display: block; font-size: 15px; }
   .now p { margin: 2px 0 0; color: var(--cc-muted); font-size: 13px; }
 
-  .quick { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
+  /* One action per row. At the pane width this page is written for the three
+     columns already collapsed; at desktop width they did not, and the card there
+     is about 460px — roughly 150px per action, which wrapped the names and cut
+     every description mid-word, an ellipsis landing wherever the pixels ran out.
+     A row fits the name and two readable lines under it at every width this page
+     is served at. */
+  .quick { display: grid; gap: 6px; align-content: start; }
   .quick .skill {
-    min-height: 72px; padding: 12px 30px 12px 12px;
+    min-height: 62px; padding: 11px 32px 11px 13px;
     border: 1px solid var(--cc-border); background: var(--cc-surface-raised);
   }
-  .quick .skill::after { right: 13px; }
+  .quick .skill::after { right: 14px; }
+  .quick .skill .desc {
+    white-space: normal; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+  }
 
   .skill {
     position: relative; display: flex; flex-direction: column; justify-content: center;
@@ -113,8 +122,8 @@
   .skill:active { background: var(--cc-accent-soft); }
   .skill .name { font-size: 13.5px; font-weight: 700; overflow-wrap: anywhere; }
   .skill .desc {
-    min-width: 0; max-width: 100%; margin-top: 2px; color: var(--cc-muted); font-size: 12px;
-    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    min-width: 0; max-width: 100%; margin-top: 3px; color: var(--cc-muted); font-size: 12px;
+    line-height: 1.4; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   .skill .desc:empty { display: none; }
 
@@ -168,12 +177,17 @@
 
   @media (min-width: 640px) {
     .masthead { grid-template-columns: 1fr auto; align-items: end; }
-    .overview { grid-template-columns: minmax(0, .8fr) minmax(0, 1.2fr); }
+    /* Two columns only when there are two cards. An Agent that has published
+       nothing renders no Quick actions card, and the second column stayed
+       declared: the Workspace note sat at 40% width beside an empty half. Day
+       zero is exactly when an Agent has no published skills, so that was the
+       first thing `co host` showed most people. */
+    .overview { grid-template-columns: minmax(0, .8fr) minmax(0, 1.2fr); align-items: start; }
+    .overview:not(:has(.quick)) { grid-template-columns: 1fr; }
     .capability-rows { grid-template-columns: 1fr 1fr; gap: 4px; }
   }
   @media (max-width: 520px) {
     body { padding-inline: 10px; }
-    .quick { grid-template-columns: 1fr; }
     .quick .skill { min-height: 56px; }
     .act { align-items: flex-start; flex-direction: column; gap: 1px; }
     .act .what { white-space: normal; }

--- a/docs/blog/2026-09-11-three-columns-for-a-name-and-a-sentence.md
+++ b/docs/blog/2026-09-11-three-columns-for-a-name-and-a-sentence.md
@@ -1,0 +1,90 @@
+# Three columns for a name and a sentence
+
+The Control Center starter puts an Agent's first three skills in a card called
+Quick actions. Each one shows its name and the first sentence of its description,
+which is exactly the right thing to show. The card laid them out in three
+columns.
+
+The card is about 460 pixels wide. Three columns, minus gaps and the chevron each
+tile needs, leaves roughly 150 pixels per action. So this is what an Agent with
+ordinary skill names actually got:
+
+```text
+email-client          generate-      reconcile-
+Write a concise c…    invoice        payments
+                      Create and…    Match incom…
+```
+
+Two of the three names wrapped. All three descriptions were cut, and not cut
+politely — `white-space: nowrap` with an ellipsis cuts wherever the pixel budget
+runs out, which is usually the middle of a word. "Write a concise c…" is not a
+short description. It is a description that has been destroyed and then given a
+character that implies the rest is available somewhere. It is not.
+
+Underneath the three short tiles sat a band of empty card, because the tiles were
+one row and the card had been stretched to match the taller card beside it.
+
+## The layout was not a style choice
+
+It is tempting to treat this as taste — someone preferred a grid, someone else
+prefers a list. It isn't. A layout that cannot fit the content it is given is
+wrong in the same way a function that cannot hold its return value is wrong. The
+question to ask of a column count is not whether it looks tidy in a mock with
+three short words in it, but how many characters it gives you and how many the
+real data has. 150 pixels is about 20 characters at this size. Skill names alone
+run past that, and every one of them is followed by a sentence.
+
+One action per row gives the same card about 420 usable pixels: the full name on
+its own line and two readable lines of description under it. Three rows also fill
+the card, so the dead band goes away by itself rather than by being padded out.
+
+## The other half of the same mistake
+
+The two cards in the top row had been given each other's height. Whichever card
+had less to say grew a hole at the bottom. The fix that suggests itself is to let
+each card be its own height, and that trades the hole for an L-shaped gap beside
+the shorter card, which is not better. What the extra height is *for* is the
+answer: the composer spends it on the textarea. The person typing gets more room,
+which is the one thing in that card anybody wants more of.
+
+A masthead column was empty for a different reason. The header declared two
+columns at desktop width and put every line into the first one, so the connection
+state sat as a fourth stacked line of text under the tagline — the only live fact
+on the page, styled like a footnote. It is a pill in the second column now, which
+is what the second column was declared for.
+
+## The twin had it too, and one thing besides
+
+`starter.html` — the canonical page `co host` serves — carries the same three
+columns and the same nowrap ellipsis. Its docstring says it is written for a
+440px pane, where the columns have already collapsed to one; at desktop width
+they had not, and it truncated exactly the same way. Rendering it through
+`render_starter` rather than guessing showed the identical damage, so it gets the
+identical row.
+
+One rule deliberately differs. The Control Center's two cards keep a shared
+height because its composer can spend the difference. The starter's Workspace is
+a two-line note with nothing to spend it on, so there each card keeps its own
+height; forcing them equal would only inflate the note.
+
+Rendering the starter also turned up something that has nothing to do with
+columns. It declares two overview columns at desktop width, and an Agent that has
+published no skills renders no Quick actions card — so the Workspace note sat at
+40% width beside an empty half. Day zero is precisely when an Agent has published
+nothing, which means that lopsided page was the first thing `co host` showed most
+people. `.overview:not(:has(.quick))` collapses it to one column. The Control
+Center never had this bug because its bridge script sets a class when the skill
+list is empty; the starter has no script, and nobody had rendered the empty case.
+
+## What is checked
+
+The starter is the interactive twin of the canonical `starter.html`, and a test
+asserts that the eleven colour tokens appear in both files with the same values in
+the same order. None of them changed here; nothing about this is a repaint. The
+same test lists the landmarks and the identifiers the bridge script queries, and
+those are unchanged too, because this is the same page with its content given
+room.
+
+Light, dark, and a 390-pixel viewport were each rendered and looked at, which is
+the only way to know that a two-line clamp behaves and a pill in a grid cell does
+not stretch to the column.


### PR DESCRIPTION
## The problem

Quick actions laid three skills across a card about 460px wide. Minus gaps and
each tile's chevron, that is roughly 150px — about 20 characters — for a skill
name and the first sentence of its description. With ordinary skill names:

```text
email-client          generate-      reconcile-
Write a concise c…    invoice        payments
                      Create and…    Match incom…
```

Two of three names wrapped; all three descriptions were cut by a `nowrap`
ellipsis, which cuts wherever the pixel budget ends — usually mid-word. Under the
tiles sat a band of empty card, because one row of tiles had been stretched to
match the taller card beside it.

This is not a taste question. A layout that cannot hold the content it is given
is wrong the way a container too small for its value is wrong.

## The change

Both pages, because they are twins the file comments require to stay in structural
sync, and the canonical one had the identical bug.

- **One action per row.** The same card gives each action ~420px: the full name,
  then two readable lines of description (`-webkit-line-clamp: 2`). Three rows
  fill the card, so the dead band goes with them.
- **The two top cards keep a shared height and the composer spends the difference
  on its textarea.** Letting each card find its own height only moves the hole to
  the side of the shorter one. The quick list keeps rows at natural height
  (`align-content: start`), so one skill does not stretch into a giant row.
- **The masthead's second column is used.** It was declared at ≥640px and left
  empty while the connection state — the only live fact on the page — sat as a
  fourth stacked line under the tagline. It is a pill now, `justify-self` start on
  mobile and end on desktop so it hugs its content at both widths.
- **Closed reference panels lose their shadow until opened**, so Capabilities,
  Recent Chat and Diagnostics read as one secondary block instead of three bars
  competing with the workspace above them.
- `main` 860px → 920px in the Control Center.
- **starter.html gets the same row**, and each of its cards keeps its own height —
  its Workspace is a two-line note with nothing to spend extra height on.
- **starter.html's day-zero layout is fixed.** It declares two overview columns at
  desktop width; an Agent that has published no skills renders no Quick actions
  card, so the Workspace note sat at 40% width beside an empty half. Day zero is
  exactly when an Agent has published nothing, so that was the first thing
  `co host` showed most people. `.overview:not(:has(.quick))` collapses it. The
  Control Center never had this because its bridge sets a class when the skill
  list is empty; the starter has no script and nobody had rendered the empty case.

## What was not touched

No colour token changed, and no markup that anything depends on. The test in
`tests/unit/test_project_cmd_lib.py` pins all eleven `--cc-*` declarations to the
same values in the same order as `starter.html`, plus the landmark strings and the
identifiers `control-center.js` queries; all still pass. `sdk.js` is vendored and
untouched. The one markup change moves `#connection` out of the first masthead
column into the second — same element, same id, same children.

## Verified

105 tests pass: `test_project_cmd_lib.py`, `test_control_center_bundle.py`,
`test_control_center_runtime.py`, `test_control_center_host_wiring.py`,
`test_dashboard.py`.

Rendered and inspected rather than assumed — the starter shows nothing without a
connection, so a throwaway harness fabricated four skills with real-length names
and sentences, and the page was screenshotted before and after at 1280px, at
390px, and against the dark palette. starter.html was rendered through
`render_starter` rather than by substituting placeholders by hand, populated and
empty. Every before screenshot reproduces the truncation quoted above exactly.

One test caught a mistake worth keeping: `test_the_address_is_shown_in_full`
asserts no ellipsis character appears anywhere in the rendered page, so that an
Agent address is never shown truncated. The first draft of these CSS comments
quoted the old truncation with a real ellipsis and tripped it. The comments now
describe it in words — a comment should not be the thing that weakens a guard.

**Proposed target version:** 1.8.5
**Estimated release window:** with the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kyc1QMpxWAZE7QUbiYsAXa
