### PR TITLE
[1.8.5] co auth feishu: scan once, and the app exists

### DIFF
--- a/connectonion/cli/commands/env_commands.py
+++ b/connectonion/cli/commands/env_commands.py
@@ -39,8 +39,18 @@ console = Console()
 # line the next read refuses, and `co env` is the command that fixes those.
 _NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
-_PROVIDER_AUTH = {"GOOGLE": "co auth google", "MICROSOFT": "co auth microsoft"}
-_PROVIDER_LABEL = {"GOOGLE": "Google", "MICROSOFT": "Microsoft"}
+_PROVIDER_AUTH = {"GOOGLE": "co auth google", "MICROSOFT": "co auth microsoft",
+                  "FEISHU": "co auth feishu", "LARK": "co auth lark"}
+_PROVIDER_LABEL = {"GOOGLE": "Google", "MICROSOFT": "Microsoft",
+                   "FEISHU": "Feishu", "LARK": "Lark"}
+
+# An application's credentials are not an OAuth record — two names, not five —
+# so they are listed here rather than in PROVIDER_FIELDS. They are refused for
+# the same reason: one command writes them, and that command can also create
+# the application they belong to.
+_APP_CREDENTIALS = {f"{prefix}_{field}": prefix
+                    for prefix in ("FEISHU", "LARK")
+                    for field in ("APP_ID", "APP_SECRET")}
 
 
 def _provider_of(key: str) -> str | None:
@@ -189,6 +199,12 @@ def handle_env_set(key: str, value: str) -> None:
         _fail("AGENT_CONFIG_PATH chooses which global directory is read, so a file inside it "
               "cannot set it. Export it in your shell instead:\n"
               "  export AGENT_CONFIG_PATH=/path/to/.co\nNext: co env", 2)
+    app_provider = _APP_CREDENTIALS.get(key)
+    if app_provider is not None:
+        auth = _PROVIDER_AUTH[app_provider]
+        _fail(f"{key} is written by {auth}, which also creates the application it belongs to. "
+              f"Feishu has no API that hands out an app secret, so a hand-typed one came from "
+              f"somewhere this command cannot check. Next: {auth}", 2)
     provider = _provider_of(key)
     if provider is not None:
         auth = _PROVIDER_AUTH[provider]

