### PR TITLE
Read-only commands run unattended, and an e2e runs the job instead of the table (#1481)

### DIFF
--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -303,6 +303,21 @@ def _get_batch_remaining(agent: 'Agent', current_tool_id: str) -> list:
     return []
 
 
+def _log_permission_granted(agent: 'Agent', tool_name: str, tool_args: dict, source: str, reason: str) -> None:
+    """Show a grant on the console when there is one.
+
+    A `quiet=True` agent has a logger whose `console` is None, and that is the
+    shape every unattended run takes. Six call sites reached
+    `agent.logger.console.log_permission_granted(...)` directly, so in a quiet
+    agent every auto-approved tool call died with AttributeError — the
+    approval said yes and the tool still failed. Found by the Rust e2e, not by
+    the sixty unit tests, none of which built a real quiet Agent.
+    """
+    console = getattr(getattr(agent, 'logger', None), 'console', None)
+    if console is not None:
+        console.log_permission_granted(tool_name, tool_args, source, reason)
+
+
 def _log(agent: 'Agent', message: str, style: str = None) -> None:
     """Log message via agent's logger if available.
 
@@ -423,7 +438,7 @@ def check_approval(agent: 'Agent') -> None:
         )
         if direct_tool == tool_name and tool_name in {'codex', 'claude_code'}:
             if getattr(getattr(agent, 'logger', None), 'console', None):
-                agent.logger.console.log_permission_granted(
+                _log_permission_granted(agent, 
                     tool_name,
                     tool_args,
                     'host',
@@ -456,7 +471,7 @@ def check_approval(agent: 'Agent') -> None:
                 )
             if verdict == 'allow':
                 if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
-                    agent.logger.console.log_permission_granted(
+                    _log_permission_granted(agent, 
                         tool_name, tool_args, 'policy', policy.get('reason', 'auto-approved')
                     )
                 return
@@ -490,7 +505,7 @@ def check_approval(agent: 'Agent') -> None:
                 permitted, reason, source = check_bash_chain_permitted(tool_args['command'], permissions)
                 if permitted:
                     if getattr(getattr(agent, 'logger', None), 'console', None):
-                        agent.logger.console.log_permission_granted('bash', tool_args, source, reason)
+                        _log_permission_granted(agent, 'bash', tool_args, source, reason)
                     return
 
             # Check each permission in the dict
@@ -519,7 +534,7 @@ def check_approval(agent: 'Agent') -> None:
                     reason = perm.get('reason', 'unknown')
                     source = perm.get('source', 'config')
                     if getattr(getattr(agent, 'logger', None), 'console', None):
-                        agent.logger.console.log_permission_granted(tool_name, tool_args, source, reason)
+                        _log_permission_granted(agent, tool_name, tool_args, source, reason)
                     return
 
     # =================================================================
@@ -533,7 +548,7 @@ def check_approval(agent: 'Agent') -> None:
         tool_name = pending['name'] if pending else 'unknown'
         tool_args = pending.get('arguments', {}) if pending else {}
         if getattr(getattr(agent, 'logger', None), 'console', None):
-            agent.logger.console.log_permission_granted(tool_name, tool_args, 'mode', 'full_access mode')
+            _log_permission_granted(agent, tool_name, tool_args, 'mode', 'full_access mode')
         return
 
     # reject_hard was set by a previous tool in this batch — reject remaining
@@ -559,7 +574,7 @@ def check_approval(agent: 'Agent') -> None:
     if mode == AUTO:
         if tool_name in FILE_EDIT_TOOLS:
             if getattr(getattr(agent, 'logger', None), 'console', None):
-                agent.logger.console.log_permission_granted(
+                _log_permission_granted(agent, 
                     tool_name, tool_args, 'mode', AUTO
                 )
             return

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -248,26 +248,96 @@ def _classify_single_command(command: str, root: Path | None = None) -> dict:
     return decision("command", "ask", "command is outside the focused verification and read-only allowlists", "call", requires_human=True)
 
 
-_OUTPUT_REDIRECT = re.compile(r">(?!&\d)")
+def _redirect_targets(command: str) -> list[str]:
+    """The files a command's output redirects write to.
+
+    `2>&1` duplicates a descriptor and writes nothing; `> >(cmd)` is process
+    substitution, and the inner command is classified on its own by
+    _extract_subcommands. Everything else — `>`, `>>`, `2> file` — is a file
+    being written, which bashlex keeps out of the word list, so this is the
+    one place a write hiding behind a read-only command is seen.
+    """
+    import bashlex
+
+    targets: list[str] = []
+
+    def visit(node):
+        if node.kind == "redirect" and node.type in (">", ">>") and hasattr(node.output, "word"):
+            if not node.output.word.startswith(">("):
+                targets.append(node.output.word)
+        for attr in ("parts", "list"):
+            for child in getattr(node, attr, None) or []:
+                visit(child)
+        for attr in ("command", "output", "input"):
+            child = getattr(node, attr, None)
+            if child is not None and hasattr(child, "kind"):
+                visit(child)
+
+    for node in bashlex.parse(command):
+        visit(node)
+    return targets
 
 
-def _has_output_redirect(command: str) -> bool:
-    """A `>` that points at a file means something is being written, so
-    nothing about the command is read-only — even `head -1 f > out`. `2>&1`
-    and `>&2` only duplicate a descriptor and write nothing new. bashlex keeps
-    redirects out of the word list, so this is the one place they are seen."""
-    return bool(_OUTPUT_REDIRECT.search(command))
+def _redirect_verdict(targets: list[str], root: Path | None) -> dict | None:
+    """A redirect is a file write, and is held to the write tool's rules.
+
+    Inside the workspace it is a reversible edit and allowed — `echo x > f`
+    is what a model reaches for instead of the write tool. A control file is
+    denied, a target outside the workspace is denied, and a target that
+    depends on the environment (`$HOME/...`) cannot be resolved and asks.
+    """
+    from .approval import _is_control_file
+
+    for target in targets:
+        if "$" in target or "`" in target:
+            return decision("command", "ask", "redirect target depends on the environment", "call", requires_human=True)
+        if root is None:
+            return decision("command", "ask", "a redirect writes a file", "call", requires_human=True)
+        path = Path(target).expanduser()
+        resolved = (path if path.is_absolute() else root / path).resolve(strict=False)
+        if _is_control_file(str(resolved)):
+            return decision("authorization_control", "deny", "agents cannot rewrite authorization control files", "call")
+        if not _inside_workspace(resolved, root):
+            return decision("write_outside_workspace", "deny", "writes outside the workspace are not auto-approved", "call")
+    return None
+
+
+_HEREDOC_OPERATOR = re.compile(r"<<-?\s*(['\"]?)(\w+)\1")
+
+
+def _without_heredoc_body(command: str) -> str:
+    """`cat << 'EOF' > f\n...\nEOF` classified by its first line, body dropped.
+
+    bashlex cannot parse a here-document, and an unparseable command asks —
+    which is how a real model's first attempt to write main.rs was refused
+    unattended: models reach for `cat << EOF > file` even when a write tool is
+    offered. The body is data to the command on the first line. For a
+    read-only command that is inert; for anything that executes its input
+    (`bash << EOF`, `python << EOF`) the first word is not read-only and the
+    command asks as before, body or no body.
+    """
+    header, _, _ = command.partition("\n")
+    if not _HEREDOC_OPERATOR.search(header):
+        return command
+    return _HEREDOC_OPERATOR.sub("", header, count=1)
 
 
 def _classify_command(command: str, root: Path | None = None) -> dict:
+    command = _without_heredoc_body(command)
     try:
         subcommands = _extract_subcommands(command)
+        targets = _redirect_targets(command)
     except Exception:
         return decision("command", "ask", "command could not be parsed safely", "call", requires_human=True)
     results = [_classify_single_command(full, root) for _, full in subcommands]
-    if _has_output_redirect(command):
+    if targets:
+        verdict = _redirect_verdict(targets, root)
+        if verdict is not None:
+            return verdict
+        # Every write target is a reversible workspace file: the read-only
+        # segments feeding it are now a workspace edit, and are allowed as one.
         results = [
-            decision("command", "ask", "a read-only command with an output redirect writes a file", "call", requires_human=True)
+            decision("workspace_edit", "allow", "read-only command writing a workspace file", "workspace")
             if item["effect_class"] == "read" else item
             for item in results
         ]
@@ -278,9 +348,12 @@ def _classify_command(command: str, root: Path | None = None) -> dict:
     if asked:
         return asked
     effects = {item["effect_class"] for item in results}
+    count = f"{len(results)} command{'s' if len(results) != 1 else ''}"
     if effects == {"read"}:
-        return decision("read", "allow", f"read-only command chain ({len(results)} command{'s' if len(results) != 1 else ''})", "workspace")
-    return decision("verification", "allow", f"focused verification chain ({len(results)} command{'s' if len(results) != 1 else ''})", "workspace")
+        return decision("read", "allow", f"read-only command chain ({count})", "workspace")
+    if effects == {"workspace_edit"}:
+        return decision("workspace_edit", "allow", f"workspace file written by a read-only chain ({count})", "workspace")
+    return decision("verification", "allow", f"focused verification chain ({count})", "workspace")
 
 
 def evaluate_auto_approve(tool_name: str, args: dict, root: Path | None = None) -> dict:
@@ -378,7 +451,7 @@ def _headless_configured_command(
     # granted browser command plus a filter on its output. Every other segment
     # must match a standing grant, so `co browser status && co email send ...`
     # is still an email send nobody authorized (#1481).
-    command = str((pending.get("arguments") or {}).get("command", ""))
+    command = _without_heredoc_body(str((pending.get("arguments") or {}).get("command", "")))
     try:
         root = project_root().resolve()
         segments = _extract_subcommands(command)
@@ -386,7 +459,7 @@ def _headless_configured_command(
             full for _, full in segments
             if _classify_single_command(full, root).get("effect_class") != "read"
         ]
-        if _has_output_redirect(command):
+        if _redirect_targets(command):
             needs_grant = [full for _, full in segments]
         # The shipped historical Bash(co *) grant is broader than its "safe CLI"
         # description. Preserve the unattended browser/status compatibility
@@ -425,8 +498,13 @@ def record_approval_policy(agent: "Agent", pending: dict) -> None:
     result = pending.get("approval_policy")
     if not isinstance(result, dict):
         return
+    # The executor records the call id as `tool_id` (`id` is the trace
+    # sequence number). This compared against `id`, so in a real Agent the
+    # decision never reached the trace — the audit record every "UI-safe
+    # decision" test asserted on existed only in tests whose pending tool had
+    # no id at all. Found by the Rust e2e.
     tool_id = pending.get("id")
     for entry in reversed(agent.current_session.get("trace", [])):
-        if entry.get("type") == "tool_call" and (not tool_id or entry.get("id") == tool_id):
+        if entry.get("type") == "tool_call" and (not tool_id or entry.get("tool_id") == tool_id):
             entry["approval_policy"] = dict(result)
             return

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -43,6 +43,16 @@ _FOCUSED_COMMANDS = {
     "pytest", "ruff", "mypy", "pyright", "eslint", "tsc", "vitest",
     "jest", "cargo", "go", "make",
 }
+# This category is an execution surface by design: an agent that may write a
+# test and run it may run anything the test runs. What the narrowing below is
+# for is the commands in it that are not verification at all — `make install`
+# writes outside the workspace by convention, and 1.8.4 allowed it, along with
+# bare `make` and `make -C /etc all`. `cargo`, `go` and the package runners
+# were already narrowed this way; `make` was the one left open.
+_MAKE_VERIFICATION_TARGETS = {
+    "test", "tests", "check", "checks", "lint", "typecheck", "fmt", "format",
+    "build", "coverage", "cov", "ci", "verify", "audit",
+}
 _PACKAGE_RUNNERS = {"npm", "pnpm", "yarn", "bun"}
 _DESTRUCTIVE_COMMANDS = {"rm", "rmdir", "shred", "truncate", "del", "erase", "format"}
 _EXTERNAL_COMMANDS = {"curl", "wget", "ssh", "scp", "rsync", "mail", "sendmail"}
@@ -289,6 +299,16 @@ def _classify_single_command(command: str, root: Path | None = None) -> dict:
         focused = len(words) > 1 and words[1] in {"test", "check", "clippy", "build"}
     if first == "go":
         focused = len(words) > 1 and words[1] == "test"
+    if first == "make":
+        # A named verification target, and nothing that redirects make
+        # somewhere else. Bare `make` runs whatever the default target is.
+        targets = [w for w in words[1:] if not w.startswith("-")]
+        flags = [w for w in words[1:] if w.startswith("-")]
+        focused = (
+            bool(targets)
+            and all(t in _MAKE_VERIFICATION_TARGETS for t in targets)
+            and not any(f.startswith(("-C", "--directory", "-f", "--file", "--makefile")) for f in flags)
+        )
     if focused:
         return decision("verification", "allow", "focused test, lint, or build command", "workspace")
     if first in _READ_ONLY_COMMANDS:

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -225,6 +225,22 @@ def _command_words(command: str) -> list[str]:
         return []
 
 
+_UNRESOLVABLE = re.compile(r"\$[A-Za-z_{(]|`")
+
+
+def _reads_an_unresolvable_path(words: list[str]) -> bool:
+    """True if a file argument comes from a substitution or a variable.
+
+    `cat $(cat which_file.txt)` is a read of whatever that file names, and
+    `head $HOME/.ssh/id_rsa` of whatever HOME is. Neither can be checked
+    against the workspace, so neither is a checked read. Two of these passed
+    before this rule, by luck: one word happened to split across the
+    substitution, another happened to contain "secret". `grep 'foo$' f` is
+    not affected — a bare `$` names nothing.
+    """
+    return any(_UNRESOLVABLE.search(word) for word in words[1:] if not word.startswith("-"))
+
+
 def _reads_outside_workspace(words: list[str], root: Path) -> bool:
     """A path-looking argument that resolves outside the workspace.
 
@@ -276,6 +292,8 @@ def _classify_single_command(command: str, root: Path | None = None) -> dict:
     if focused:
         return decision("verification", "allow", "focused test, lint, or build command", "workspace")
     if first in _READ_ONLY_COMMANDS:
+        if first in _PATH_READING_COMMANDS and _reads_an_unresolvable_path(words):
+            return decision("read_outside_workspace", "ask", "the file to read depends on the environment", "call", requires_human=True)
         if root is not None and first in _PATH_READING_COMMANDS and _reads_outside_workspace(words, root):
             return decision("read_outside_workspace", "ask", "reading outside the workspace requires approval", "call", requires_human=True)
         return decision("read", "allow", "read-only command", "workspace")

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -389,6 +389,15 @@ def evaluate_auto_approve(tool_name: str, args: dict, root: Path | None = None) 
     """Classify one exact Auto-profile tool call without side effects."""
     root = (root or project_root()).resolve()
     name = str(tool_name).lower()
+    # Before anything else: the tools hold the same line the shell commands do.
+    # `cat server.pem` was denied while `read_file("server.pem")` was allowed,
+    # so a model asked for the first simply reached for the second — measured
+    # through the real `co ai`, which printed "policy read-only workspace
+    # operation" for a private key. A gate one tool wide is a detour.
+    if name in READ_TOOLS | WORKSPACE_EDIT_TOOLS | DELETE_TOOLS:
+        raw = next((args.get(key) for key in ("file_path", "path", "target", "filename", "pattern") if args.get(key)), None)
+        if raw is not None and _is_key_material(str(raw)):
+            return decision("credentials", "deny", "credential access is never auto-approved", "call")
     if name in READ_TOOLS:
         path = _workspace_path(args)
         if path is not None and not _inside_workspace(path, root):

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -7,6 +7,7 @@ tool call after the Host has selected ``auto``.
 
 from __future__ import annotations
 
+import re
 import shlex
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -47,6 +48,29 @@ _DESTRUCTIVE_COMMANDS = {"rm", "rmdir", "shred", "truncate", "del", "erase", "fo
 _EXTERNAL_COMMANDS = {"curl", "wget", "ssh", "scp", "rsync", "mail", "sendmail"}
 _SENSITIVE_COMMANDS = {
     "env", "printenv", "security", "keychain", "gcloud", "aws", "az",
+}
+# Commands that read, filter or print and do nothing else. They run unattended
+# in Auto, on workspace paths, with no output redirect. Before this list only
+# the eleven test/build tools above auto-approved; `head`, `grep`, `wc`, `ls`
+# fell through to "ask", and an unattended "ask" is a "deny" — a 7×/day
+# LinkedIn round died on `co browser ... get_text | head -40` after sixteen
+# clean iterations (#1481). This is the Auto *policy* for the agent's own
+# calls; the remote-EXEC whitelist in host.yaml is a different gate and is
+# deliberately not widened here.
+_READ_ONLY_COMMANDS = {
+    "head", "tail", "cat", "less", "more", "grep", "egrep", "fgrep", "rg",
+    "wc", "ls", "sed", "awk", "sort", "uniq", "cut", "tr", "basename",
+    "dirname", "jq", "echo", "printf", "pwd", "cd", "true", "test", "[",
+    "which", "file", "stat", "diff", "date", "whoami", "hostname", "uname",
+}
+_SED_IN_PLACE_FLAGS = ("-i", "--in-place")
+# The read-only commands that open the paths they are given. `basename`,
+# `echo`, `pwd` and friends take strings, not files, and `cd` is here because
+# leaving the workspace makes every later relative path a path outside it.
+_PATH_READING_COMMANDS = {
+    "head", "tail", "cat", "less", "more", "grep", "egrep", "fgrep", "rg",
+    "wc", "ls", "sed", "awk", "sort", "uniq", "cut", "jq", "file", "stat",
+    "diff", "cd",
 }
 
 
@@ -165,12 +189,33 @@ def _command_words(command: str) -> list[str]:
         return []
 
 
-def _classify_single_command(command: str) -> dict:
+def _reads_outside_workspace(words: list[str], root: Path) -> bool:
+    """A path-looking argument that resolves outside the workspace.
+
+    `head ~/.ssh/id_rsa` and `cat /etc/shadow` are reads, but not workspace
+    reads; the read *tools* already ask for those, and the read *commands*
+    hold the same line. `s/a/b/` also contains a slash and resolves inside the
+    root, which is the right answer for a sed script.
+    """
+    for word in words[1:]:
+        if word.startswith("-") or not (word.startswith(("/", "~", ".")) or "/" in word):
+            continue
+        path = Path(word).expanduser()
+        resolved = (path if path.is_absolute() else root / path).resolve(strict=False)
+        if not _inside_workspace(resolved, root):
+            return True
+    return False
+
+
+def _classify_single_command(command: str, root: Path | None = None) -> dict:
     words = _command_words(command)
     if not words:
         return decision("command", "ask", "command could not be parsed safely", "call", requires_human=True)
 
     lowered = [word.lower() for word in words]
+    # `VAR=value cmd ...` — the command is the first word that is not an assignment.
+    while len(words) > 1 and "=" in words[0] and not words[0].startswith("-"):
+        words, lowered = words[1:], lowered[1:]
     first = Path(words[0]).name.lower()
     if first in _DESTRUCTIVE_COMMANDS:
         return decision("deletion", "deny", "destructive command requires an explicit safer workflow", "call")
@@ -194,21 +239,47 @@ def _classify_single_command(command: str) -> dict:
         focused = len(words) > 1 and words[1] == "test"
     if focused:
         return decision("verification", "allow", "focused test, lint, or build command", "workspace")
-    return decision("command", "ask", "command is outside the focused verification allowlist", "call", requires_human=True)
+    if first in _READ_ONLY_COMMANDS:
+        if first == "sed" and any(w.startswith(_SED_IN_PLACE_FLAGS) for w in words[1:]):
+            return decision("workspace_edit", "ask", "sed -i rewrites files; use the edit tool", "call", requires_human=True)
+        if root is not None and first in _PATH_READING_COMMANDS and _reads_outside_workspace(words, root):
+            return decision("read_outside_workspace", "ask", "reading outside the workspace requires approval", "call", requires_human=True)
+        return decision("read", "allow", "read-only command", "workspace")
+    return decision("command", "ask", "command is outside the focused verification and read-only allowlists", "call", requires_human=True)
 
 
-def _classify_command(command: str) -> dict:
+_OUTPUT_REDIRECT = re.compile(r">(?!&\d)")
+
+
+def _has_output_redirect(command: str) -> bool:
+    """A `>` that points at a file means something is being written, so
+    nothing about the command is read-only — even `head -1 f > out`. `2>&1`
+    and `>&2` only duplicate a descriptor and write nothing new. bashlex keeps
+    redirects out of the word list, so this is the one place they are seen."""
+    return bool(_OUTPUT_REDIRECT.search(command))
+
+
+def _classify_command(command: str, root: Path | None = None) -> dict:
     try:
         subcommands = _extract_subcommands(command)
     except Exception:
         return decision("command", "ask", "command could not be parsed safely", "call", requires_human=True)
-    results = [_classify_single_command(full) for _, full in subcommands]
+    results = [_classify_single_command(full, root) for _, full in subcommands]
+    if _has_output_redirect(command):
+        results = [
+            decision("command", "ask", "a read-only command with an output redirect writes a file", "call", requires_human=True)
+            if item["effect_class"] == "read" else item
+            for item in results
+        ]
     denied = next((item for item in results if item["decision"] == "deny"), None)
     if denied:
         return denied
     asked = next((item for item in results if item["decision"] == "ask"), None)
     if asked:
         return asked
+    effects = {item["effect_class"] for item in results}
+    if effects == {"read"}:
+        return decision("read", "allow", f"read-only command chain ({len(results)} command{'s' if len(results) != 1 else ''})", "workspace")
     return decision("verification", "allow", f"focused verification chain ({len(results)} command{'s' if len(results) != 1 else ''})", "workspace")
 
 
@@ -238,7 +309,7 @@ def evaluate_auto_approve(tool_name: str, args: dict, root: Path | None = None) 
     if name in EXTERNAL_EFFECT_TOOLS:
         return decision("external_effect", "ask", "external side effects require human approval", "call", requires_human=True)
     if name in {"bash", "shell", "run", "run_in_dir", "run_background"}:
-        return _classify_command(str(args.get("command", "")))
+        return _classify_command(str(args.get("command", "")), root)
     if name == "kill_task":
         return decision("task_control", "ask", "stopping a running task requires approval", "call", requires_human=True)
     return decision("unknown", "ask", "unknown tools never run silently", "call", requires_human=True)
@@ -303,27 +374,35 @@ def _headless_configured_command(
         for pattern, permission in permissions.items()
         if isinstance(permission, dict) and permission.get("source") == "config"
     }
-    # The shipped historical Bash(co *) grant is broader than its "safe CLI"
-    # description. Preserve the unattended browser/status compatibility users
-    # relied on without silently authorizing email, account, server, or payment
-    # commands. Operators can still name a narrower command explicitly.
-    broad_co = configured.pop("Bash(co *)", None)
-    if broad_co is not None:
-        subcommands = _extract_subcommands(
-            str((pending.get("arguments") or {}).get("command", ""))
-        )
-        if subcommands and all(
+    # A read-only segment needs no grant: `co browser ... | head -40` is the
+    # granted browser command plus a filter on its output. Every other segment
+    # must match a standing grant, so `co browser status && co email send ...`
+    # is still an email send nobody authorized (#1481).
+    command = str((pending.get("arguments") or {}).get("command", ""))
+    try:
+        root = project_root().resolve()
+        segments = _extract_subcommands(command)
+        needs_grant = [
+            full for _, full in segments
+            if _classify_single_command(full, root).get("effect_class") != "read"
+        ]
+        if _has_output_redirect(command):
+            needs_grant = [full for _, full in segments]
+        # The shipped historical Bash(co *) grant is broader than its "safe CLI"
+        # description. Preserve the unattended browser/status compatibility
+        # users relied on without silently authorizing email, account, server,
+        # or payment commands. Operators can still name a narrower command.
+        broad_co = configured.pop("Bash(co *)", None)
+        if broad_co is not None and needs_grant and all(
             full == "co status" or full.startswith("co browser ")
-            for _, full in subcommands
+            for full in needs_grant
         ):
             configured["Bash(co *)"] = broad_co
-    try:
-        permitted, _, _ = check_bash_chain_permitted(
-            str((pending.get("arguments") or {}).get("command", "")), configured
-        )
+        for full in needs_grant:
+            permitted, _, _ = check_bash_chain_permitted(full, configured)
+            if not permitted:
+                return None
     except Exception:
-        return None
-    if not permitted:
         return None
     return decision(
         "configured_command",

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -64,6 +64,35 @@ _READ_ONLY_COMMANDS = {
     "which", "file", "stat", "diff", "date", "whoami", "hostname", "uname",
 }
 _SED_IN_PLACE_FLAGS = ("-i", "--in-place")
+# Key material, recognised by where it lives and what it is called rather than
+# by substring: `keys.md` is documentation and `monkey.txt` is a file. Reading
+# any of this is a credential read wherever it sits, so the workspace rule is
+# not what protects it — the workspace often *is* the home directory, a key
+# gets committed, and `.co/keys/` holds the agent's own signing key.
+_CREDENTIAL_DIRS = {".ssh", ".gnupg", ".aws", ".azure", ".kube", ".docker", "keys"}
+_CREDENTIAL_FILES = {
+    "id_rsa", "id_ed25519", "id_ecdsa", "id_dsa", "authorized_keys",
+    ".npmrc", ".netrc", ".pgpass", ".git-credentials", ".pypirc",
+    "keys.env", "credentials", "service-account.json", "id_rsa.pub",
+}
+_CREDENTIAL_SUFFIXES = (".pem", ".key", ".p12", ".pfx", ".jks", ".keystore", ".ppk")
+
+
+def _is_key_material(word: str) -> bool:
+    """True if this argument names key material."""
+    import os
+
+    normalised = os.path.normpath(word).replace(os.sep, "/").lstrip("/")
+    parts = [part for part in normalised.split("/") if part not in ("", ".", "..")]
+    if not parts:
+        return False
+    name = parts[-1].lower()
+    return (
+        any(part.lower() in _CREDENTIAL_DIRS for part in parts[:-1])
+        or name in _CREDENTIAL_DIRS          # the directory itself, e.g. `ls .co/keys`
+        or name in _CREDENTIAL_FILES
+        or name.endswith(_CREDENTIAL_SUFFIXES)
+    )
 # The read-only commands that open the paths they are given. `basename`,
 # `echo`, `pwd` and friends take strings, not files, and `cd` is here because
 # leaving the workspace makes every later relative path a path outside it.
@@ -225,7 +254,7 @@ def _classify_single_command(command: str, root: Path | None = None) -> dict:
         return decision("external_network", "ask", "external network access requires human approval", "call", requires_human=True)
     if first in _SENSITIVE_COMMANDS or any(
         ".env" in token or "credential" in token or "secret" in token for token in lowered
-    ):
+    ) or any(_is_key_material(word) for word in words[1:] if not word.startswith("-")):
         return decision("credentials", "deny", "credential access is never auto-approved", "call")
 
     focused = first in _FOCUSED_COMMANDS

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -59,11 +59,19 @@ _SENSITIVE_COMMANDS = {
 # deliberately not widened here.
 _READ_ONLY_COMMANDS = {
     "head", "tail", "cat", "less", "more", "grep", "egrep", "fgrep", "rg",
-    "wc", "ls", "sed", "awk", "sort", "uniq", "cut", "tr", "basename",
+    "wc", "ls", "sort", "uniq", "cut", "tr", "basename",
     "dirname", "jq", "echo", "printf", "pwd", "cd", "true", "test", "[",
     "which", "file", "stat", "diff", "date", "whoami", "hostname", "uname",
 }
-_SED_IN_PLACE_FLAGS = ("-i", "--in-place")
+# `sed` and `awk` are deliberately absent. They take a *program*, and a
+# program is code: `awk 'BEGIN{system("rm -rf /")}'` reads like an inspection
+# and is arbitrary execution, as does `sed 's/a/b/e'` on GNU. Any rule that
+# tried to keep them while excluding their execution constructs would be a
+# parser in a security path, written by the person it has to outsmart. The
+# inspection they are reached for has cover: `head`, `tail`, `cut`, `sort`,
+# `uniq`, `wc`, `jq` and `grep` are on the list, `read_file` takes `limit`
+# and `offset`, and the agent has `grep` and `glob` tools. Both still ask,
+# which is what they did before 1.8.5 as well.
 # Key material, recognised by where it lives and what it is called rather than
 # by substring: `keys.md` is documentation and `monkey.txt` is a file. Reading
 # any of this is a credential read wherever it sits, so the workspace rule is
@@ -98,8 +106,7 @@ def _is_key_material(word: str) -> bool:
 # leaving the workspace makes every later relative path a path outside it.
 _PATH_READING_COMMANDS = {
     "head", "tail", "cat", "less", "more", "grep", "egrep", "fgrep", "rg",
-    "wc", "ls", "sed", "awk", "sort", "uniq", "cut", "jq", "file", "stat",
-    "diff", "cd",
+    "wc", "ls", "sort", "uniq", "cut", "jq", "file", "stat", "diff", "cd",
 }
 
 
@@ -269,8 +276,6 @@ def _classify_single_command(command: str, root: Path | None = None) -> dict:
     if focused:
         return decision("verification", "allow", "focused test, lint, or build command", "workspace")
     if first in _READ_ONLY_COMMANDS:
-        if first == "sed" and any(w.startswith(_SED_IN_PLACE_FLAGS) for w in words[1:]):
-            return decision("workspace_edit", "ask", "sed -i rewrites files; use the edit tool", "call", requires_human=True)
         if root is not None and first in _PATH_READING_COMMANDS and _reads_outside_workspace(words, root):
             return decision("read_outside_workspace", "ask", "reading outside the workspace requires approval", "call", requires_human=True)
         return decision("read", "allow", "read-only command", "workspace")

--- a/docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md
+++ b/docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md
@@ -1,0 +1,127 @@
+# Sixty green tests and a job that could not run
+
+At iteration sixteen of a LinkedIn round that runs seven times a day, the agent
+asked to look at a page it had just fetched:
+
+```
+CO_WHO=x co browser -t t get_text | head -40
+```
+
+and got back
+
+```
+Tool 'bash' denied by connectonion.auto: command is outside the focused
+verification allowlist; no approval channel is available
+```
+
+It never recovered. Twenty-eight of three hundred iterations, zero comments
+posted, no report written, and three health checks that read the report went
+red for a reason none of them could name. The operator found it the next
+morning. The test suite, sixty-odd tests deep on exactly this approval policy,
+had been green the whole time.
+
+## The tests were right
+
+The first instinct is that a test was missing. It was not. There is a test that
+says an unknown shell command asks a person. There is a test that says, when
+no person is present, asking fails closed. Both were written on purpose in
+1.7, both have names that say what they check, and both were passing because
+the code did exactly that.
+
+`head` is not on any list. Neither is `grep`, `wc`, `cat`, `ls`, `tail`,
+`sed`. Only eleven commands auto-approve, all of them test and build tools.
+Everything else asks, and unattended, asking is refusing. Then the chain rule
+compounds it: every segment of a piped command needs its own permission, so
+the shipped grant that covered `co browser ...` was worthless the moment the
+model piped its output into a filter.
+
+None of that is a bug in the sense a test can find. The tests encode the
+policy, the policy said this, and the policy was wrong. A suite built to catch
+"the code does not do what we said" has no purchase on "what we said is not
+what an operator needs."
+
+## What was missing was the job
+
+Every one of those sixty tests is a single call to the classifier: this
+command, this verdict. Not one of them models what an unattended agent
+actually does when given a task. So I wrote that test: an agent, with nobody
+to ask, writes a small Rust command-line tool, builds it, runs its tests, runs
+the binary, and looks at the result through `head` and `wc` and `grep`. The
+model is scripted; the Agent loop, the tool executor, the approval plugin and
+`cargo` are real.
+
+It failed on the first step. Not on `| head`. On `mkdir`.
+
+Not because `mkdir` was refused — the operator grant covered it — but because
+the agent was `quiet=True`, as every unattended agent is, and a quiet agent's
+logger has no console. Six places in the approval code reached
+`agent.logger.console.log_permission_granted(...)` directly. The policy said
+yes, then the plugin crashed on the way to saying so, and the tool result read
+`'NoneType' object has no attribute 'log_permission_granted'`. Every
+auto-approved call in every quiet agent had been doing this. The unit tests
+never built a quiet Agent; they built a `SimpleNamespace` with `logger=None`,
+which the guard handled.
+
+The second finding was quieter. Every policy decision is supposed to be
+recorded on the trace entry for its tool call, and there is a test that checks
+the decision has the right fields. The recorder matched the entry by `id`; the
+executor stores the call id as `tool_id`. In a real agent the decision never
+reached the trace. The test passed because its fake pending tool had no id at
+all, and "no id" matched the last entry.
+
+Three bugs, then, from one test that runs the job instead of the table.
+
+## The fix, and what it does not touch
+
+Read-only commands now run in Auto without asking: the filters and printers
+you reach for to look at output. Two things take a command back out: a path
+argument that resolves outside the workspace asks, the way the read tools
+already do, and `sed -i` asks, because it rewrites the file. An output
+redirect is a file write and is held to the write tool's rule — inside the
+workspace it is allowed, a control file or a path outside is denied; `2>&1` is
+not a write. In an unattended run, a read-only pipe segment rides along beside
+a granted command, and every other segment still needs its own grant, so `co
+browser status && co email send` is still an email send nobody authorized.
+
+This is the Auto policy for the agent's own calls. The remote-EXEC whitelist in
+`host.yaml` carries a comment saying it must never include `cat` or `head`,
+and it still does not. Two different questions: what may a stranger make this
+agent run, and what may this agent run for itself.
+
+## What the Rust test pins down
+
+The scripted job needs exactly two operator grants: `mkdir`, and the binary it
+just built. Everything else — the file writes, `cargo build`, `cargo test`, and
+every `cd`, `tail`, `head`, `wc`, `ls`, `grep` around them — rides on the
+built-in policy. The test asserts which rule carried each step, and a second
+test takes the two grants away and asserts that exactly those two steps are
+refused and nothing else. If a future policy change makes `| tail -20` need a
+grant again, that test fails at the build step, with the step and the rule
+named, instead of in production at iteration sixteen.
+
+## What a real model reaches for
+
+A real-model version of the same job sits behind the `real_api` marker. It
+lets the model pick the commands, which is how you find out what a model
+reaches for that the list does not cover. Three runs, three findings.
+
+The first run wrote `main.rs` with `cat << 'EOF' > greeter/src/main.rs`, a
+heredoc. `bashlex` cannot parse a here-document, an unparseable command asks,
+and unattended that is a refusal. So a heredoc is now classified by its first
+line — the body is data to `cat` — and a redirect into a workspace file is
+held to the write tool's rule: inside the workspace it is a reversible edit,
+a control file is denied, outside is denied. `bash << EOF` still asks,
+because `bash` is not read-only and the body is what it would run.
+
+The second run started with `cargo new`, which writes `src/main.rs`; then
+`write` refused to overwrite an existing file, the heredoc was blocked by the
+plugin that steers models toward the write tool, and the model tried
+`python3 -c "open(...).write(...)"`. The policy refused that, correctly. It
+also refused `ping -c 1 8.8.8.8`, correctly. The model rewrote the project
+around `lib.rs` and finished anyway: tests green, binary built, `Hello,
+Aaron!`. The finding was about the operator's setup, not the policy — give
+the agent an `edit` tool — and about the test: a refusal is a finding to
+print, not a failure, when the policy was right to refuse. What decides the
+test is whether the job got done with nobody present.
+
+The third run passed in twenty-two seconds.

--- a/docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md
+++ b/docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md
@@ -184,5 +184,56 @@ That widening was the one thing in this change that made the system less
 safe than 1.8.4, and it lasted about an hour, because I wrote down what I was
 unsure about instead of hoping nobody asked.
 
-Five of the six bugs here were found by running the thing rather than by
-reading it. The sixth was found by a test — the one I wrote to run the thing.
+## The sweep
+
+At that point the pattern was obvious enough to industrialise. I wrote out
+twenty-six things an attacker would try — `cd /etc && cat passwd`,
+exfiltration through the granted browser command, `tee`, `cp`, `dd`, `ln -s`,
+`sh -c`, `perl -e`, `python3 -c`, a read-only first segment carrying a payload
+after `&&` — and printed the verdict for each.
+
+Twenty-five refused. The twenty-sixth was `make install`.
+
+That one predates all of this: 1.8.4 allowed `make install`, bare `make`, and
+`make -C /etc all`, all classified as "focused test, lint, or build command".
+`cargo` had been narrowed to `test`/`check`/`clippy`/`build`, `go` to `test`,
+the package runners to targets naming test or lint or build. `make` was the
+one nobody got to. It now needs a named verification target and no `-C` or
+`-f` pointing it somewhere else.
+
+It is worth being precise about what that fixes, because it would be easy to
+oversell. The focused-verification category is an execution surface on
+purpose: an agent that may write a test and run it may run whatever that test
+runs, and no amount of target-name checking changes that. What the narrowing
+removes is the commands in that category that were never verification —
+`make install` writes outside the workspace by convention, and that is a
+different claim from "run my tests".
+
+One more came out of the same sweep, which I had thought was already covered:
+
+```
+cat $(cat which_file.txt)   →  allow
+```
+
+The outside-workspace check looks at arguments that look like paths. That one
+does not look like a path; it looks like a substitution, and it reads whatever
+the file names. Two neighbouring cases had been refused and I had taken that
+as the rule holding — `head $(echo /etc/shadow)` because bashlex splits the
+word and the tail starts with a slash, `cat ${SECRET_PATH}` because the word
+happens to contain "secret". Luck, twice, in a security path. A file argument
+containing `$(`, a backtick or `$name` now asks; a bare `$` still means
+end-of-line, so `grep 'foo$' notes.txt` is untouched.
+
+## The tally
+
+Six defects, one of them the reported bug and five found while fixing it,
+plus two pre-existing holes in code the fix sat next to. Of the eight, one
+was found by a test. The other seven were found by running the thing: an
+agent doing a real job, the real CLI in a throwaway directory, and a list of
+what an attacker would try with the verdicts printed beside it.
+
+The suite is not what found them, and it was never going to be — it had sixty
+green tests on this exact policy while production was failing. What the suite
+does is hold them. Every one of the eight now has a test that was red before
+the fix, so the next person to widen this policy gets told which specific
+thing they broke, by name, in about forty seconds.

--- a/docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md
+++ b/docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md
@@ -162,6 +162,27 @@ The shell rule and the tool rule disagreed. `cat server.pem` was denied;
 the only reason nothing leaked is that the model happened to have better
 manners than the policy. Both now refuse key material by the same rule.
 
-Four of the five bugs in this change were found by running the thing rather
-than by reading it. The fifth was found by a test — the one I wrote to run
-the thing.
+Then the third, and this one I had already written down. The pull request
+said, under "least confident about": *`awk` can call `system()` and GNU `sed`
+has an `e` flag, neither of which this checks.* Having written the sentence,
+I ran it:
+
+```
+awk 'BEGIN{system("rm -rf /")}'   →  allow
+```
+
+There is no clever fix. Keeping `awk` and `sed` on a read-only list while
+excluding the ways they execute means writing a parser for two languages, in
+a security path, and being right about it — against an adversary who is
+prompt injection and has all day. The honest line is the one the category
+already implies: a command that takes a *program* is not a command that
+reads. Both come off the list. They ask, which is what they did before any
+of this, and the inspection they get reached for is covered by `head`,
+`tail`, `cut`, `jq` and `read_file(limit=, offset=)`.
+
+That widening was the one thing in this change that made the system less
+safe than 1.8.4, and it lasted about an hour, because I wrote down what I was
+unsure about instead of hoping nobody asked.
+
+Five of the six bugs here were found by running the thing rather than by
+reading it. The sixth was found by a test — the one I wrote to run the thing.

--- a/docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md
+++ b/docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md
@@ -149,3 +149,19 @@ substrings, so `keys.md` is still documentation. Ten tests, red first.
 That one was not found by a test. It was found by writing down what the
 answers ought to be, running them, and looking at the column that did not
 match. The tests then made it permanent.
+
+And then the same method found the next one. With the key rule in, I ran the
+whole thing through the real `co ai` — no scripted model, no fixture, the
+actual CLI in a temp project — and asked it for `cat server.pem | head -2`.
+The model declined, politely, on its own initiative. But the transcript above
+its refusal showed it had first called `read_file` on the same file, and the
+console had printed `policy read-only workspace operation` beside it.
+
+The shell rule and the tool rule disagreed. `cat server.pem` was denied;
+`read_file("server.pem")` was allowed. A gate one tool wide is a detour, and
+the only reason nothing leaked is that the model happened to have better
+manners than the policy. Both now refuse key material by the same rule.
+
+Four of the five bugs in this change were found by running the thing rather
+than by reading it. The fifth was found by a test — the one I wrote to run
+the thing.

--- a/docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md
+++ b/docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md
@@ -125,3 +125,27 @@ print, not a failure, when the policy was right to refuse. What decides the
 test is whether the job got done with nobody present.
 
 The third run passed in twenty-two seconds.
+
+## One more, found by not trusting the tests
+
+With the suite green I ran the issue's own table by hand — the shipped
+permissions, an agent with `io=None`, sixteen commands, print the verdict
+beside the one I expected. Fifteen matched. `head ~/.ssh/id_rsa` came back
+**allow**.
+
+The outside-workspace rule was supposed to catch it, and normally does,
+because `~` is not the project. In that check HOME *was* the project, which
+is the shape the test suite's own isolation creates — and is also a real
+configuration, and is also what happens when a key gets committed, and is
+always true of the agent's own `.co/keys/agent.key`. The credential check
+only looked for `.env`, `secret` and `credential` in the words. A private key
+matched none of them.
+
+So key material is now recognised by where it lives and what it is called,
+and denied wherever it sits: anything under `.ssh`, `.gnupg`, `.aws`, a `keys`
+directory; the usual filenames; the usual suffixes. On path components, not
+substrings, so `keys.md` is still documentation. Ten tests, red first.
+
+That one was not found by a test. It was found by writing down what the
+answers ought to be, running them, and looking at the column that did not
+match. The tests then made it permanent.

--- a/docs/features/permissions.md
+++ b/docs/features/permissions.md
@@ -9,6 +9,9 @@ the human approval hook:
 
 - workspace reads and reversible workspace edits are allowed;
 - focused test, lint, type-check, and build commands are allowed;
+- read-only shell commands (`head`, `grep`, `wc`, `ls`, `sed` without `-i`, ...)
+  on workspace paths with no output redirect are allowed, alone or as pipe
+  segments beside a granted command (#1481);
 - deletions and credential access are denied;
 - deployment, publishing, external communication, payments, outside-workspace
   reads, and unknown tools ask a person.

--- a/docs/features/permissions.md
+++ b/docs/features/permissions.md
@@ -12,7 +12,8 @@ the human approval hook:
 - read-only shell commands (`head`, `grep`, `wc`, `ls`, `sed` without `-i`, ...)
   on workspace paths with no output redirect are allowed, alone or as pipe
   segments beside a granted command (#1481);
-- deletions and credential access are denied;
+- deletions and credential access are denied, including reads of key material
+  by path or name (`.ssh/`, `.co/keys/`, `id_rsa`, `*.pem`, ...) wherever it sits;
 - deployment, publishing, external communication, payments, outside-workspace
   reads, and unknown tools ask a person.
 

--- a/docs/features/permissions.md
+++ b/docs/features/permissions.md
@@ -9,9 +9,10 @@ the human approval hook:
 
 - workspace reads and reversible workspace edits are allowed;
 - focused test, lint, type-check, and build commands are allowed;
-- read-only shell commands (`head`, `grep`, `wc`, `ls`, `sed` without `-i`, ...)
-  on workspace paths with no output redirect are allowed, alone or as pipe
-  segments beside a granted command (#1481);
+- read-only shell commands (`head`, `tail`, `grep`, `wc`, `ls`, `cut`, `jq`, ...)
+  on workspace paths are allowed, alone or as pipe segments beside a granted
+  command; nothing that takes a program text is read-only, so `sed` and `awk`
+  still ask (#1481);
 - deletions and credential access are denied, including reads of key material
   by path or name (`.ssh/`, `.co/keys/`, `id_rsa`, `*.pem`, ...) wherever it sits;
 - deployment, publishing, external communication, payments, outside-workspace

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -161,13 +161,20 @@ basename dirname jq echo printf pwd cd true test [ which file stat diff
 date whoami hostname uname
 ```
 
-Three things take a command back out of this list: a path argument that
+Two things take a command back out of this list: a path argument that
 resolves outside the workspace (`cat /etc/hosts`, `head ~/.ssh/id_rsa`,
 `cd ..`) asks, the same way the read *tools* ask for outside-workspace reads;
-`sed -i` / `--in-place` asks, because it rewrites the file; and any output
-redirect that points at a file (`> out`, `>> log`, `2> err`) turns the whole
-chain into a write and it asks. `2>&1` is not a write. Credential tokens
-(`.env`, `secret`, `credential`) are denied before any of this applies.
+and `sed -i` / `--in-place` asks, because it rewrites the file. Credential
+tokens (`.env`, `secret`, `credential`) are denied before any of this applies.
+
+An output redirect (`> out`, `>> log`, `2> err`) is a file write and is held
+to the write tool's rules: inside the workspace it is a reversible edit and
+allowed (`echo x > notes.txt`, `cat << 'EOF' > src/main.rs ... EOF` — models
+reach for both instead of the write tool); a control file is denied; a target
+outside the workspace is denied; a target that depends on the environment
+(`> $HOME/x`) cannot be resolved and asks. `2>&1` is not a write. A heredoc
+is classified by its first line — the body is data to that command — so
+`bash << EOF` still asks, because `bash` is not read-only.
 
 The same list decides which pipe segments ride along on an operator grant in
 an unattended run. `co browser ... get_text | head -40` is the granted browser

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -8,7 +8,7 @@ human decision.
 | Mode | Behaviour |
 |---|---|
 | `read-only` | Manual approval for every effectful live-IO call not explicitly permitted |
-| `auto` | Auto-approves reversible workspace work and focused verification; asks or denies higher-impact calls |
+| `auto` | Auto-approves reversible workspace work, focused verification, and read-only commands on workspace paths; asks or denies higher-impact calls |
 | `full-access` | Explicit bounded approval bypass under the Host launch ceiling |
 
 No aliases are accepted or translated. Unknown stored values become Auto.
@@ -149,6 +149,33 @@ write, edit, multi_edit
 run_background, kill_task
 send_email, post, delete, remove
 ```
+
+### Read-Only Commands (Auto)
+
+In Auto, a shell command whose every segment only reads, filters or prints
+runs without a dialog — and, unattended, without being denied:
+
+```
+head tail cat less more grep egrep fgrep rg wc ls sed awk sort uniq cut tr
+basename dirname jq echo printf pwd cd true test [ which file stat diff
+date whoami hostname uname
+```
+
+Three things take a command back out of this list: a path argument that
+resolves outside the workspace (`cat /etc/hosts`, `head ~/.ssh/id_rsa`,
+`cd ..`) asks, the same way the read *tools* ask for outside-workspace reads;
+`sed -i` / `--in-place` asks, because it rewrites the file; and any output
+redirect that points at a file (`> out`, `>> log`, `2> err`) turns the whole
+chain into a write and it asks. `2>&1` is not a write. Credential tokens
+(`.env`, `secret`, `credential`) are denied before any of this applies.
+
+The same list decides which pipe segments ride along on an operator grant in
+an unattended run. `co browser ... get_text | head -40` is the granted browser
+command plus a filter on its output, so it runs; `co browser status && co email
+send ...` is still an email send nobody authorized, so it does not (#1481).
+
+This is the Auto policy for the agent's own calls. The remote-EXEC whitelist
+in `host.yaml` is a separate gate and is not widened by it.
 
 ### Unknown Tools
 

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -178,6 +178,11 @@ on the workspace rule — the workspace is sometimes the home directory, keys
 get committed, and `.co/keys/` is under the project root. Matching is on path
 components and suffixes, so `keys.md` and `monkey.txt` are ordinary files.
 
+The read, write, edit and delete *tools* hold the same line: `read_file`,
+`glob`, `write`, `edit` and the rest refuse key material by the same rule.
+They have to — a gate one tool wide is a detour, and a model asked for
+`cat server.pem` will simply reach for `read_file` instead.
+
 An output redirect (`> out`, `>> log`, `2> err`) is a file write and is held
 to the write tool's rules: inside the workspace it is a reversible edit and
 allowed (`echo x > notes.txt`, `cat << 'EOF' > src/main.rs ... EOF` — models

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -150,6 +150,17 @@ run_background, kill_task
 send_email, post, delete, remove
 ```
 
+### Focused Verification (Auto)
+
+Test, lint, type-check and build commands run without a dialog. This category
+is an execution surface by design — an agent that may write a test and run it
+may run whatever that test runs — so what the narrowing does is keep out the
+commands in it that are not verification at all. `cargo` is limited to
+`test`/`check`/`clippy`/`build`, `go` to `test`, the package runners to
+targets naming test/lint/build/check/typecheck, and `make` to a named
+verification target with no `-C`/`-f` redirecting it elsewhere: `make test`
+runs, `make install`, bare `make` and `make -C /etc all` ask.
+
 ### Read-Only Commands (Auto)
 
 In Auto, a shell command whose every segment only reads, filters or prints

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -156,15 +156,22 @@ In Auto, a shell command whose every segment only reads, filters or prints
 runs without a dialog — and, unattended, without being denied:
 
 ```
-head tail cat less more grep egrep fgrep rg wc ls sed awk sort uniq cut tr
+head tail cat less more grep egrep fgrep rg wc ls sort uniq cut tr
 basename dirname jq echo printf pwd cd true test [ which file stat diff
 date whoami hostname uname
 ```
 
-Two things take a command back out of this list: a path argument that
-resolves outside the workspace (`cat /etc/hosts`, `head ~/.ssh/id_rsa`,
-`cd ..`) asks, the same way the read *tools* ask for outside-workspace reads;
-and `sed -i` / `--in-place` asks, because it rewrites the file.
+`sed` and `awk` are deliberately **not** on it. They take a program, and a
+program is code: `awk 'BEGIN{system("rm -rf /")}'` reads like an inspection
+and is arbitrary execution, and GNU `sed`'s `e` flag is the same. A rule that
+kept them while excluding their execution constructs would be a parser in a
+security path. Both ask, as they did before 1.8.5, including their innocent
+shapes — whose job `head`, `tail`, `cut` and `read_file(limit=, offset=)`
+already do. Nothing else on the list takes a program text.
+
+One thing takes a listed command back out: a path argument that resolves
+outside the workspace (`cat /etc/hosts`, `head ~/.ssh/id_rsa`, `cd ..`) asks,
+the same way the read *tools* ask for outside-workspace reads.
 
 Credentials are denied before any of this applies, and not only by token
 (`.env`, `secret`, `credential`): key material is recognised by where it lives

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -169,9 +169,13 @@ security path. Both ask, as they did before 1.8.5, including their innocent
 shapes — whose job `head`, `tail`, `cut` and `read_file(limit=, offset=)`
 already do. Nothing else on the list takes a program text.
 
-One thing takes a listed command back out: a path argument that resolves
+Two things take a listed command back out. A path argument that resolves
 outside the workspace (`cat /etc/hosts`, `head ~/.ssh/id_rsa`, `cd ..`) asks,
-the same way the read *tools* ask for outside-workspace reads.
+the same way the read *tools* ask for outside-workspace reads. And a file
+argument the policy cannot resolve asks: `cat $(cat which_file.txt)` reads
+whatever that file names and `head $HOME/x` whatever `HOME` is, so neither is
+a checked read. A bare `$` is end-of-line, not a variable, so
+`grep 'foo$' notes.txt` is unaffected.
 
 Credentials are denied before any of this applies, and not only by token
 (`.env`, `secret`, `credential`): key material is recognised by where it lives

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -164,8 +164,19 @@ date whoami hostname uname
 Two things take a command back out of this list: a path argument that
 resolves outside the workspace (`cat /etc/hosts`, `head ~/.ssh/id_rsa`,
 `cd ..`) asks, the same way the read *tools* ask for outside-workspace reads;
-and `sed -i` / `--in-place` asks, because it rewrites the file. Credential
-tokens (`.env`, `secret`, `credential`) are denied before any of this applies.
+and `sed -i` / `--in-place` asks, because it rewrites the file.
+
+Credentials are denied before any of this applies, and not only by token
+(`.env`, `secret`, `credential`): key material is recognised by where it lives
+and what it is called — anything under `.ssh`, `.gnupg`, `.aws`, `.azure`,
+`.kube`, `.docker` or a `keys` directory (which includes the agent's own
+`.co/keys/`), the usual filenames (`id_rsa`, `id_ed25519`, `authorized_keys`,
+`.npmrc`, `.netrc`, `.git-credentials`, `.pypirc`, `keys.env`), and the usual
+suffixes (`.pem`, `.key`, `.p12`, `.pfx`, `.jks`, `.keystore`, `.ppk`). A read
+of key material is a credential read wherever it sits, so this does not depend
+on the workspace rule — the workspace is sometimes the home directory, keys
+get committed, and `.co/keys/` is under the project root. Matching is on path
+components and suffixes, so `keys.md` and `monkey.txt` are ordinary files.
 
 An output redirect (`> out`, `>> log`, `2> err`) is a file write and is held
 to the write tool's rules: inside the workspace it is a reversible edit and

--- a/tests/e2e/real_api/test_real_unattended_rust_cli.py
+++ b/tests/e2e/real_api/test_real_unattended_rust_cli.py
@@ -1,0 +1,120 @@
+"""A real model, unattended, writes a Rust CLI and gets it built, tested and run.
+
+The scripted version of this job lives in
+tests/e2e/test_an_unattended_agent_builds_a_rust_cli.py and runs on every CI
+pass. This one lets the model choose the commands. It is the test that says
+whether the read-only allowlist and the operator grants cover what a
+model *actually* reaches for — `cargo new`? `cat -n`? `ls -la target/`? — not
+what we imagined it would. Opt-in: real_api, paid, needs a key.
+
+The verification at the end is independent of the model's own claims: the
+test itself re-runs `cargo test` and the binary.
+"""
+
+import os
+import pwd
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from connectonion import Agent
+from connectonion.useful_plugins import prefer_write_tool
+from connectonion.useful_plugins.tool_approval import tool_approval
+from connectonion.useful_tools.bash import bash
+from connectonion.useful_tools.file_tools import edit, read_file, write
+
+CARGO = shutil.which("cargo") or shutil.which("cargo", path="/opt/homebrew/bin:/usr/local/bin")
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.timeout(600),   # a real model plus a cold cargo build, not a unit test
+    pytest.mark.skipif(CARGO is None, reason="cargo is not installed on this machine"),
+]
+
+HOST_YAML = {
+    "name": "rust-builder",
+    "permissions": {
+        "Bash(mkdir *)": {"allowed": True, "source": "config", "reason": "project layout", "expires": {"type": "never"}},
+        "Bash(cargo *)": {"allowed": True, "source": "config", "reason": "cargo new/run are not in the focused list", "expires": {"type": "never"}},
+        "Bash(./target/debug/greeter *)": {"allowed": True, "source": "config", "reason": "run what it built", "expires": {"type": "never"}},
+        "Bash(./greeter/target/debug/greeter *)": {"allowed": True, "source": "config", "reason": "same binary from the parent dir", "expires": {"type": "never"}},
+    },
+}
+
+PROMPT = (
+    "Create a Rust command-line tool called greeter in the directory ./greeter "
+    "(relative to the current directory). It takes --name <name> and prints "
+    "'Hello, <name>!'. Include a unit test for the greeting function. Build it "
+    "with cargo, run the tests, then run the binary with --name Aaron and show "
+    "the first line of its output. You are running unattended: nobody can "
+    "approve anything, so stay inside ./greeter and do not delete files."
+)
+
+
+def test_a_real_model_builds_tests_and_runs_the_cli_unattended(tmp_path, monkeypatch):
+    real_home = Path(pwd.getpwuid(os.getuid()).pw_dir)
+    for var, sub in (("RUSTUP_HOME", ".rustup"), ("CARGO_HOME", ".cargo")):
+        if not os.environ.get(var) and (real_home / sub).is_dir():
+            monkeypatch.setenv(var, str(real_home / sub))
+    monkeypatch.setenv("CARGO_NET_OFFLINE", "true")
+    monkeypatch.setenv("PATH", f"{Path(CARGO).parent}{os.pathsep}{os.environ.get('PATH', '')}")
+    (tmp_path / ".co").mkdir()
+    (tmp_path / ".co" / "host.yaml").write_text(yaml.safe_dump(HOST_YAML), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    # prefer_write_tool is what a shipped co-ai agent runs with: the first
+    # real run of this test wrote main.rs through `cat << 'EOF' > file`, a
+    # heredoc bashlex cannot parse, and an unparseable command asks — so the
+    # policy refused it. The plugin steers the model to the write tool, which
+    # is the reversible edit the policy allows.
+    # `edit` is here because the first runs showed why: the model ran
+    # `cargo new`, which writes src/main.rs, and `write` refuses to overwrite
+    # an existing file. Without `edit` it tried a heredoc (blocked), then
+    # `python3 -c "open(...).write(...)"` (denied, correctly), then rewrote
+    # the project around lib.rs. It got there; an operator would rather it
+    # had an edit tool.
+    agent = Agent(
+        "rust-builder",
+        tools=[bash, write, edit, read_file],
+        plugins=[tool_approval, prefer_write_tool],
+        max_iterations=25,
+        log=False,
+        quiet=True,
+    )
+    assert agent.io is None
+
+    answer = agent.input(PROMPT)
+
+    trace = agent.current_session["trace"]
+    calls = [e for e in trace if e.get("type") == "tool_call"]
+    what_it_did = [(c["name"], str(c["args"].get("command", c["args"].get("path")))[:160]) for c in calls]
+    results = [e for e in trace if e.get("type") == "tool_result"]
+    # Printed so a failure report shows the whole run, not a truncated repr.
+    for call, result in zip(what_it_did, results):
+        print(f"{call[0]:>10}  {result.get('status'):>8}  {call[1]!r}")
+        if result.get("status") != "success":
+            print(f"{'':>21}-> {str(result.get('result'))[:300]!r}")
+    refused = [
+        (c["args"].get("command", c["args"].get("path")), c.get("approval_policy"))
+        for c in calls
+        if (c.get("approval_policy") or {}).get("decision") != "allow"
+    ]
+    # Refusals are findings, not failures. The first runs refused
+    # `ping -c 1 8.8.8.8` and `python3 -c "open(...).write(...)"` — both
+    # correct — and the model finished the job anyway. What decides this test
+    # is whether the job got done with nobody present. A refusal of a command
+    # the policy *should* allow shows up in the printout above and, if the
+    # model could not route around it, in the outcome asserts below.
+    for command, policy in refused:
+        print(f"refused: {command!r} -> {(policy or {}).get('reason')}")
+
+    project = tmp_path / "greeter"
+    binary = project / "target" / "debug" / "greeter"
+    assert binary.exists(), f"no binary; model said: {answer!r}"
+    tests = subprocess.run([CARGO, "test", "--quiet"], cwd=project, capture_output=True, text=True, timeout=600)
+    assert tests.returncode == 0, tests.stdout + tests.stderr
+    run = subprocess.run([str(binary), "--name", "Aaron"], capture_output=True, text=True, timeout=60)
+    assert run.stdout.strip().splitlines()[0] == "Hello, Aaron!", run.stdout

--- a/tests/e2e/test_an_unattended_agent_builds_a_rust_cli.py
+++ b/tests/e2e/test_an_unattended_agent_builds_a_rust_cli.py
@@ -1,0 +1,228 @@
+"""An unattended agent writes a small Rust CLI, builds it, tests it, and runs it.
+
+Why this test exists
+--------------------
+The Auto policy has sixty-odd unit tests, every one a single call to the
+classifier: this command → this verdict. They were all green while a 7×/day
+LinkedIn round died in production on `co browser ... get_text | head -40`,
+because the tests encoded "unknown command asks" as correct and nothing
+modelled what an unattended job actually *does*: make a directory, write
+files, build, test, run the result, look at the output through a filter (#1481).
+
+So this is the job, end to end, with the real Agent loop, the real tool
+executor, the real approval plugin and a real toolchain. Only the model is
+scripted. The scripted calls are the ones a model reaches for when told to
+write a CLI: `mkdir`, two `write`s, `cargo build`, `cargo test`, run the
+binary, inspect with `wc`/`ls`/`grep`. Every one of them must pass the
+approval gate with nobody present, and the test records *which rule* carried
+each step, so a policy change that quietly moves one of them from allow to
+ask fails here with the step and the rule named.
+
+What an operator has to grant
+-----------------------------
+Two things, in `.co/host.yaml`, and the test grants exactly those:
+`Bash(mkdir *)` and `Bash(./target/debug/greeter *)`. Neither is read-only
+and neither is a build tool, so the built-in policy asks about them, which
+unattended is a refusal. Everything else — the file writes, `cargo build`,
+`cargo test`, and every `cd`/`head`/`tail`/`wc`/`ls`/`grep` around them —
+rides on the built-in policy alone.
+
+Needs `cargo` on PATH. Skips, with that reason, where it is not installed.
+"""
+
+import os
+import pwd
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+from connectonion import Agent
+from connectonion.useful_plugins.tool_approval import tool_approval
+from connectonion.useful_tools.bash import bash
+from connectonion.useful_tools.file_tools import write
+from tests.utils.mock_helpers import LLMResponseBuilder as R
+from tests.utils.mock_helpers import MockLLM
+
+CARGO = shutil.which("cargo") or shutil.which("cargo", path="/opt/homebrew/bin:/usr/local/bin")
+
+pytestmark = pytest.mark.skipif(
+    CARGO is None,
+    reason="cargo is not installed on this machine; the Rust e2e cannot run here (it runs on CI, which ships a Rust toolchain)",
+)
+
+CARGO_TOML = """[package]
+name = "greeter"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+"""
+
+MAIN_RS = """use std::env;
+
+fn greet(name: &str) -> String {
+    format!("Hello, {}!", name)
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let name = args
+        .iter()
+        .position(|a| a == "--name")
+        .and_then(|i| args.get(i + 1))
+        .map(String::as_str)
+        .unwrap_or("world");
+    println!("{}", greet(name));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::greet;
+
+    #[test]
+    fn greets_by_name() {
+        assert_eq!(greet("Aaron"), "Hello, Aaron!");
+    }
+}
+"""
+
+# The operator's standing grants. Each has a `reason` because that is what
+# the approval audit shows; `source: config` is what `_headless_configured_command`
+# looks for.
+HOST_YAML = {
+    "name": "rust-builder",
+    "permissions": {
+        "Bash(mkdir *)": {
+            "allowed": True,
+            "source": "config",
+            "reason": "the builder lays out its own project directories",
+            "expires": {"type": "never"},
+        },
+        "Bash(./target/debug/greeter *)": {
+            "allowed": True,
+            "source": "config",
+            "reason": "running the binary it just built is the point",
+            "expires": {"type": "never"},
+        },
+    },
+}
+
+# What the model does, in order, and which rule the test expects to carry it.
+STEPS = [
+    ("bash", {"command": "mkdir -p greeter/src", "description": "project layout"}, "configured_command"),
+    ("write", {"path": "greeter/Cargo.toml", "content": CARGO_TOML}, "workspace_edit"),
+    ("write", {"path": "greeter/src/main.rs", "content": MAIN_RS}, "workspace_edit"),
+    ("bash", {"command": "cd greeter && cargo build --quiet 2>&1 | tail -20", "description": "build", "timeout": 300}, "verification"),
+    ("bash", {"command": "cd greeter && cargo test --quiet 2>&1 | tail -20", "description": "test", "timeout": 300}, "verification"),
+    ("bash", {"command": "cd greeter && ./target/debug/greeter --name Aaron | head -1", "description": "run it"}, "configured_command"),
+    ("bash", {"command": "wc -l greeter/src/main.rs && ls greeter/target/debug | grep -c '^greeter$'", "description": "inspect"}, "read"),
+]
+
+
+@pytest.fixture
+def rust_toolchain_env(monkeypatch):
+    """The suite isolates HOME, which is right for `~/.co` and wrong for rustup.
+
+    A rustup-managed `cargo` is a proxy that finds the real toolchain through
+    RUSTUP_HOME, defaulting to ~/.rustup — the real one, not the test's empty
+    tmp HOME. CI sets RUSTUP_HOME/CARGO_HOME explicitly; a developer machine
+    usually does not. Point them at the real home only when they are unset
+    and the directories exist. A Homebrew cargo needs none of this.
+    """
+    real_home = Path(pwd.getpwuid(os.getuid()).pw_dir)
+    for var, sub in (("RUSTUP_HOME", ".rustup"), ("CARGO_HOME", ".cargo")):
+        if not os.environ.get(var) and (real_home / sub).is_dir():
+            monkeypatch.setenv(var, str(real_home / sub))
+    # No dependencies, so nothing to fetch — and nothing must try.
+    monkeypatch.setenv("CARGO_NET_OFFLINE", "true")
+    monkeypatch.setenv("PATH", f"{Path(CARGO).parent}{os.pathsep}{os.environ.get('PATH', '')}")
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """A fresh workspace with the operator's two grants and nothing else."""
+    (tmp_path / ".co").mkdir()
+    (tmp_path / ".co" / "host.yaml").write_text(yaml.safe_dump(HOST_YAML), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _scripted_model():
+    responses = [
+        R.tool_call_response(name, args, call_id=f"call_{i}")
+        for i, (name, args, _) in enumerate(STEPS)
+    ]
+    responses.append(R.text_response("Built greeter, its test passes, and it greets Aaron."))
+    return MockLLM(responses=responses, model="scripted-rust-builder")
+
+
+def test_an_unattended_agent_builds_tests_and_runs_a_rust_cli(project, rust_toolchain_env):
+    agent = Agent(
+        "rust-builder",
+        llm=_scripted_model(),
+        tools=[bash, write],
+        plugins=[tool_approval],
+        max_iterations=len(STEPS) + 2,
+        log=False,
+        quiet=True,
+    )
+    assert agent.io is None, "this test is about the run with nobody to ask"
+
+    result = agent.input(
+        "Create a Rust CLI called greeter in ./greeter that takes --name and prints "
+        "'Hello, <name>!'. Add a unit test, build it, run the tests, run it for Aaron."
+    )
+
+    trace = agent.current_session["trace"]
+    calls = [e for e in trace if e.get("type") == "tool_call"]
+    results = [e for e in trace if e.get("type") == "tool_result"]
+
+    # Every step ran, none was refused, and a person was never needed.
+    assert len(calls) == len(STEPS), [c.get("name") for c in calls]
+    refused = [r for r in results if r.get("status") != "success"]
+    assert not refused, refused
+    for (name, args, expected_rule), call in zip(STEPS, calls):
+        policy = call.get("approval_policy") or {}
+        assert policy.get("decision") == "allow", (args.get("command", args.get("path")), policy)
+        assert policy.get("requires_human") is False, (args, policy)
+        # Which rule carried the step. A policy change that moves a step to a
+        # different rule is allowed to fail here: it is telling you the
+        # operator's grants no longer mean what they did.
+        assert policy.get("effect_class") == expected_rule, (args.get("command", args.get("path")), policy)
+
+    # The toolchain did the real work.
+    by_step = {i: r["result"] for i, r in enumerate(results)}
+    assert "test result: ok. 1 passed" in by_step[4], by_step[4]
+    assert by_step[5].strip() == "Hello, Aaron!", by_step[5]
+    assert (project / "greeter" / "target" / "debug" / "greeter").exists()
+    assert result == "Built greeter, its test passes, and it greets Aaron."
+
+
+def test_the_two_grants_are_the_only_two_the_job_needs(project, rust_toolchain_env):
+    """Take the grants away and exactly the two granted steps are refused.
+
+    This is the test that would have caught #1481 in reverse: it pins down
+    that the built-in policy, not an operator grant, carries the file writes,
+    the cargo runs and every pipe filter. If a future policy change made
+    `| tail -20` need a grant again, this fails at the build step, not in
+    production at iteration sixteen.
+    """
+    (project / ".co" / "host.yaml").write_text(yaml.safe_dump({"name": "rust-builder"}), encoding="utf-8")
+    agent = Agent(
+        "rust-builder",
+        llm=_scripted_model(),
+        tools=[bash, write],
+        plugins=[tool_approval],
+        max_iterations=len(STEPS) + 2,
+        log=False,
+        quiet=True,
+    )
+
+    agent.input("same job, no grants")
+
+    calls = [e for e in agent.current_session["trace"] if e.get("type") == "tool_call"]
+    decisions = [(s[1].get("command", s[1].get("path")), c["approval_policy"]["decision"]) for s, c in zip(STEPS, calls)]
+    denied = [command for command, decision in decisions if decision == "deny"]
+    assert denied == ["mkdir -p greeter/src", "cd greeter && ./target/debug/greeter --name Aaron | head -1"], decisions

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -436,8 +436,10 @@ def test_headless_auto_allows_read_only_commands(tmp_path, monkeypatch, command)
     [
         "sed -i s/a/b/ notes.txt",            # in-place edit writes the file
         "sed --in-place s/a/b/ notes.txt",
-        "head -1 notes.txt > out.txt",        # a redirect writes wherever it points
-        "echo secret >> ~/.bashrc",
+        "echo secret >> ~/.bashrc",           # a redirect outside the workspace
+        "echo x > ../outside.txt",
+        "echo 'Bash(*)' > .co/host.yaml",     # a redirect into a control file
+        "cat notes.txt > $HOME/notes.txt",    # a redirect nobody can resolve
         "tee out.txt",                        # writes its input
         "find . -name '*.log' -delete",       # deletes
         "xargs rm",                           # runs whatever it is given
@@ -453,7 +455,9 @@ def test_read_only_names_do_not_cover_writes_or_credentials(tmp_path, monkeypatc
 
     result = instance.current_session["pending_tool"]["approval_policy"]
     assert result["decision"] == "deny", result   # headless: nothing to ask
-    with pytest.raises(ValueError, match=f"denied by {POLICY_ID}"):
+    # The control-file case is refused one step earlier, by name, before the
+    # policy verdict is even read; either refusal is the right answer.
+    with pytest.raises(ValueError, match=f"denied by {POLICY_ID}|names a file that decides"):
         check_approval(instance)
 
 
@@ -490,6 +494,69 @@ def test_a_granted_command_still_cannot_smuggle_an_ungranted_one(tmp_path, monke
         "name": "bash",
         "arguments": {"command": "co browser status && co email send --to a@example.com hi"},
     }
+
+    apply_auto_approve_policy(instance)
+
+    assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "deny"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo hi > notes.txt",
+        "head -1 notes.txt > out.txt",
+        "printf '%s\\n' a b >> list.txt",
+        "cargo test --quiet > test-output.txt 2>&1",
+        "sort notes.txt | uniq > uniq.txt",
+    ],
+)
+def test_a_redirect_into_the_workspace_is_a_reversible_edit(tmp_path, monkeypatch, command):
+    """`echo x > file` is what a model reaches for instead of the write tool, and
+    it is held to the write tool's rule: inside the workspace it is allowed."""
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "allow", result
+    assert result["effect_class"] in {"workspace_edit", "verification"}, result
+
+
+HEREDOC_WRITE = "cat << 'EOF' > greeter/src/main.rs\nfn main() {\n    println!(\"hi\");\n}\nEOF"
+
+
+def test_a_heredoc_into_a_workspace_file_is_a_reversible_edit(tmp_path, monkeypatch):
+    """A real model's first move, unattended, was `cat << 'EOF' > src/main.rs`.
+    bashlex cannot parse a here-document, so it was refused as unparseable.
+    The body is data; the first line is what runs."""
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": HEREDOC_WRITE}}
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "allow", result
+    assert result["effect_class"] == "workspace_edit"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat << 'EOF' > ../outside.rs\nfn main() {}\nEOF",     # outside the workspace
+        "cat << 'EOF' > .co/host.yaml\npermissions: {}\nEOF",  # a control file
+        "bash << 'EOF'\nrm -rf /\nEOF",                        # the body executes
+        "python3 << 'EOF'\nprint(1)\nEOF",
+    ],
+)
+def test_a_heredoc_body_that_executes_or_lands_outside_is_not_an_edit(tmp_path, monkeypatch, command):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
 
     apply_auto_approve_policy(instance)
 

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -406,8 +406,6 @@ READ_ONLY_COMMANDS = [
     "rg --count foo",
     "wc -l notes.txt",
     "ls -la",
-    "sed -n 1,10p notes.txt",
-    "awk '{print $1}' notes.txt",
     "sort notes.txt | uniq -c | cut -d' ' -f1",
     "basename /tmp/x.txt",
     "jq .name package.json",
@@ -434,8 +432,9 @@ def test_headless_auto_allows_read_only_commands(tmp_path, monkeypatch, command)
 @pytest.mark.parametrize(
     "command",
     [
-        "sed -i s/a/b/ notes.txt",            # in-place edit writes the file
-        "sed --in-place s/a/b/ notes.txt",
+        "sed -n 1,10p notes.txt",             # sed takes a program: not read-only
+        "sed -i s/a/b/ notes.txt",
+        "awk '{print $1}' notes.txt",         # nor is awk
         "echo secret >> ~/.bashrc",           # a redirect outside the workspace
         "echo x > ../outside.txt",
         "echo 'Bash(*)' > .co/host.yaml",     # a redirect into a control file
@@ -673,3 +672,30 @@ def test_ordinary_files_still_reach_the_read_and_write_tools(tmp_path, monkeypat
     check_approval(instance)
 
     assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "allow"
+
+
+def test_the_read_only_list_is_not_a_way_to_run_arbitrary_code(tmp_path, monkeypatch):
+    """Nothing that takes a program text is read-only.
+
+    `awk 'BEGIN{system("rm -rf /")}'` reads like an inspection and is
+    arbitrary execution; GNU `sed`'s `e` flag is the same. Keeping them while
+    excluding their execution constructs would need a parser in a security
+    path, so both ask — including their innocent shapes, whose job `head`,
+    `cut` and `read_file(limit=, offset=)` already do.
+    """
+    monkeypatch.chdir(tmp_path)
+    for command in [
+        "awk 'BEGIN{system(\"rm -rf /\")}'",   # arbitrary execution
+        "awk -f script.awk data.txt",          # runs a program file
+        "awk '{print $1}' notes.txt",           # the innocent shape, same rule
+        "sed 's/a/b/e' notes.txt",             # GNU sed's e flag executes
+        "sed -n 1,10p notes.txt",              # the innocent shape, same rule
+        "find . -exec rm {} +",
+        "xargs -I{} rm {}",
+        "env sh -c 'rm -rf /'",
+    ]:
+        instance = agent(io=False)
+        instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
+        apply_auto_approve_policy(instance)
+        result = instance.current_session["pending_tool"]["approval_policy"]
+        assert result["decision"] == "deny", (command, result)

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -561,3 +561,60 @@ def test_a_heredoc_body_that_executes_or_lands_outside_is_not_an_edit(tmp_path, 
     apply_auto_approve_policy(instance)
 
     assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "deny"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat .ssh/id_rsa",                     # a private key inside the workspace
+        "head -5 .ssh/id_ed25519",
+        "cat .co/keys/agent.key",              # the agent's OWN signing key
+        "grep -r . .co/keys/",
+        "cat server.pem",
+        "cat deploy.key",
+        "cat .ssh/authorized_keys",            # who may log in
+        "cat .npmrc",                          # carries an auth token
+        "cat .git-credentials",
+        "wc -c id_rsa",
+    ],
+)
+def test_key_material_is_never_read_silently_wherever_it_lives(tmp_path, monkeypatch, command):
+    """A private key read is a credential read, workspace or not.
+
+    The outside-workspace rule caught `head ~/.ssh/id_rsa` only because `~`
+    is usually not the project. Where the workspace *is* the home directory —
+    or where a key was committed, or the agent's own `.co/keys/` is under the
+    project root — the read was allowed, because the credential check only
+    looked for `.env`, `secret` and `credential` in the words. Found by
+    verifying #1481 against the shipped permissions rather than by a test.
+    """
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
+
+    apply_auto_approve_policy(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "deny", result
+    assert result["effect_class"] == "credentials", result
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat keys.md",                 # documentation about keys is not a key
+        "grep -n 'key' notes.txt",
+        "head -3 keyboard.md",
+        "cat monkey.txt",
+        "ls .co/skills",
+    ],
+)
+def test_the_key_rule_does_not_swallow_ordinary_files(tmp_path, monkeypatch, command):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "allow"

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -386,3 +386,111 @@ def test_headless_full_access_keeps_the_explicit_bounded_bypass(name, arguments)
     check_approval(instance)
 
     assert "approval_policy" not in instance.current_session["pending_tool"]
+
+
+# ---------------------------------------------------------------------------
+# #1481: read-only commands run unattended, and a read-only pipe segment does
+# not poison a command an operator has already granted.
+#
+# Before this, only eleven test/build tools auto-approved; `head`, `grep`,
+# `wc`, `ls` fell through to "ask", and unattended "ask" is "deny". A 7×/day
+# LinkedIn round died on `co browser ... get_text | head -40` after sixteen
+# clean iterations, posted nothing, and wrote no report.
+# ---------------------------------------------------------------------------
+
+READ_ONLY_COMMANDS = [
+    "head -40 notes.txt",
+    "tail -n 5 log.txt",
+    "cat README.md",
+    "grep -i foo notes.txt",
+    "rg --count foo",
+    "wc -l notes.txt",
+    "ls -la",
+    "sed -n 1,10p notes.txt",
+    "awk '{print $1}' notes.txt",
+    "sort notes.txt | uniq -c | cut -d' ' -f1",
+    "basename /tmp/x.txt",
+    "jq .name package.json",
+    "echo ok",
+    "pwd",
+    "cd src && ls",
+]
+
+
+@pytest.mark.parametrize("command", READ_ONLY_COMMANDS)
+def test_headless_auto_allows_read_only_commands(tmp_path, monkeypatch, command):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "allow", result
+    assert result["effect_class"] == "read"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sed -i s/a/b/ notes.txt",            # in-place edit writes the file
+        "sed --in-place s/a/b/ notes.txt",
+        "head -1 notes.txt > out.txt",        # a redirect writes wherever it points
+        "echo secret >> ~/.bashrc",
+        "tee out.txt",                        # writes its input
+        "find . -name '*.log' -delete",       # deletes
+        "xargs rm",                           # runs whatever it is given
+        "cat .env",                           # credentials: still denied
+    ],
+)
+def test_read_only_names_do_not_cover_writes_or_credentials(tmp_path, monkeypatch, command):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
+
+    apply_auto_approve_policy(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "deny", result   # headless: nothing to ask
+    with pytest.raises(ValueError, match=f"denied by {POLICY_ID}"):
+        check_approval(instance)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "CO_WHO=x co browser -t t get_text | head -40",
+        "CO_WHO=x co browser -t t get_text | grep -i foo",
+        "co browser -t t run_page_script a.js && echo ok",
+        "co browser status 2>&1 | tail -3",
+    ],
+)
+def test_a_read_only_segment_does_not_poison_a_granted_command(tmp_path, monkeypatch, command):
+    """The shipped Bash(co *) grant covered the browser command; the pipe into
+    head is what killed the unattended run (#1481)."""
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False, permissions=load_permission_patterns(tmp_path / ".co"))
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "allow", result
+    assert result["effect_class"] == "configured_command"
+
+
+def test_a_granted_command_still_cannot_smuggle_an_ungranted_one(tmp_path, monkeypatch):
+    """Only read-only segments ride along. `co browser ... && co email send` is
+    still an email send."""
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False, permissions=load_permission_patterns(tmp_path / ".co"))
+    instance.current_session["pending_tool"] = {
+        "name": "bash",
+        "arguments": {"command": "co browser status && co email send --to a@example.com hi"},
+    }
+
+    apply_auto_approve_policy(instance)
+
+    assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "deny"

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -618,3 +618,58 @@ def test_the_key_rule_does_not_swallow_ordinary_files(tmp_path, monkeypatch, com
     check_approval(instance)
 
     assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "allow"
+
+
+@pytest.mark.parametrize(
+    ("name", "path"),
+    [
+        ("read_file", "server.pem"),
+        ("read", ".ssh/id_rsa"),
+        ("read_file", ".ssh/id_ed25519"),
+        ("read_file", "deploy.key"),
+        ("read_file", ".netrc"),
+        ("read_file", ".git-credentials"),
+        ("glob", ".ssh/*"),
+        ("write", ".ssh/authorized_keys"),
+        ("edit", "server.pem"),
+        ("multi_edit", ".aws/credentials"),
+    ],
+)
+def test_the_read_and_write_tools_hold_the_same_line_on_key_material(tmp_path, monkeypatch, name, path):
+    """`cat server.pem` was denied while `read_file("server.pem")` was allowed.
+
+    Found by running the fixed code through the real `co ai`: asked for
+    `cat server.pem | head -2`, the model reached for `read_file` instead, and
+    the console printed "policy read-only workspace operation". The shell rule
+    and the tool rule have to agree, or the gate is a detour.
+    """
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {"name": name, "arguments": {"path": path}}
+
+    apply_auto_approve_policy(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "deny", result
+    assert result["effect_class"] == "credentials", result
+
+
+@pytest.mark.parametrize(
+    ("name", "path"),
+    [
+        ("read_file", "keys.md"),
+        ("read_file", "notes.txt"),
+        ("write", "src/main.rs"),
+        ("edit", "monkey.py"),
+        ("glob", "src/*.rs"),
+    ],
+)
+def test_ordinary_files_still_reach_the_read_and_write_tools(tmp_path, monkeypatch, name, path):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {"name": name, "arguments": {"path": path}}
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "allow"

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -699,3 +699,50 @@ def test_the_read_only_list_is_not_a_way_to_run_arbitrary_code(tmp_path, monkeyp
         apply_auto_approve_policy(instance)
         result = instance.current_session["pending_tool"]["approval_policy"]
         assert result["decision"] == "deny", (command, result)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "head $(echo /etc/shadow)",      # the path arrives from a substitution
+        "cat `echo /etc/passwd`",
+        "head $HOME/.ssh/id_rsa",        # and from the environment
+        "cat ${SECRET_PATH}",
+        "cat $(cat which_file.txt)",
+    ],
+)
+def test_a_path_the_policy_cannot_resolve_is_not_a_workspace_path(tmp_path, monkeypatch, command):
+    """A read-only command whose target comes from a substitution or a variable
+    is not a read the policy has checked.
+
+    `cat $(cat which_file.txt)` reads whatever that file names. Two of these
+    were refused before the rule existed, but by luck: one word happened to
+    split across the substitution and another happened to contain "secret".
+    """
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
+
+    apply_auto_approve_policy(instance)
+
+    assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "deny"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "grep 'foo$' notes.txt",       # a bare $ is end-of-line, not a variable
+        "grep -c '$' notes.txt",
+        "echo $HOME",                  # echo reads no file
+        "head -3 notes.txt",
+    ],
+)
+def test_a_bare_dollar_is_not_a_variable(tmp_path, monkeypatch, command):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "allow"

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -746,3 +746,47 @@ def test_a_bare_dollar_is_not_a_variable(tmp_path, monkeypatch, command):
     check_approval(instance)
 
     assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "allow"
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["make test", "make check", "make lint", "make build", "make coverage"],
+)
+def test_make_still_runs_a_named_verification_target(tmp_path, monkeypatch, command):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "allow", result
+    assert result["effect_class"] == "verification"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "make install",              # not verification; writes outside by convention
+        "make",                      # the default target is whatever the file says
+        "make -C /etc all",          # make, pointed somewhere else
+        "make -f /tmp/evil.mk test", # make, given another program
+        "make test install",         # one verification target does not carry the rest
+    ],
+)
+def test_make_is_not_a_way_to_run_anything(tmp_path, monkeypatch, command):
+    """1.8.4 allowed all of these under "focused test, lint, or build command".
+
+    `cargo`, `go` and the package runners were already narrowed to their
+    verification subcommands; `make` was the one left open. Found by an
+    adversarial sweep of the shipped policy before publishing 1.8.5a1, not by
+    a test.
+    """
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
+
+    apply_auto_approve_policy(instance)
+
+    assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "deny"

--- a/tests/unit/test_tool_approval.py
+++ b/tests/unit/test_tool_approval.py
@@ -1033,3 +1033,41 @@ class TestPollInterrupt:
         poll_interrupt(agent)
 
         assert 'stop_signal' not in agent.current_session
+
+
+def test_a_quiet_agent_can_have_a_tool_auto_approved(tmp_path, monkeypatch):
+    """`quiet=True` is the shape of every unattended run, and it had no console.
+
+    Six places in check_approval() reached `agent.logger.console.log_permission_granted`
+    directly. With `quiet=True` the logger's console is None, so every
+    auto-approved call raised AttributeError *after* the policy said yes: the
+    tool result read "Error: 'NoneType' object has no attribute
+    'log_permission_granted'" and the agent carried on as if the tool had
+    failed. None of the decision-table tests built a real quiet Agent; the
+    Rust e2e did, on its first step.
+    """
+    from connectonion import Agent
+    from connectonion.useful_plugins.tool_approval import tool_approval
+    from connectonion.useful_tools.file_tools import write
+    from tests.utils.mock_helpers import LLMResponseBuilder, MockLLM
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".co").mkdir()
+    llm = MockLLM(responses=[
+        LLMResponseBuilder.tool_call_response("write", {"path": "note.txt", "content": "hi"}, call_id="call_1"),
+        LLMResponseBuilder.text_response("written"),
+    ])
+    agent = Agent("quiet-writer", llm=llm, tools=[write], plugins=[tool_approval], log=False, quiet=True)
+
+    assert agent.input("write a note") == "written"
+
+    trace = agent.current_session["trace"]
+    result = next(e for e in trace if e.get("type") == "tool_result")
+    assert result["status"] == "success", result
+    assert (tmp_path / "note.txt").read_text() == "hi"
+    # And the decision is on the trace where the audit reads it: the executor
+    # records the call id as `tool_id`, which the recorder used to compare
+    # against the trace sequence `id`, so it never landed.
+    call = next(e for e in trace if e.get("type") == "tool_call")
+    assert call["approval_policy"]["decision"] == "allow"
+    assert call["approval_policy"]["effect_class"] == "workspace_edit"


### PR DESCRIPTION
## Description

Fixes #1481. `tool_approval` refused every shell command outside eleven test/build tools when nobody was present, so an unattended `co browser ... | head -40` killed a production LinkedIn round at iteration sixteen. This makes read-only commands run unattended, lets a read-only pipe segment ride along beside a granted command, and adds the end-to-end test that models an unattended job — which found three more bugs on the way.

Refs #210 (job-shaped tests), #1462 (rides in 1.8.5).

## What changed

**Policy (`useful_plugins/tool_approval/policy.py`)**

| command | 1.8.4 | now |
|---|---|---|
| `head -40 f`, `grep -i x f`, `wc -l f`, `ls`, `sed -n 1p f`, `cd src && ls` | ask → denied unattended | allow (`read`) |
| `cat /etc/hosts`, `head ~/.ssh/id_rsa`, `cd ..` | ask | ask (outside the workspace, like the read tools) |
| `sed -i s/a/b/ f` | ask | ask (rewrites the file) |
| `echo x > notes.txt`, `cat << 'EOF' > src/main.rs …` | ask / unparseable | allow (`workspace_edit`, the write tool's rule) |
| `echo x > ../out`, `> .co/host.yaml` | ask | deny (outside / control file) |
| `cargo test 2>&1 \| tail -20` | ask (tail) | allow (`2>&1` is not a write) |
| `co browser … get_text \| head -40` with the shipped `Bash(co *)` grant, unattended | denied | allow (`configured_command`) |
| `co browser status && co email send …` | denied | denied |
| `bash << EOF … EOF`, `python3 -c "…"`, `ping 8.8.8.8` | ask → denied | unchanged |

The remote-EXEC whitelist in `host.yaml` (whose own comment forbids `cat`/`head`) is a different gate and is not widened.

**Bugs the e2e found in 1.8.4 (`approval.py`, `policy.py`)**

- A `quiet=True` agent has no console; six call sites reached `agent.logger.console.log_permission_granted(...)` directly, so every auto-approved call in a quiet agent raised `AttributeError` after the policy said yes. One guarded helper now.
- `record_approval_policy` matched the trace entry by `id`; the executor stores the call id as `tool_id`. The decision never reached the trace in a real agent.

**Tests**

- `tests/unit/test_auto_approve_policy.py`: 40 new cases across read-only, outside-workspace, `sed -i`, redirects, heredocs, control files, granted-command chains. 19 of the first 29 failed on the 1.8.4 policy before the fix.
- `tests/unit/test_tool_approval.py`: a quiet Agent with a real MockLLM run gets a tool auto-approved and the decision lands on the trace.
- `tests/e2e/test_an_unattended_agent_builds_a_rust_cli.py`: the job. Scripted model, real everything else, real `cargo`. Asserts which rule carried each of seven steps; a second test removes the two operator grants and asserts exactly those two steps are refused. Skips with a reason where cargo is absent; ubuntu runners have it.
- `tests/e2e/real_api/test_real_unattended_rust_cli.py`: same job, real model chooses the commands. Three runs surfaced the heredoc finding, the `cargo new` → `write` refuses to overwrite → needs `edit` finding, and two correct refusals (`ping`, `python3 -c`). Third run passed in 22 s. Opt-in.

## Labels and target release (required)

- **Suggested labels:** bug, tests
- **Proposed target version:** 1.8.5
- **Estimated release window:** next alpha (1.8.5a1, with #1472)
- **Milestone:** maintainer assigns
- **Why this release:** production automation is dying on it today; the policy widening is bounded (read-only names, workspace paths, no redirect outside the workspace) and the two 1.8.4 bugs affect every quiet agent. Rollback is a revert.
- **Forward-port tracking issue (stable patches only):** N/A — mainline work

## How this was written

- [x] Mostly AI-generated — Claude Fable 5.1 via Claude Code, on the maintainer's instruction to fix #1481, design an e2e that would have exposed it, and merge.

**Least confident about:** the read-only list itself. It is a judgement about which commands cannot write or execute their input; `awk` can call `system()` and `sed` has `e` on GNU, neither of which this checks. Both are bounded by the workspace-path and redirect rules, but a determined prompt injection has more room than before. Say so if you want `awk`/`sed` out.

**Not verified:** the Windows branch (`bash` tool refuses Windows anyway); the e2e on macOS CI (the macOS job runs only the browser e2e).

**If this is wrong, what breaks first:** `test_the_two_grants_are_the_only_two_the_job_needs` — it pins exactly which steps need a grant, so a policy change in either direction fails there with the step named.

## Dev Blog

> docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md

## Testing

```
$ make test
8711 passed, 21 skipped, 6 warnings in 39.87s

$ pytest -m real_api tests/e2e/real_api/test_real_unattended_rust_cli.py   # paid, one run
1 passed in 22.29s
```

Fail-first: with `policy.py`/`approval.py` from `origin/main` swapped in, both scripted e2e tests fail (the first on the quiet-console crash at `mkdir`).

## Scope

- `connectonion/useful_plugins/tool_approval/policy.py` — read-only list, path/redirect/heredoc rules, per-segment grants, trace id match
- `connectonion/useful_plugins/tool_approval/approval.py` — the guarded console helper
- `docs/useful_plugins/tool_approval.md`, `docs/features/permissions.md` — the new rules
- tests as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLqqyEND1RpEtSPTe86NsK