--- a/connectonion/cli/commands/feishu_auth.py
+++ b/connectonion/cli/commands/feishu_auth.py
@@ -1,0 +1,115 @@
+"""
+Purpose: `co auth feishu` — scan once, and the app that receives your messages exists and is configured
+LLM-Note:
+  Dependencies: imports from [io, sys, qrcode, environment.py, env_file.py] and lazily from [lark_oapi] | imported by [cli/main.py via the auth command] | tested by [tests/unit/test_feishu_auth.py]
+  Data flow: lark_oapi.register_app() → a verification link and a terminal QR → the person approves in Feishu → {client_id, client_secret, user_info.tenant_brand} → upsert_env writes FEISHU_APP_ID/SECRET (or LARK_*) to the selected env file
+  State/Effects: creates a real Feishu application owned by the person who scans | writes two names to the selected env file | prints a link and a QR, never the secret
+  Integration: the pair this writes is exactly what inbox/feishu.py reads, so `co feishu check` passes straight after | `co env set FEISHU_APP_SECRET` refuses and names this command, as the Google and Microsoft records do
+  Performance: one HTTP round trip to begin, then a poll every few seconds until the person approves or ten minutes pass
+  Errors: a missing SDK exits 3 with the pip command | a denied or expired scan is one line and exit 1 | a response without both halves writes nothing and exits 1
+
+Why a scan and not a paste: Feishu has no API that hands out an app_secret —
+`application/v6` never returns one, and reading it needs a token you can only
+get if you already have the secret. The one documented way around that is the
+platform's own scan-to-create-an-app flow, which registers an application in
+the scanner's tenant and returns its credentials to whoever started the flow.
+The request that begins it carries no client identity, so this is a public
+protocol and not a private channel for the official CLI.
+
+What one scan does not do: it cannot list the applications you already own —
+no such API exists — so this always creates a new one rather than offering a
+choice. Which application it becomes is decided on Feishu's own confirmation
+page, which is the right place for that decision to be made.
+"""
+
+import io
+import sys
+
+from ...environment import display_path, selected_env_file
+from ...env_file import upsert_env
+
+SDK_MISSING = "The Feishu SDK is not installed. Run: pip install lark-oapi"
+
+# Shown on Feishu's confirmation page, so that a person looking at their list
+# of applications a month from now knows what this one is and who made it.
+APP_PRESET = {
+    "name": "ConnectOnion",
+    "desc": "Receives messages for a ConnectOnion agent and replies as this bot.",
+}
+
+
+def _register_app():
+    """The SDK's registration flow, imported late so the CLI starts without it."""
+    try:
+        from lark_oapi import register_app
+    except ImportError as exc:
+        raise RuntimeError(SDK_MISSING) from exc
+    return register_app
+
+
+def _qr(url: str) -> str:
+    import qrcode
+
+    code = qrcode.QRCode(border=1)
+    code.add_data(url)
+    out = io.StringIO()
+    # invert=True draws dark modules as light blocks, which is what a phone
+    # camera expects on the dark terminals most people use.
+    code.print_ascii(out=out, invert=True)
+    return out.getvalue()
+
+
+def handle_feishu_auth(brand: str = "feishu") -> None:
+    """Create the application by scanning, and save what it needs to run."""
+    try:
+        register_app = _register_app()
+    except RuntimeError as error:
+        print(str(error))
+        raise SystemExit(3)
+
+    print("Creating a Feishu application. Scan this with the Feishu or Lark app,")
+    print("or open the link, and approve it. The application is yours, in your tenant.")
+    print()
+
+    def show(info) -> None:
+        url = info.get("url", "")
+        print(_qr(url))
+        print(url)
+        print()
+        print("Waiting for approval. Ctrl-C to stop.")
+
+    try:
+        result = register_app(
+            on_qr_code=show,
+            app_preset=dict(APP_PRESET),
+            source="connectonion",
+        )
+    except KeyboardInterrupt:
+        print("Stopped. Nothing was saved.")
+        raise SystemExit(1)
+    except Exception as error:
+        # The platform's own sentence, once. A traceback through the SDK says
+        # nothing the sentence does not, and "denied" and "expired" are both
+        # things a person did, not faults to debug.
+        print(str(error) or type(error).__name__)
+        raise SystemExit(1)
+
+    app_id = (result or {}).get("client_id") or ""
+    app_secret = (result or {}).get("client_secret") or ""
+    if not (app_id and app_secret):
+        # Half a credential is worse than none: it would be written, then fail
+        # at connect time with an error about the half that is there.
+        print("Feishu returned an incomplete registration; nothing was saved. Next: co auth feishu")
+        raise SystemExit(1)
+
+    # The flow always begins on Feishu and moves to Lark if that is where the
+    # scanner's tenant lives, so which of the two this is, is known only now.
+    tenant = ((result or {}).get("user_info") or {}).get("tenant_brand") or brand
+    prefix = "LARK" if str(tenant).lower() == "lark" else "FEISHU"
+
+    path = selected_env_file()
+    upsert_env(path, {f"{prefix}_APP_ID": app_id, f"{prefix}_APP_SECRET": app_secret})
+    print(f"✓ {prefix} application {app_id} saved to {display_path(path)}")
+    print()
+    print("Add the bot to a group and @ it, or send it a direct message.")
+    print(f"Next: co {prefix.lower()} check")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -229,7 +229,7 @@ def deploy(
 
 
 @app.command()
-def auth(service: Optional[str] = typer.Argument(None, help="Service: google, microsoft"),
+def auth(service: Optional[str] = typer.Argument(None, help="Service: google, microsoft, feishu, lark"),
          scopes: Optional[str] = typer.Option(None, "--scopes", help="Google: comma-separated limited scopes. Default: Gmail, Calendar, Drive and YouTube.")):
     """Authenticate with OpenOnion."""
     if scopes is not None and service != "google":
@@ -241,6 +241,9 @@ def auth(service: Optional[str] = typer.Argument(None, help="Service: google, mi
     elif service == "microsoft":
         from .commands.auth_commands import handle_microsoft_auth
         handle_microsoft_auth()
+    elif service in ("feishu", "lark"):
+        from .commands.feishu_auth import handle_feishu_auth
+        handle_feishu_auth(brand=service)
     else:
         from .commands.auth_commands import handle_auth
         handle_auth()

--- a/docs/blog/2026-09-11-the-secret-you-cannot-ask-for.md
+++ b/docs/blog/2026-09-11-the-secret-you-cannot-ask-for.md
@@ -1,0 +1,98 @@
+# The secret you cannot ask for
+
+Connecting a Feishu bot took eleven steps, and step four was the one that
+decided whether anyone finished. Open the developer console. Create a
+self-built application. Find the permissions page, add three scopes whose names
+you have to get exactly right. Find the events page, choose long connection,
+subscribe to one event. Publish. Then go to the credentials page, copy a string
+that starts with `cli_`, copy a second string that is a password, and paste both
+into a file in your home directory.
+
+The eleven steps are not the problem. The problem is that nothing tells you when
+you have got one of them wrong. A missing scope is not an error at setup time.
+It is an error an hour later, in a log, when someone in a group @-mentions the
+bot and nothing happens.
+
+So we started designing the smallest thing that could fix that: a command that
+opens the right console page, takes the secret on stdin so it never reaches
+shell history, and then verifies — fetches a token, names the bot back to you,
+checks the scopes against the list, and says which one is missing before you
+walk away. One paste, then certainty.
+
+The paste seemed irreducible. We checked. `application/v6` has an API that
+returns an application's information, and its response has app_id, name, avatar,
+owner, scopes, status — and no secret, which is correct; an API that hands out
+credentials for an app you name is not an API, it is a vulnerability. It also
+requires a `tenant_access_token`, which you can only get if you already have the
+secret. There is no way in. We wrote that down as a constraint and moved on.
+
+## The tool we were copying had already solved it
+
+Feishu's own CLI does the setup in one step. We assumed it was privileged — an
+official tool with an official back door. There was even a string in the binary
+that supported the theory: `/open-apis/application/v6/larksuite_cli_app/probe`,
+an endpoint named after the CLI itself.
+
+It is MIT licensed. The endpoint turned out to be a best-effort telemetry ping
+fired after the credentials are already saved, whose result the code explicitly
+discards. The actual flow is forty lines above it, and it is this:
+
+```
+POST /oauth/v1/app/registration
+  action=begin  archetype=PersonalAgent  auth_method=client_secret
+→ device_code, user_code, verification_uri
+
+person scans, approves
+
+POST /oauth/v1/app/registration
+  action=poll  device_code=…
+→ client_id, client_secret
+```
+
+The begin request carries no client id, no key, no signature, nothing that says
+which program is asking. It is OAuth 2.0's device authorization grant pointed at
+app creation instead of login: the application is created by the person
+scanning, in their own tenant, and the credentials are handed to whoever started
+the flow. It is documented on the platform, under a heading we had not read, and
+wrapped in all three official SDKs — including the Python one this project
+already depends on, as `lark_oapi.register_app`.
+
+So `co auth feishu` is a QR code in the terminal, and then two names in
+`keys.env`. No console, no copy, no paste. We had spent a day designing a good
+way to survive a constraint that was not there.
+
+## What the mistake was
+
+Not "we missed a feature". We concluded from a name. `larksuite_cli_app` reads
+like a private channel, and that reading was consistent with everything else we
+knew: no API returns a secret, the console is the only place the secret exists,
+the official CLI does something we cannot. Three true facts and one inference,
+and the inference felt like a fourth fact.
+
+The correction was cheap — the source was public, MIT, and one command away. It
+was cheap the whole time we were not doing it. What made us not do it was that
+the conclusion already fit.
+
+There is a smaller lesson under it about what verification means. We had
+verified the API surface exhaustively: every endpoint under `application/v6`,
+every documented response field, twice. That work was correct and it answered
+the wrong question. The question was not "does an API return the secret" but
+"how does the tool that does this get it", and those have different answers
+because the mechanism is not an API at all — it is an authorization flow.
+Checking harder in the place you are already looking does not find the thing
+that is somewhere else.
+
+## What one scan still does not do
+
+It creates an application; it cannot list the ones you already have, because no
+API does. So `co auth feishu` always makes a new one, and choosing between them
+happens on Feishu's own confirmation page, which is the right place for it.
+
+The preset it creates comes with more permissions than a message bot needs, and
+the SDK's `addons` parameter only adds — there is no way to narrow it. In a
+company tenant an administrator may have to approve those. We have not tested
+that, and we are not going to claim it works until someone has.
+
+The manual path is still documented, one collapsed section down, for anyone
+with an application already. It is the same eleven steps. They are just no
+longer the first thing a new person sees.

--- a/docs/cli/feishu.md
+++ b/docs/cli/feishu.md
@@ -11,18 +11,43 @@ OpenOnion credential, and nothing billed.
 
 ## Setup
 
-1. Create a self-built application at <https://open.feishu.cn/app> (Lark:
-   <https://open.larksuite.com/app>). Enable the **bot** capability.
+```bash
+pip install lark-oapi
+co auth feishu
+```
+
+`co auth feishu` prints a QR code and a link. Scan it with Feishu or Lark,
+approve, and the application exists — in your own tenant, owned by you — with
+its credentials written to `~/.co/keys.env`. There is no developer console to
+visit and nothing to copy. It starts on Feishu and moves to Lark by itself if
+that is where your tenant lives, so there is nothing to choose first either.
+
+Then add the bot to a group and @ it, or send it a direct message.
+
+```bash
+co feishu check                  # says what is missing, if anything
+```
+
+`check` exits 3 and names the missing item.
+
+<details>
+<summary>Using an application you already have</summary>
+
+`co auth feishu` always creates a new application, because Feishu has no API
+that lists the ones you own. To use an existing one, configure it by hand:
+
+1. At <https://open.feishu.cn/app> (Lark: <https://open.larksuite.com/app>),
+   enable the **bot** capability.
 2. Under *Permissions* add `im:message.group_at_msg:readonly` (group messages
    that @ the bot) and `im:message:send_as_bot` (reply). Add
    `im:message.p2p_msg:readonly` if people will message the bot directly.
 3. Under *Events*, choose **long connection** and subscribe to
    `im.message.receive_v1`. No request URL is needed.
-4. Publish the application to your tenant, then put its credentials in your
-   global credential file:
+4. Publish it to your tenant, then write its credentials into
+   `~/.co/keys.env` with an editor — `co env set` refuses these two names,
+   because a hand-typed app secret came from somewhere it cannot check:
 
    ```dotenv
-   # ~/.co/keys.env
    FEISHU_APP_ID=cli_xxx
    FEISHU_APP_SECRET=xxx
    # Lark uses its own pair
@@ -30,15 +55,7 @@ OpenOnion credential, and nothing billed.
    LARK_APP_SECRET=yyy
    ```
 
-5. Install the SDK and check:
-
-   ```bash
-   pip install lark-oapi
-   co feishu check
-   ```
-
-`check` exits 3 and names the missing item if anything above is incomplete.
-Add the bot to a group, @ it, and it is listening.
+</details>
 
 ## The directory
 

--- a/tests/unit/test_feishu_auth.py
+++ b/tests/unit/test_feishu_auth.py
@@ -1,0 +1,146 @@
+"""
+LLM-Note: Tests for connectonion.cli.commands.feishu_auth — `co auth feishu`,
+the scan that creates the app and writes its credentials. The SDK call is
+faked: no browser, no network, no app created.
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from connectonion.cli.commands import feishu_auth
+
+
+class FakeRegistration:
+    """Stands in for lark_oapi.register_app."""
+
+    def __init__(self, result=None, error=None, brand="feishu"):
+        self.result = result or {
+            "client_id": "cli_new123",
+            "client_secret": "secret-new123",
+            "user_info": {"open_id": "ou_me", "tenant_brand": brand},
+        }
+        self.error = error
+        self.shown = []
+
+    def __call__(self, on_qr_code, on_status_change=None, **kwargs):
+        on_qr_code({"url": "https://open.feishu.cn/page/cli?user_code=ABC", "expire_in": 600})
+        self.shown.append(kwargs)
+        if self.error:
+            raise self.error
+        return self.result
+
+
+@pytest.fixture
+def rig(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("AGENT_CONFIG_PATH", str(tmp_path / ".co"))
+    (tmp_path / ".co").mkdir(parents=True, exist_ok=True)
+    written = {}
+
+    def fake_upsert(path, values):
+        written.setdefault(str(path), {}).update(values)
+
+    monkeypatch.setattr(feishu_auth, "upsert_env", fake_upsert)
+    return tmp_path, written
+
+
+def run(register, monkeypatch, **kwargs):
+    monkeypatch.setattr(feishu_auth, "_register_app", lambda: register)
+    return feishu_auth.handle_feishu_auth(**kwargs)
+
+
+class TestTheScan:
+    def test_the_link_is_printed_so_a_terminal_without_a_camera_still_works(self, rig, monkeypatch, capsys):
+        register = FakeRegistration()
+        run(register, monkeypatch)
+        out = capsys.readouterr().out
+        assert "https://open.feishu.cn/page/cli?user_code=ABC" in out
+
+    def test_a_qr_code_is_drawn(self, rig, monkeypatch, capsys):
+        register = FakeRegistration()
+        run(register, monkeypatch)
+        out = capsys.readouterr().out
+        # The block characters a terminal QR is made of.
+        assert any(ch in out for ch in "█▀▄")
+
+    def test_the_app_is_named_so_it_is_findable_later(self, rig, monkeypatch):
+        register = FakeRegistration()
+        run(register, monkeypatch)
+        preset = register.shown[0].get("app_preset") or {}
+        assert "ConnectOnion" in (preset.get("name") or "")
+
+
+class TestWhatGetsWritten:
+    def test_credentials_land_in_the_selected_env_file(self, rig, monkeypatch):
+        tmp_path, written = rig
+        run(FakeRegistration(), monkeypatch)
+        values = next(iter(written.values()))
+        assert values["FEISHU_APP_ID"] == "cli_new123"
+        assert values["FEISHU_APP_SECRET"] == "secret-new123"
+
+    def test_a_lark_tenant_writes_the_lark_names(self, rig, monkeypatch):
+        # The flow always starts on Feishu and switches if the tenant is Lark,
+        # so which brand it was is only known at the end.
+        tmp_path, written = rig
+        run(FakeRegistration(brand="lark"), monkeypatch)
+        values = next(iter(written.values()))
+        assert values["LARK_APP_ID"] == "cli_new123"
+        assert "FEISHU_APP_ID" not in values
+
+    def test_the_secret_is_never_printed(self, rig, monkeypatch, capsys):
+        run(FakeRegistration(), monkeypatch)
+        assert "secret-new123" not in capsys.readouterr().out
+
+    def test_it_ends_by_naming_the_next_command(self, rig, monkeypatch, capsys):
+        run(FakeRegistration(), monkeypatch)
+        out = capsys.readouterr().out
+        assert "co feishu check" in out or "co ai" in out
+
+
+class TestWhenItCannotRun:
+    def test_a_missing_sdk_names_the_install_command(self, rig, monkeypatch, capsys):
+        def no_sdk():
+            raise RuntimeError("The Feishu SDK is not installed. Run: pip install lark-oapi")
+
+        monkeypatch.setattr(feishu_auth, "_register_app", no_sdk)
+        with pytest.raises(SystemExit) as exit:
+            feishu_auth.handle_feishu_auth()
+        assert exit.value.code == 3
+        assert "pip install lark-oapi" in capsys.readouterr().out
+
+    def test_a_refused_scan_is_one_line_not_a_traceback(self, rig, monkeypatch, capsys):
+        register = FakeRegistration(error=RuntimeError("app registration denied by user"))
+        with pytest.raises(SystemExit) as exit:
+            run(register, monkeypatch)
+        assert exit.value.code == 1
+        out = capsys.readouterr().out
+        assert "denied" in out.lower()
+        assert "Traceback" not in out
+
+    def test_nothing_is_written_when_the_scan_fails(self, rig, monkeypatch):
+        tmp_path, written = rig
+        register = FakeRegistration(error=RuntimeError("device code expired"))
+        with pytest.raises(SystemExit):
+            run(register, monkeypatch)
+        assert written == {}, "a failed scan must not leave half a credential behind"
+
+    def test_a_response_without_a_secret_is_refused(self, rig, monkeypatch, capsys):
+        tmp_path, written = rig
+        register = FakeRegistration(result={"client_id": "cli_x", "client_secret": ""})
+        with pytest.raises(SystemExit) as exit:
+            run(register, monkeypatch)
+        assert exit.value.code == 1
+        assert written == {}
+
+
+class TestEnvSetStillRefusesTheseNames:
+    def test_the_app_secret_points_at_this_command(self):
+        # co env set must refuse a Feishu credential the way it refuses a
+        # Google one, or two ways of writing it drift apart.
+        from connectonion.cli.commands.env_commands import _PROVIDER_AUTH
+
+        assert _PROVIDER_AUTH["FEISHU"] == "co auth feishu"
+        assert _PROVIDER_AUTH["LARK"] == "co auth lark"


### PR DESCRIPTION
- **Proposed target version:** 1.8.5, first published as `1.8.5a1`
- **Estimated release window:** next alpha, with #1480 and #1472

Stacked on #1480 (`feat/1.8.5-inbox`), which is stacked on #1472. Merge in that order.

## The problem

Connecting a Feishu bot took eleven steps, and step four decided whether anyone finished: create a self-built app in the console, add three scopes whose names have to be exactly right, choose long connection, subscribe to one event, publish, then copy an id and a password into `~/.co/keys.env`.

The eleven steps are not the problem. Nothing tells you when one of them is wrong. A missing scope is not an error at setup time — it is an error an hour later, in a log, when somebody @-mentions the bot and nothing happens.

## What this adds

```bash
pip install lark-oapi
co auth feishu
```

A QR code in the terminal and a link beside it. Scan, approve, and the application exists — in your own tenant, owned by you — with `FEISHU_APP_ID` and `FEISHU_APP_SECRET` written to the selected env file. No console, no copy, no paste. The flow begins on Feishu and moves to Lark by itself if that is where your tenant lives, so there is nothing to choose up front either; whichever it turns out to be is what gets written.

## Why we thought this was impossible

Worth recording, because the reasoning was wrong in an ordinary way.

`application/v6` returns an application's info and no `app_secret` — correct, an API that hands out credentials for an app you name is a vulnerability — and it needs a `tenant_access_token`, which you cannot get without the secret. We verified that exhaustively. Feishu's own CLI does the setup in one step anyway, and its binary contains `/open-apis/application/v6/larksuite_cli_app/probe`, an endpoint named after the CLI itself. That read as the private back door that explained the discrepancy.

The CLI is MIT licensed. `larksuite_cli_app/probe` is a best-effort telemetry ping fired *after* credentials are saved, whose result the code explicitly discards. The real flow is forty lines above it:

```
POST /oauth/v1/app/registration   action=begin  archetype=PersonalAgent  auth_method=client_secret
  → device_code, user_code, verification_uri
                                  (person scans and approves)
POST /oauth/v1/app/registration   action=poll  device_code=…
  → client_id, client_secret
```

The begin request carries no client id, key or signature — nothing that says which program is asking. It is OAuth 2.0's device authorization grant pointed at app creation instead of login. It is documented on open.feishu.cn under 集成智能体到飞书, and wrapped by all three official SDKs, including the Python one this project already depends on.

So the implementation is `lark_oapi.register_app` plus a QR renderer. `qrcode>=8.2` was already a dependency; `lark-oapi` stays optional and a missing one exits 3 with the pip command, the same shape `co feishu listen` uses.

## `co env set` refuses these two names

`FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `LARK_APP_ID`, `LARK_APP_SECRET` are now refused with `Next: co auth feishu`, the way the Google and Microsoft records are.

The reason is different and the message says so. A Google record field is refused so one field cannot describe a different account than the rest. An app secret is refused because a hand-typed one came from somewhere the command cannot check — and there is now a command that can. They are not OAuth records (two names, not five), so they live in their own small table rather than in `PROVIDER_FIELDS`.

## What one scan does not do

- **It cannot list applications you already own** — no API does — so it always creates a new one, and choosing between applications happens on Feishu's own confirmation page. That is the right place for that decision.
- **The preset carries more permissions than a message bot needs**, and the SDK's `addons` parameter only adds; there is no way to narrow it. In a company tenant an administrator may have to approve them. **Not tested, and not claimed.**
- **The manual path is still documented**, one collapsed `<details>` section down, for anyone with an application already.
- One unverified detail from the local investigation: an app created this way opens the long connection and subscribes to `im.message.receive_v1` (`[source] feishu-websocket: connected`), but `/open-apis/bot/v3/info` answered `20008` on it, where a console-made bot answers normally. Whether it can be invited to a group and @-mentioned is a ten-minute live test that has not been run.

## Evidence

```
tests/unit              9011 passed, 15 skipped   (24s)
tests/e2e                596 passed,  7 skipped   (55s)
```

`tests/unit/test_feishu_auth.py`, 12 cases written failing first: the link is printed for a terminal with no camera beside it; a QR is drawn; the app is named so it is findable later; credentials land in the selected file; a Lark tenant writes the `LARK_*` names; **the secret is never printed**; a missing SDK exits 3 with the pip command; a denied or expired scan is one line and exit 1, not a traceback; **a failed scan writes nothing**; a response missing either half is refused; and `co env set` refuses both names.

CLI surface, against a built CLI in a temp HOME:

| check | result |
|---|---|
| `co auth --help` lists feishu and lark | yes |
| `co env set FEISHU_APP_SECRET` | exit 2, names `co auth feishu` |
| `co env set LARK_APP_ID` | exit 2, names `co auth lark` |
| `co env set OPENAI_API_KEY` still saves | exit 0 |
| Google record still refused | exit 2, names `co auth google` |

Two failures on this machine are not from this branch: `test_co_command_works` fails identically on a clean `origin/main` checkout, and `test_native_egress_preflight_real_driver` needs real network.

## Checklist
- [x] I proposed a target version and release window above
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published — no: stacked on #1480, then #1472
- [ ] Maintenance-branch forward-port tracker — N/A, mainline work
- [x] Evidence the linked issue asks for: test counts, the CLI table, and what is not claimed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3VJDT8R3Sr69BzfEBxT6
