### PR TITLE
[1.8.5] A command runs unless a rule holds it back

### DIFF
--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -511,7 +511,7 @@ def check_approval(agent: 'Agent') -> None:
             # This prevents sneaking in dangerous commands via chaining
             if tool_name == 'bash' and 'command' in tool_args:
                 # Check if ALL commands in chain are permitted
-                permitted, reason, source = check_bash_chain_permitted(tool_args['command'], permissions)
+                permitted, reason, source = check_bash_chain_permitted(tool_args['command'], permissions, carry_unguarded=True)
                 if permitted:
                     if getattr(getattr(agent, 'logger', None), 'console', None):
                         _log_permission_granted(agent, 'bash', tool_args, source, reason)
@@ -880,7 +880,7 @@ def is_tool_permitted(tool_name: str, tool_args: dict, permissions: dict) -> tup
     # prefix-match the whole chain string ("co status && rm -rf /") and wrongly
     # permit the dangerous half. Per-subcommand matching is the only safe check.
     if tool_name == 'bash' and 'command' in tool_args:
-        permitted, reason, _ = check_bash_chain_permitted(tool_args['command'], permissions)
+        permitted, reason, _ = check_bash_chain_permitted(tool_args['command'], permissions, carry_unguarded=True)
         return (True, reason or "permitted") if permitted else (False, "command not in the permission whitelist")
 
     for pattern, perm in permissions.items():

--- a/connectonion/useful_plugins/tool_approval/bash_parser.py
+++ b/connectonion/useful_plugins/tool_approval/bash_parser.py
@@ -159,7 +159,23 @@ def _extract_subcommands(command: str) -> list[tuple[str, str]]:
     return result
 
 
-def check_bash_chain_permitted(command: str, permissions: dict) -> tuple[bool, str, str]:
+def _needs_no_grant(segment: str) -> bool:
+    """Whether this segment would run on its own, without any grant.
+
+    Imported here rather than at module scope: policy imports this module.
+    """
+    try:
+        from ...project import project_root
+        from .policy import _classify_single_command
+
+        return _classify_single_command(segment, project_root()).get("decision") == "allow"
+    except Exception:
+        # A classifier that cannot answer must not widen anything.
+        return False
+
+
+def check_bash_chain_permitted(command: str, permissions: dict,
+                               *, carry_unguarded: bool = False) -> tuple[bool, str, str]:
     """Check if ALL commands in bash chain are permitted.
 
     For "pwd && ls -F", checks if BOTH pwd AND ls -F are allowed.
@@ -174,6 +190,12 @@ def check_bash_chain_permitted(command: str, permissions: dict) -> tuple[bool, s
         command: Bash command (may be chain)
         permissions: Session permissions dict
 
+    carry_unguarded: when True, a segment that needs no grant at all does not
+    need one here either, and the answer is still False unless some segment
+    was actually granted. Off by default, because the plain question this
+    function answers — "does a pattern cover every segment" — is also what
+    decides whether one pattern is broader than another.
+
     Returns:
         (permitted, reason, source) tuple - source comes from permission that matched
     """
@@ -182,7 +204,7 @@ def check_bash_chain_permitted(command: str, permissions: dict) -> tuple[bool, s
     from .approval import matches_permission_pattern
 
     subcommands = _extract_subcommands(command)
-    return _subcommands_permitted(subcommands, permissions)
+    return _subcommands_permitted(subcommands, permissions, carry_unguarded=carry_unguarded)
 
 
 def segment_permitted(cmd_name: str, full_cmd: str, permissions: dict) -> tuple[bool, str, str]:
@@ -197,12 +219,14 @@ def segment_permitted(cmd_name: str, full_cmd: str, permissions: dict) -> tuple[
     return _subcommands_permitted([(cmd_name, full_cmd)], permissions)
 
 
-def _subcommands_permitted(subcommands, permissions: dict) -> tuple[bool, str, str]:
+def _subcommands_permitted(subcommands, permissions: dict, *,
+                           carry_unguarded: bool = False) -> tuple[bool, str, str]:
     import fnmatch
 
     from .approval import matches_permission_pattern
 
     unpermitted = []
+    granted_any = False
     matched_source = 'config'  # Default source
 
     for cmd_name, full_cmd in subcommands:
@@ -226,10 +250,26 @@ def _subcommands_permitted(subcommands, permissions: dict) -> tuple[bool, str, s
             found = True
             matched_source = perm.get('source', 'config')
             break
+        if found:
+            granted_any = True
+        elif carry_unguarded and _needs_no_grant(full_cmd):
+            # A segment nobody granted is still fine if it needed no grant.
+            # Without this, `head` is permitted alone and refused one character
+            # later as `| head`, so an operator's `Bash(co browser *)` is
+            # defeated by the filter they piped it through (#1488). The grant
+            # still has to carry the segment the policy holds back: this asks
+            # the same classifier, so `&& co email send` is no more permitted
+            # here than it is on its own.
+            found = True
         if not found:
             unpermitted.append(cmd_name)
 
     if unpermitted:
+        return False, None, None
+    if carry_unguarded and not granted_any:
+        # Nothing here was granted, so this is not an operator decision and
+        # must not be reported as one. The policy allows it on its own merits
+        # or not at all.
         return False, None, None
 
     reason = f"safe chain ({len(subcommands)} commands)" if len(subcommands) > 1 else "permitted"

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -97,6 +97,10 @@ _PATH_WRITING_COMMANDS = {
     "chmod", "chown", "chgrp", "dd",
 }
 
+# Build tools whose input is a file of commands. A narrowed verification run
+# is allowed above; anything else they are asked to do runs that file.
+_CONFIG_EXECUTING_COMMANDS = {"make", "cargo", "go", "npm", "pnpm", "yarn", "bun", "gradle", "mvn"}
+
 # Wrappers that run their next word: `uv run python -c` is `python -c`.
 _COMMAND_RUNNERS = {"uv", "poetry", "pipx", "npx", "bunx", "pdm", "rye", "hatch", "nix-shell"}
 
@@ -369,6 +373,15 @@ def _classify_single_command(command: str, root: Path | None = None) -> dict:
         )
     if focused:
         return decision("verification", "allow", "focused test, lint, or build command", "workspace")
+    if first in _CONFIG_EXECUTING_COMMANDS:
+        # It got here, so it is not one of the verification runs narrowed
+        # above. What is left runs whatever the Makefile, build.rs or
+        # package.json script says, which is a program this policy cannot
+        # read — the same reason `bash` and `awk` ask.
+        return decision(
+            "code_execution", "ask",
+            "the command runs a project script this policy cannot read", "call",
+            requires_human=True)
     if first in _CODE_EXECUTING_COMMANDS or executing in _CODE_EXECUTING_COMMANDS:
         return decision(
             "code_execution", "ask",

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -33,6 +33,12 @@ READ_TOOLS = {
     "screenshot", "load_guide",
 }
 WORKFLOW_TOOLS = {"task", "ask_user", "skill", "todo_list"}
+# Classes whose every method is planning with no side effect. Matched on the
+# owner because the method names cannot be: TodoList registers `add`, `start`,
+# `complete`, `update`, `list`, `remove` and `clear`, and `remove` is in
+# DELETE_TOOLS while `list` is in READ_TOOLS. `todo_list` was in WORKFLOW_TOOLS
+# and is never a tool name, so 438 `add` calls were denied in six days (#1447).
+WORKFLOW_TOOL_CLASSES = {"TodoList"}
 WORKSPACE_EDIT_TOOLS = {"write", "edit", "multi_edit"}
 DELETE_TOOLS = {"delete", "remove", "unlink", "rmdir", "delete_file"}
 EXTERNAL_EFFECT_TOOLS = {
@@ -57,6 +63,43 @@ _MAKE_VERIFICATION_TARGETS = {
 _PACKAGE_RUNNERS = {"npm", "pnpm", "yarn", "bun"}
 _DESTRUCTIVE_COMMANDS = {"rm", "rmdir", "shred", "truncate", "del", "erase", "format"}
 _EXTERNAL_COMMANDS = {"curl", "wget", "ssh", "scp", "rsync", "mail", "sendmail"}
+# Commands whose argument is a *program*. `bash << EOF … EOF`, `python3 -c`,
+# `awk 'BEGIN{system("rm -rf /")}'` and GNU `sed 's/a/b/e'` all run text that
+# no rule here can inspect, so allowing them by name would allow everything
+# through one of them. These ask; a person can still say yes.
+#
+# This is the line default-allow actually draws. It is not "which command
+# names are safe" — that list can never be finished, and an unattended job
+# dies on the first tool nobody thought of. It is "can this command execute
+# something we cannot see".
+_CODE_EXECUTING_COMMANDS = {
+    "bash", "sh", "zsh", "fish", "dash", "ksh", "csh", "tcsh",
+    "python", "python2", "python3", "node", "deno", "bun", "ruby", "perl",
+    "php", "lua", "Rscript", "osascript", "eval", "exec", "source",
+    "awk", "gawk", "mawk", "nawk", "sed", "xargs", "env",
+}
+# Subcommands that send something to somebody. Under default allow these are
+# the other half of the line: `co email send`, `co feishu send`, `gh pr create`
+# and `git push` are not dangerous to this machine, they are visible to other
+# people, and an unattended agent must not be the one deciding to be seen.
+# Checked in the first few words, where a subcommand lives, so that a file
+# called `send.py` in an argument does not trip it.
+_OUTWARD_SUBCOMMANDS = {
+    "send", "reply", "post", "publish", "deploy", "release", "push",
+    "transfer", "pay", "invite", "announce", "broadcast", "comment", "merge",
+}
+
+# Commands that write a file named in their arguments rather than through a
+# redirect, so `_redirect_targets` never sees them. They are held to the write
+# tool's rule: inside the workspace is a reversible edit, outside is not.
+_PATH_WRITING_COMMANDS = {
+    "tee", "cp", "mv", "ln", "install", "touch", "mkdir", "truncate",
+    "chmod", "chown", "chgrp", "dd",
+}
+
+# Wrappers that run their next word: `uv run python -c` is `python -c`.
+_COMMAND_RUNNERS = {"uv", "poetry", "pipx", "npx", "bunx", "pdm", "rye", "hatch", "nix-shell"}
+
 _SENSITIVE_COMMANDS = {
     "env", "printenv", "security", "keychain", "gcloud", "aws", "az",
 }
@@ -81,21 +124,6 @@ _CO_SUBCOMMAND_EFFECTS = {
 # clean iterations (#1481). This is the Auto *policy* for the agent's own
 # calls; the remote-EXEC whitelist in host.yaml is a different gate and is
 # deliberately not widened here.
-_READ_ONLY_COMMANDS = {
-    "head", "tail", "cat", "less", "more", "grep", "egrep", "fgrep", "rg",
-    "wc", "ls", "sort", "uniq", "cut", "tr", "basename",
-    "dirname", "jq", "echo", "printf", "pwd", "cd", "true", "test", "[",
-    "which", "file", "stat", "diff", "date", "whoami", "hostname", "uname",
-}
-# `sed` and `awk` are deliberately absent. They take a *program*, and a
-# program is code: `awk 'BEGIN{system("rm -rf /")}'` reads like an inspection
-# and is arbitrary execution, as does `sed 's/a/b/e'` on GNU. Any rule that
-# tried to keep them while excluding their execution constructs would be a
-# parser in a security path, written by the person it has to outsmart. The
-# inspection they are reached for has cover: `head`, `tail`, `cut`, `sort`,
-# `uniq`, `wc`, `jq` and `grep` are on the list, `read_file` takes `limit`
-# and `offset`, and the agent has `grep` and `glob` tools. Both still ask,
-# which is what they did before 1.8.5 as well.
 # Key material, recognised by where it lives and what it is called rather than
 # by substring: `keys.md` is documentation and `monkey.txt` is a file. Reading
 # any of this is a credential read wherever it sits, so the workspace rule is
@@ -297,6 +325,8 @@ def _classify_single_command(command: str, root: Path | None = None) -> dict:
         return decision("deletion", "deny", "destructive command requires an explicit safer workflow", "call")
     if any(token in lowered for token in ("publish", "deploy", "release", "push")):
         return decision("publication", "ask", "publishing and deployment require human approval", "call", requires_human=True)
+    if any(word.lower() in _OUTWARD_SUBCOMMANDS for word in words[1:4]):
+        return decision("external_effect", "ask", "sending something to other people requires human approval", "call", requires_human=True)
     if first in _EXTERNAL_COMMANDS:
         return decision("external_network", "ask", "external network access requires human approval", "call", requires_human=True)
     if first == "co" and len(words) > 1:
@@ -308,6 +338,15 @@ def _classify_single_command(command: str, root: Path | None = None) -> dict:
         ".env" in token or "credential" in token or "secret" in token for token in lowered
     ) or any(_is_key_material(word) for word in words[1:] if not word.startswith("-")):
         return decision("credentials", "deny", "credential access is never auto-approved", "call")
+
+    # The runner's own name says nothing; what it runs does.
+    executing = first
+    if first in _COMMAND_RUNNERS:
+        after = [word for word in words[1:] if not word.startswith("-")]
+        if after and after[0] == "run":
+            after = after[1:]
+        if after:
+            executing = Path(after[0]).name.lower()
 
     focused = first in _FOCUSED_COMMANDS
     focused = focused or (first in {"python", "python3"} and words[1:3] == ["-m", "pytest"])
@@ -330,13 +369,48 @@ def _classify_single_command(command: str, root: Path | None = None) -> dict:
         )
     if focused:
         return decision("verification", "allow", "focused test, lint, or build command", "workspace")
-    if first in _READ_ONLY_COMMANDS:
-        if first in _PATH_READING_COMMANDS and _reads_an_unresolvable_path(words):
+    if first in _CODE_EXECUTING_COMMANDS or executing in _CODE_EXECUTING_COMMANDS:
+        return decision(
+            "code_execution", "ask",
+            "the command runs a program this policy cannot read", "call",
+            requires_human=True)
+    if first == "find" and any(flag in lowered for flag in ("-delete", "-exec", "-execdir", "-ok")):
+        # A deletion and an execution hiding in a flag. `find` itself is a
+        # search; these two arguments make it something else.
+        return decision("command", "ask", "find is deleting or executing, not searching", "call", requires_human=True)
+    if first in _PATH_WRITING_COMMANDS:
+        from .approval import _is_control_file
+
+        for word in words[1:]:
+            if word.startswith("-"):
+                continue
+            if "$" in word or "`" in word:
+                return decision("command", "ask", "the file to write depends on the environment", "call", requires_human=True)
+            target = Path(word).expanduser()
+            resolved = (target if target.is_absolute() else (root or Path.cwd()) / target).resolve(strict=False)
+            if _is_control_file(str(resolved)):
+                return decision("authorization_control", "deny", "agents cannot rewrite authorization control files", "call")
+            if root is not None and not _inside_workspace(resolved, root):
+                return decision("write_outside_workspace", "deny", "writes outside the workspace are not auto-approved", "call")
+        return decision("workspace_edit", "allow", "file written inside the workspace", "workspace")
+    if first in _PATH_READING_COMMANDS:
+        if _reads_an_unresolvable_path(words):
             return decision("read_outside_workspace", "ask", "the file to read depends on the environment", "call", requires_human=True)
-        if root is not None and first in _PATH_READING_COMMANDS and _reads_outside_workspace(words, root):
+        if root is not None and _reads_outside_workspace(words, root):
             return decision("read_outside_workspace", "ask", "reading outside the workspace requires approval", "call", requires_human=True)
         return decision("read", "allow", "read-only command", "workspace")
-    return decision("command", "ask", "command is outside the focused verification and read-only allowlists", "call", requires_human=True)
+    # Everything the rules above did not name runs. #1481 asked for this and
+    # the enumerated alternative cannot get there: a list of safe command
+    # names is a list somebody has to extend for every tool anyone installs,
+    # and until they do, an unattended job dies on `xargs`.
+    #
+    # The lines that hold are the ones checked before this point, and this
+    # change moves none of them: destructive commands, external network,
+    # credentials and key material, publication, anything that executes a
+    # program we cannot read, writes outside the workspace, authorization
+    # control files, and reads outside the workspace for the commands whose
+    # file arguments can be seen.
+    return decision("command", "allow", "ordinary command, allowed by default", "workspace")
 
 
 def _redirect_targets(command: str) -> list[str]:
@@ -428,8 +502,8 @@ def _classify_command(command: str, root: Path | None = None) -> dict:
         # Every write target is a reversible workspace file: the read-only
         # segments feeding it are now a workspace edit, and are allowed as one.
         results = [
-            decision("workspace_edit", "allow", "read-only command writing a workspace file", "workspace")
-            if item["effect_class"] == "read" else item
+            decision("workspace_edit", "allow", "command writing a workspace file", "workspace")
+            if item["effect_class"] in ("read", "command") else item
             for item in results
         ]
     denied = next((item for item in results if item["decision"] == "deny"), None)
@@ -444,7 +518,14 @@ def _classify_command(command: str, root: Path | None = None) -> dict:
         return decision("read", "allow", f"read-only command chain ({count})", "workspace")
     if effects == {"workspace_edit"}:
         return decision("workspace_edit", "allow", f"workspace file written by a read-only chain ({count})", "workspace")
-    return decision("verification", "allow", f"focused verification chain ({count})", "workspace")
+    if "verification" in effects and effects <= {"verification", "read", "command"}:
+        # `cd x && cargo build | tail -20` is a verification run with filters
+        # around it. The filters are what it is piped through, not what it is.
+        return decision("verification", "allow", f"focused verification chain ({count})", "workspace")
+    # Mixed or ordinary. Named for what it is: a chain that reached here has
+    # passed every deny and ask rule, so the reason should not claim it was
+    # recognised as a test command when it was simply not refused.
+    return decision("command", "allow", f"ordinary command chain ({count}), allowed by default", "workspace")
 
 
 def evaluate_auto_approve(tool_name: str, args: dict, root: Path | None = None) -> dict:
@@ -488,6 +569,24 @@ def evaluate_auto_approve(tool_name: str, args: dict, root: Path | None = None) 
     return decision("unknown", "ask", "unknown tools never run silently", "call", requires_human=True)
 
 
+def _owned_by_workflow_class(agent: "Agent", tool_name) -> bool:
+    """Whether this call is a method of a planning tool the agent holds.
+
+    Asked of the agent rather than of the name, because the names collide with
+    tools that must keep their stronger verdict — a tool genuinely called
+    `remove` is still a deletion.
+    """
+    registry = getattr(agent, "tools", None)
+    if registry is None or not tool_name:
+        return False
+    try:
+        tool = registry.get(str(tool_name))
+    except Exception:
+        return False
+    owner = getattr(tool, "__self__", None)
+    return owner is not None and type(owner).__name__ in WORKFLOW_TOOL_CLASSES
+
+
 def workspace_policy_for_pending(agent: "Agent", pending: dict) -> dict | None:
     """Return a deterministic decision for any ordinary Auto session."""
     if ensure_approval_mode(agent) != AUTO:
@@ -498,6 +597,13 @@ def workspace_policy_for_pending(agent: "Agent", pending: dict) -> dict | None:
                 "managed_delegation",
                 "allow",
                 MANAGED_DELEGATION_REASON,
+                "session",
+            )
+        elif _owned_by_workflow_class(agent, pending.get("name")):
+            result = decision(
+                "workflow",
+                "allow",
+                "built-in planning tool with no side effects",
                 "session",
             )
         else:

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -62,7 +62,13 @@ _MAKE_VERIFICATION_TARGETS = {
 }
 _PACKAGE_RUNNERS = {"npm", "pnpm", "yarn", "bun"}
 _DESTRUCTIVE_COMMANDS = {"rm", "rmdir", "shred", "truncate", "del", "erase", "format"}
-_EXTERNAL_COMMANDS = {"curl", "wget", "ssh", "scp", "rsync", "mail", "sendmail"}
+_EXTERNAL_COMMANDS = {
+    "curl", "wget", "ssh", "scp", "rsync", "mail", "sendmail",
+    # These reached the network too and were refused only because nothing had
+    # named them. Under default allow, "nobody listed it" stops being a reason.
+    "ping", "ping6", "nc", "netcat", "telnet", "ftp", "sftp", "dig", "nslookup",
+    "traceroute", "whois", "http", "httpie", "aria2c",
+}
 # Commands whose argument is a *program*. `bash << EOF … EOF`, `python3 -c`,
 # `awk 'BEGIN{system("rm -rf /")}'` and GNU `sed 's/a/b/e'` all run text that
 # no rule here can inspect, so allowing them by name would allow everything
@@ -329,8 +335,6 @@ def _classify_single_command(command: str, root: Path | None = None) -> dict:
         return decision("deletion", "deny", "destructive command requires an explicit safer workflow", "call")
     if any(token in lowered for token in ("publish", "deploy", "release", "push")):
         return decision("publication", "ask", "publishing and deployment require human approval", "call", requires_human=True)
-    if any(word.lower() in _OUTWARD_SUBCOMMANDS for word in words[1:4]):
-        return decision("external_effect", "ask", "sending something to other people requires human approval", "call", requires_human=True)
     if first in _EXTERNAL_COMMANDS:
         return decision("external_network", "ask", "external network access requires human approval", "call", requires_human=True)
     if first == "co" and len(words) > 1:
@@ -338,6 +342,8 @@ def _classify_single_command(command: str, root: Path | None = None) -> dict:
         if effect:
             effect_class, verdict, reason = effect
             return decision(effect_class, verdict, reason, "call", requires_human=(verdict == "ask"))
+    if any(word.lower() in _OUTWARD_SUBCOMMANDS for word in words[1:4]):
+        return decision("external_effect", "ask", "sending something to other people requires human approval", "call", requires_human=True)
     if first in _SENSITIVE_COMMANDS or any(
         ".env" in token or "credential" in token or "secret" in token for token in lowered
     ) or any(_is_key_material(word) for word in words[1:] if not word.startswith("-")):

--- a/docs/blog/2026-09-11-the-list-was-never-going-to-be-finished.md
+++ b/docs/blog/2026-09-11-the-list-was-never-going-to-be-finished.md
@@ -1,0 +1,93 @@
+# The list was never going to be finished
+
+Yesterday we fixed a policy that refused `head`. An unattended job had been
+running seven times a day, and on the sixteenth iteration it reached
+`co browser ... get_text | head -40` and stopped. The policy allowed eleven
+commands — `pytest`, `ruff`, `cargo`, `make` and seven more — and everything
+else fell through to "ask", which with nobody watching is "no".
+
+The fix added the read-only commands: `head`, `tail`, `grep`, `wc`, `ls`,
+`sort`, `cut`, `jq`, thirty-odd names. Tests went green. The job ran.
+
+Then the maintainer asked a question that undid it. *If the default were
+allow, what would the list be for?*
+
+Nothing. That is the whole answer. The two designs are alternatives, not
+layers: either you enumerate what may run, or you enumerate what may not.
+We had been asked for the second and had built the first, and the first is
+the one that cannot be finished. Every list of safe command names is a list
+somebody has to extend for every tool anyone ever installs, and the way you
+find out it needs extending is that a job dies at two in the morning.
+
+## What we went looking at
+
+Before changing anything we looked at what the tools on this machine actually
+do. Claude Code's settings file has an allow list, an ask list and a deny list,
+and all three are empty. Codex's config has no command list at all; it has a
+reviewer. Neither of them decides anything by command name.
+
+They constrain by boundary. Can this touch that directory. Does it leave the
+sandbox. A name is not a capability — which is obvious once said, and was not
+obvious while we were adding `basename` to a set.
+
+## What the list was not buying
+
+The argument for enumerating is that you know what each name does. We had a
+careful comment explaining why `sed` and `awk` were deliberately excluded:
+they take a *program*, and `awk 'BEGIN{system("rm -rf /")}'` reads like an
+inspection and is arbitrary execution. Correct, and worth the paragraph.
+
+`make` was on the allow list. A Makefile recipe is arbitrary execution.
+`cargo build` runs `build.rs`. `npm test` runs whatever `package.json` says.
+The policy was refusing `awk` and running three things that do the same job
+with a config file. It was not holding a line; it was holding an alphabet.
+
+The argument was right and it was pointed at the wrong list. Executing
+unreadable input *is* the thing to refuse — just not by asking whether the
+command's name is on a roster of thirty.
+
+## Flipping it, and what fell out
+
+The change is small: an ordinary command runs. Everything that was denied
+before is still denied, and three rules had to be written down that the list
+had been enforcing by omission.
+
+The first was the one that mattered. With the default flipped,
+`bash << 'EOF' rm -rf / EOF` was allowed — `bash` is just a command name, and
+the heredoc body is not something any rule here can read. So: a command whose
+argument is a program asks. That is `bash`, `sh`, `python`, `node`, `ruby`,
+`perl`, `awk`, `sed`, and `uv run python -c`, which is `python -c` wearing a
+coat. The careful paragraph about `awk` survives, generalised.
+
+The second we found the same way. `co email send --to ... hi` was allowed.
+Nothing about that command is dangerous to this machine; it is dangerous to
+the relationship with whoever receives it. An unattended agent must not be the
+one deciding to be seen, so anything whose subcommand is `send`, `reply`,
+`post`, `publish`, `deploy`, `push`, `transfer` or `pay` asks. Local damage and
+outward visibility are different axes, and the old list had conflated them by
+accident — `co email send` was refused for being unrecognised, not for being
+an email.
+
+The third was `tee out.txt` and `find . -delete`, which write and delete
+through their arguments rather than through a redirect, so the redirect rule
+never saw them. They now get the same workspace check the write tool gets.
+
+Three rules, and the shape of them is the point: they describe categories of
+consequence, not names of programs. The set of dangerous *verbs* is small and
+changes slowly. The set of safe *commands* is unbounded and changes every time
+someone runs `brew install`.
+
+## The test that fired
+
+The job test from yesterday pinned exactly which steps needed an operator
+grant, with a docstring promising it would fail loudly if a policy change made
+a pipe filter need a grant again. It failed loudly in the other direction:
+the two steps that had needed a grant — making a directory, and running the
+binary the job had just built — needed nothing.
+
+Needing a standing `Bash(co *)` permission to run `mkdir` was the shape of the
+problem, not a boundary anyone would defend. The test now asserts the job needs
+no grant at all, which is a better thing to pin.
+
+Two bugs in one file, two days apart, and the second one only visible because
+the first fix was wrong in a way that worked.

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -8,7 +8,7 @@ human decision.
 | Mode | Behaviour |
 |---|---|
 | `read-only` | Manual approval for every effectful live-IO call not explicitly permitted |
-| `auto` | Auto-approves reversible workspace work, focused verification, and read-only commands on workspace paths; asks or denies higher-impact calls |
+| `auto` | Runs ordinary local commands; asks or denies the ones that leave the machine, execute unreadable input, touch credentials, or write outside the workspace |
 | `full-access` | Explicit bounded approval bypass under the Host launch ceiling |
 
 No aliases are accepted or translated. Unknown stored values become Auto.
@@ -212,15 +212,49 @@ reach for both instead of the write tool); a control file is denied; a target
 outside the workspace is denied; a target that depends on the environment
 (`> $HOME/x`) cannot be resolved and asks. `2>&1` is not a write. A heredoc
 is classified by its first line — the body is data to that command — so
-`bash << EOF` still asks, because `bash` is not read-only.
+`bash << EOF` still asks, because `bash` runs whatever the body says.
 
-The same list decides which pipe segments ride along on an operator grant in
-an unattended run. `co browser ... get_text | head -40` is the granted browser
-command plus a filter on its output, so it runs; `co browser status && co email
-send ...` is still an email send nobody authorized, so it does not (#1481).
+### A command runs unless a rule holds it back
+
+A command nobody thought of runs. There is no list of safe command names to be
+on, because that list can never be finished — an unattended job dies on the
+first tool nobody added, which is how a seven-times-a-day round died at
+iteration sixteen on `head -40` (#1481).
+
+What holds a command back, all checked before the default applies:
+
+| rule | example | verdict |
+|---|---|---|
+| destroys files | `rm -rf build`, `shred x` | deny |
+| credentials or key material | `env`, `aws s3 ls`, `cat ~/.ssh/id_rsa` | deny |
+| writes outside the workspace | `echo x > ../out`, `cp f /etc/x` | deny |
+| rewrites an authorization control file | `> .co/host.yaml` | deny |
+| leaves the machine | `curl`, `ssh`, `git push`, `co email send`, `co feishu send` | ask |
+| runs a program this policy cannot read | `bash << EOF`, `python3 -c`, `awk`, `sed`, `uv run python -c` | ask |
+| deletes or executes through a flag | `find . -delete`, `find . -exec` | ask |
+| reads outside the workspace | `cat /etc/passwd` | ask |
+| cannot be parsed | `echo 'unclosed` | ask |
+
+A chain is only as permitted as its worst link: `ls && rm -rf build` is denied.
+`co browser status && co email send ...` is still an email send nobody
+authorized, so it asks, and in an unattended run that is a refusal.
+
+One known gap, recorded rather than guessed at: `gh pr create` is allowed.
+`create` is too generic to add to the outward list — `co create my-agent` is
+local work — and a pull request is a reversible proposal in the operator's own
+repository.
 
 This is the Auto policy for the agent's own calls. The remote-EXEC whitelist
 in `host.yaml` is a separate gate and is not widened by it.
+
+### Planning tools
+
+A class whose every method is planning with no side effect is recognised by
+what owns the call, not by its name. `TodoList` registers `add`, `start`,
+`complete`, `update`, `list`, `remove` and `clear`; matching those names would
+be wrong in both directions, since `remove` is a deletion and `list` is a read
+for every other tool. Before this, `todo_list` sat in the workflow list and was
+never a tool name, so 438 `add` calls were refused in six days (#1447).
 
 ### Unknown Tools
 

--- a/tests/e2e/test_an_unattended_agent_builds_a_rust_cli.py
+++ b/tests/e2e/test_an_unattended_agent_builds_a_rust_cli.py
@@ -111,12 +111,12 @@ HOST_YAML = {
 
 # What the model does, in order, and which rule the test expects to carry it.
 STEPS = [
-    ("bash", {"command": "mkdir -p greeter/src", "description": "project layout"}, "configured_command"),
+    ("bash", {"command": "mkdir -p greeter/src", "description": "project layout"}, "workspace_edit"),
     ("write", {"path": "greeter/Cargo.toml", "content": CARGO_TOML}, "workspace_edit"),
     ("write", {"path": "greeter/src/main.rs", "content": MAIN_RS}, "workspace_edit"),
     ("bash", {"command": "cd greeter && cargo build --quiet 2>&1 | tail -20", "description": "build", "timeout": 300}, "verification"),
     ("bash", {"command": "cd greeter && cargo test --quiet 2>&1 | tail -20", "description": "test", "timeout": 300}, "verification"),
-    ("bash", {"command": "cd greeter && ./target/debug/greeter --name Aaron | head -1", "description": "run it"}, "configured_command"),
+    ("bash", {"command": "cd greeter && ./target/debug/greeter --name Aaron | head -1", "description": "run it"}, "command"),
     ("bash", {"command": "wc -l greeter/src/main.rs && ls greeter/target/debug | grep -c '^greeter$'", "description": "inspect"}, "read"),
 ]
 
@@ -200,14 +200,23 @@ def test_an_unattended_agent_builds_tests_and_runs_a_rust_cli(project, rust_tool
     assert result == "Built greeter, its test passes, and it greets Aaron."
 
 
-def test_the_two_grants_are_the_only_two_the_job_needs(project, rust_toolchain_env):
-    """Take the grants away and exactly the two granted steps are refused.
+def test_the_job_needs_no_grant_at_all(project, rust_toolchain_env):
+    """Take every grant away and the whole job still runs.
 
     This is the test that would have caught #1481 in reverse: it pins down
     that the built-in policy, not an operator grant, carries the file writes,
     the cargo runs and every pipe filter. If a future policy change made
     `| tail -20` need a grant again, this fails at the build step, not in
     production at iteration sixteen.
+
+    It used to expect two refusals — `mkdir` and running the binary the job
+    just built — which were carried by an operator grant rather than by the
+    policy. Needing a standing `Bash(co *)` to make a directory was the shape
+    of the problem, not a boundary worth keeping: with the default flipped
+    (#1481), an ordinary local command runs and the rules that hold are the
+    ones about leaving the machine, executing unreadable input, credentials
+    and writing outside the workspace. A grant that still binds is covered in
+    tests/unit/test_auto_approve_policy.py.
     """
     (project / ".co" / "host.yaml").write_text(yaml.safe_dump({"name": "rust-builder"}), encoding="utf-8")
     agent = Agent(
@@ -225,4 +234,4 @@ def test_the_two_grants_are_the_only_two_the_job_needs(project, rust_toolchain_e
     calls = [e for e in agent.current_session["trace"] if e.get("type") == "tool_call"]
     decisions = [(s[1].get("command", s[1].get("path")), c["approval_policy"]["decision"]) for s, c in zip(STEPS, calls)]
     denied = [command for command, decision in decisions if decision == "deny"]
-    assert denied == ["mkdir -p greeter/src", "cd greeter && ./target/debug/greeter --name Aaron | head -1"], decisions
+    assert denied == [], decisions

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -326,8 +326,10 @@ def test_headless_auto_honors_the_operator_command_allowlist(
 
     result = instance.current_session["pending_tool"]["approval_policy"]
     assert result["decision"] == "allow"
-    assert result["effect_class"] == "configured_command"
-    assert result["reason"] == "operator-configured command allowlist"
+    # These are ordinary commands, so the default now carries them and the
+    # grant is never consulted. The grant still decides for the commands the
+    # rules hold back — the next test is the one that proves it still binds.
+    assert result["effect_class"] in ("configured_command", "command", "read")
 
 
 def test_packaged_permissions_keep_headless_co_browser_status_working(
@@ -447,7 +449,10 @@ def test_headless_auto_allows_read_only_commands(tmp_path, monkeypatch, command)
 
     result = instance.current_session["pending_tool"]["approval_policy"]
     assert result["decision"] == "allow", result
-    assert result["effect_class"] == "read"
+    # "read" once meant "found on the read-only name list". With default allow
+    # the label says what was checked: a command whose file arguments can be
+    # seen is still "read"; one with nothing to check is an ordinary command.
+    assert result["effect_class"] in ("read", "command")
 
 
 @pytest.mark.parametrize(
@@ -460,7 +465,6 @@ def test_headless_auto_allows_read_only_commands(tmp_path, monkeypatch, command)
         "echo x > ../outside.txt",
         "echo 'Bash(*)' > .co/host.yaml",     # a redirect into a control file
         "cat notes.txt > $HOME/notes.txt",    # a redirect nobody can resolve
-        "tee out.txt",                        # writes its input
         "find . -name '*.log' -delete",       # deletes
         "xargs rm",                           # runs whatever it is given
         "cat .env",                           # credentials: still denied
@@ -502,7 +506,10 @@ def test_a_read_only_segment_does_not_poison_a_granted_command(tmp_path, monkeyp
 
     result = instance.current_session["pending_tool"]["approval_policy"]
     assert result["decision"] == "allow", result
-    assert result["effect_class"] == "configured_command"
+    # Either route is correct. Before default allow only the operator's grant
+    # could carry these; now the default carries them and the grant is what
+    # still carries a command the rules hold back.
+    assert result["effect_class"] in ("configured_command", "command", "read")
 
 
 def test_a_granted_command_still_cannot_smuggle_an_ungranted_one(tmp_path, monkeypatch):

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -851,7 +851,10 @@ def _granted(pattern, source="config", command=None):
         ("Bash(cat .env)", "cat .env"),                      # credentials
         ("Bash(sed -i *)", "sed -i s/a/b/ notes.txt"),       # takes a program
         ("Bash(awk *)", "awk '{print $1}' notes.txt"),
-        ("Bash(mkdir *)", "mkdir -p build"),                 # ordinary
+        # `mkdir -p build` is an ordinary workspace write now, so the default
+        # carries it and the grant is never consulted. This claim needs a call
+        # the rules hold back, which is what a grant is for.
+        ("Bash(python3 *)", "python3 -c 'print(1)'"),         # ordinary
         ("Bash(co email send *)", "co email send --to a@b.c hi"),
     ],
 )
@@ -1074,11 +1077,11 @@ REFUSED_CALLS = [
     ("co deploy", "publication"),
     ("co email send --to a@b.c hi", "external_effect"),
     ("co transfer 0xabc 5", "payment"),
-    ("sed -n 1,10p notes.txt", "command"),
-    ("awk '{print $1}' notes.txt", "command"),
-    ("make install", "command"),
-    ("ping -c 1 8.8.8.8", "command"),
-    ("python3 -c 'print(1)'", "command"),
+    ("sed -n 1,10p notes.txt", "code_execution"),
+    ("awk '{print $1}' notes.txt", "code_execution"),
+    ("make install", "code_execution"),
+    ("ping -c 1 8.8.8.8", "external_network"),
+    ("python3 -c 'print(1)'", "code_execution"),
 ]
 
 

--- a/tests/unit/test_chain_consults_the_classifier.py
+++ b/tests/unit/test_chain_consults_the_classifier.py
@@ -1,0 +1,74 @@
+"""
+LLM-Note: Tests for #1488 — a segment that needs no grant must not need one
+just because it appears in a pipe. The chain checker used to treat "no pattern
+matched" as "not permitted", so an operator's grant was defeated by `| head`.
+"""
+
+import pytest
+
+from connectonion.useful_plugins.tool_approval.bash_parser import (
+    check_bash_chain_permitted as _check,
+)
+
+
+def check_bash_chain_permitted(command, permissions):
+    """The approval paths ask with carry_unguarded=True; so does this test."""
+    return _check(command, permissions, carry_unguarded=True)
+
+
+def grant(*patterns):
+    return {p: {"allowed": True, "source": "config", "reason": "operator grant",
+                "when": {"command": p[len("Bash("):-1]}} for p in patterns}
+
+
+class TestAFilterRidesAlong:
+    """The grant carries the command; the filter needs no grant of its own."""
+
+    @pytest.mark.parametrize("command", [
+        "co browser -t t get_text | head -40",
+        "co browser -t t get_text | grep -i foo",
+        "co browser status | head -5 | wc -l",
+        "co browser status && echo ok",
+        "CO_WHO=x co browser -t t get_text | head -40",
+    ])
+    def test_a_granted_command_still_runs_when_piped(self, command):
+        permitted, reason, source = check_bash_chain_permitted(command, grant("Bash(co browser *)"))
+        assert permitted, f"{command}: {reason}"
+
+    def test_the_grant_is_still_what_carried_it(self):
+        permitted, reason, source = check_bash_chain_permitted(
+            "co browser status | head -5", grant("Bash(co browser *)"))
+        assert permitted and source == "config"
+
+
+class TestTheUngrantedHalfStillDecides:
+    """A segment the policy refuses on its own is not rescued by a neighbour."""
+
+    @pytest.mark.parametrize("command", [
+        "co browser status && co email send --to a@b.c hi",
+        "co browser status && rm -rf build",
+        "co browser status | python3 -c 'import os'",
+        "co browser status && curl https://example.com",
+        "co browser status && cat ~/.ssh/id_rsa",
+    ])
+    def test_a_command_that_needs_approval_is_not_smuggled_in(self, command):
+        permitted, reason, source = check_bash_chain_permitted(command, grant("Bash(co browser *)"))
+        assert not permitted, f"{command} rode along on the grant"
+
+    def test_an_explicit_grant_for_the_second_half_still_works(self):
+        permitted, _, _ = check_bash_chain_permitted(
+            "co browser status && curl https://example.com",
+            grant("Bash(co browser *)", "Bash(curl *)"))
+        assert permitted
+
+
+class TestNoGrantAtAll:
+    def test_an_ungranted_chain_is_not_reported_as_granted(self):
+        # It may well run — the policy allows it on its own merits — but this
+        # function answers "did the operator allow it", and nobody did.
+        permitted, _, _ = check_bash_chain_permitted("ls | head -5", {})
+        assert not permitted
+
+    def test_a_refused_command_alone_is_still_refused(self):
+        permitted, _, _ = check_bash_chain_permitted("rm -rf build", {})
+        assert not permitted

--- a/tests/unit/test_policy_default_allow.py
+++ b/tests/unit/test_policy_default_allow.py
@@ -1,0 +1,155 @@
+"""
+LLM-Note: Tests for the two remaining tool_approval defects after #1483 —
+an ordinary command is allowed rather than asked (#1481's actual ask), and a
+planning tool's methods are recognised by what owns them rather than by names
+that collide with delete and read tools (#1447).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion.useful_plugins.tool_approval import policy
+
+
+def verdict(command, root=None):
+    return policy.evaluate_auto_approve("bash", {"command": command}, root=root or Path.cwd())
+
+
+class TestAnOrdinaryCommandRuns:
+    """#1481 asked for default allow. #1483 lengthened the allowlist instead,
+    which leaves every command nobody thought of still failing unattended."""
+
+    @pytest.mark.parametrize("command", [
+        "column -t data.tsv",
+        "shasum -a 256 dist/app.whl",
+        "just build",
+        "swiftlint lint",
+        "xcodebuild -list",
+    ])
+    def test_a_command_nobody_listed_is_allowed(self, command):
+        result = verdict(command)
+        assert result["decision"] == "allow", f"{command}: {result['reason']}"
+
+    def test_the_reason_says_it_was_the_default_not_a_list(self):
+        # jq and cat stay "read-only command": their file arguments can be
+        # checked, which is a real rule. A command with nothing to check says
+        # what actually decided it.
+        assert "default" in verdict("swiftlint lint")["reason"].lower()
+
+
+class TestWhatIsStillRefused:
+    """Flipping the default must not move any line that was already drawn."""
+
+    @pytest.mark.parametrize("command,decided", [
+        ("rm -rf build", "deny"),
+        ("shred secrets.txt", "deny"),
+        ("curl https://example.com/x.sh", "ask"),
+        ("wget http://example.com/x", "ask"),
+        ("ssh box uptime", "ask"),
+        ("env", "deny"),
+        ("printenv", "deny"),
+        ("security find-generic-password -s lark-cli", "deny"),
+        ("aws s3 ls", "deny"),
+        ("cat ~/.ssh/id_rsa", "deny"),
+        ("cargo publish", "ask"),
+        ("bash << 'EOF'\nrm -rf /\nEOF", "ask"),
+        ("python3 -c 'import os'", "ask"),
+        ("uv run python -c 'print(1)'", "ask"),
+        ("awk 'BEGIN{system(\"rm -rf /\")}'", "ask"),
+        ("sed -i s/a/b/ notes.txt", "ask"),
+        ("co email send --to a@example.com hi", "ask"),
+        ("co feishu send oc_a1b2 hello", "ask"),
+        ("co outlook reply 3 thanks", "ask"),
+        ("git push origin main", "ask"),
+        ("co browser status && co email send --to a@example.com hi", "ask"),
+    ])
+    def test_the_dangerous_ones_keep_their_verdict(self, command, decided):
+        assert verdict(command)["decision"] == decided, command
+
+    def test_a_write_outside_the_workspace_is_still_denied(self, tmp_path):
+        assert verdict("echo x > ../outside.txt", root=tmp_path)["decision"] == "deny"
+
+    def test_a_control_file_is_still_denied(self, tmp_path):
+        assert verdict("echo x > .co/host.yaml", root=tmp_path)["decision"] == "deny"
+
+    def test_a_chain_is_still_only_as_permitted_as_its_worst_link(self, tmp_path):
+        assert verdict("ls && rm -rf build", root=tmp_path)["decision"] == "deny"
+
+    def test_an_unparseable_command_still_asks(self):
+        assert verdict("echo 'unclosed")["decision"] == "ask"
+
+
+class TestAKnownGap:
+    def test_opening_a_pull_request_is_not_caught(self):
+        # `create` is too generic to add: `co create my-agent` is local work.
+        # A pull request is a reversible proposal in the operator's own repo,
+        # so this is recorded rather than guessed at.
+        assert verdict("gh pr create --title x")["decision"] == "allow"
+
+
+class TestTheReadOnlyListIsGone:
+    def test_naming_read_only_commands_is_no_longer_how_they_are_allowed(self):
+        # With default allow the list decides nothing, and a list that decides
+        # nothing is a thing to keep in sync for no reason.
+        assert not hasattr(policy, "_READ_ONLY_COMMANDS")
+
+
+class TestAPlanningToolIsRecognisedByItsOwner:
+    """#1447: TodoList registers add/start/complete/update/list/remove/clear.
+    `todo_list` is never a tool name, so 438 `add` calls were denied in six
+    days. Matching the method names instead is not a fix: `remove` is in
+    DELETE_TOOLS and would be denied, and `list` belongs to the read tools."""
+
+    def test_the_owning_class_is_what_marks_a_workflow_tool(self):
+        assert "TodoList" in policy.WORKFLOW_TOOL_CLASSES
+
+    @pytest.mark.parametrize("method", ["add", "start", "complete", "update", "list", "remove", "clear"])
+    def test_every_todo_method_is_allowed_when_it_belongs_to_the_list(self, method):
+        agent = _agent_with_todo_list()
+        result = policy.workspace_policy_for_pending(agent, {"name": method, "arguments": {}})
+        assert result["decision"] == "allow", f"{method}: {result['reason']}"
+        assert result["effect_class"] == "workflow"
+
+    def test_remove_is_still_a_deletion_when_it_is_not_the_todo_list(self):
+        # The collision this avoids: a tool genuinely named `remove` must keep
+        # the deletion verdict.
+        agent = _agent_with_todo_list(include_todo=False)
+        result = policy.workspace_policy_for_pending(agent, {"name": "remove", "arguments": {}})
+        assert result["decision"] == "deny"
+
+    def test_a_tool_the_agent_does_not_have_is_unchanged(self):
+        agent = _agent_with_todo_list()
+        result = policy.workspace_policy_for_pending(agent, {"name": "send_email", "arguments": {}})
+        assert result["decision"] in ("ask", "deny")
+
+
+class _Registry:
+    def __init__(self, tools):
+        self._tools = tools
+
+    def get(self, name, default=None):
+        return self._tools.get(name, default)
+
+
+class _Agent:
+    io = None
+    current_session = {}
+
+    def __init__(self, tools):
+        self.tools = _Registry(tools)
+
+
+def _agent_with_todo_list(include_todo=True):
+    from connectonion.useful_tools.todo_list import TodoList
+
+    tools = {}
+    if include_todo:
+        todo = TodoList()
+        for method in ("add", "start", "complete", "update", "list", "remove", "clear"):
+            bound = getattr(todo, method, None)
+            if bound is not None:
+                tools[method] = bound
+    agent = _Agent(tools)
+    agent.current_session = {"permissions": {}}
+    return agent


### PR DESCRIPTION
Fixes #1447 and #1488. Completes #1481, which #1483 answered with a longer allowlist rather than a flipped default.

- **Proposed target version:** 1.8.5, first published as `1.8.5a1`
- **Estimated release window:** next alpha, with #1483

Rebased onto `main` after #1483, #1486 (1.8.5a1) and #1487 landed; two of the three commits reconcile with what those added.

## Why this exists

#1481 asked for "default **allow**; require approval only for what is actually dangerous". #1483 added thirty read-only command names to an eleven-name allowlist. The maintainer's question undid it: **if the default were allow, what would the list be for?**

Nothing. The two are alternatives, not layers. Enumerating what may run is a list somebody has to extend for every tool anyone installs, and the way you learn it needs extending is that an unattended job dies at two in the morning.

Two pieces of evidence, both checked on the maintainer's machine:

- **Neither reference tool uses a command allowlist.** `~/.claude/settings.json` has `allow`, `ask` and `deny` — all three empty, no `defaultMode`; so does the one project-level settings file here. `~/.codex/config.toml` has no command list at all, only `approvals_reviewer = "auto_review"`. Both constrain by boundary and by a reviewer. A name is not a capability.
- **The list was not buying what it looked like.** It excluded `awk` and `sed` with a careful paragraph — they take a *program* — while allowing `make`, `cargo` and `npm`, whose Makefile, `build.rs` and `postinstall` are arbitrary execution. The argument was right and pointed at the wrong list — and this branch now applies it to those three as well, so the policy no longer refuses `awk` while running `make install`.

## What changed

An ordinary command runs. Three rules the old list had been enforcing **by omission** are now written down, each found by the flip allowing something it should not have:

| found | rule | examples |
|---|---|---|
| `bash << 'EOF' rm -rf / EOF` was allowed | a command whose argument is a program asks | `bash`, `sh`, `python3 -c`, `node`, `ruby`, `perl`, `awk`, `sed`, and `uv run python -c` (which is `python -c` wearing a coat) |
| `co email send --to … hi` was allowed | a command that sends something to somebody asks | `send`, `reply`, `post`, `publish`, `deploy`, `push`, `transfer`, `pay`, matched in the first few words where a subcommand lives |
| `tee out.txt`, `find . -delete` were allowed | writing or deleting through arguments gets the workspace check | `tee`, `cp`, `mv`, `ln`, `chmod`, `dd`; `find` with `-delete` / `-exec` asks |
| `make install` fell through main's new narrowing | an unnarrowed build tool runs a file of commands | `make`, `cargo`, `go`, `npm`, `pnpm`, `yarn`, `bun`, `gradle`, `mvn` ask unless they are one of the verification runs allowed above |

The second is the one worth naming: local damage and outward visibility are different axes. The old list had conflated them by accident — `co email send` was refused for being *unrecognised*, not for being an email. Now it is refused for being an email, which is a reason that survives someone adding `co email` to an allowlist.

**Everything denied before is still denied.** `rm -rf`, credentials and key material, writes outside the workspace, authorization control files, external network, publication, reads outside the workspace, unparseable commands. A chain is still only as permitted as its worst link.

## #1447, the TodoList denials

`WORKFLOW_TOOLS` contained `todo_list`, which is never a tool name: `TodoList` registers `add`, `start`, `complete`, `update`, `list`, `remove` and `clear`. 438 `add` + 31 `start` + 5 `complete` denials in six days, until the prompt was changed to forbid todos.

Listing the method names is not the fix — `remove` is in `DELETE_TOOLS` and would be denied, `list` is in `READ_TOOLS`. So the call is matched on **what owns it**: `WORKFLOW_TOOL_CLASSES = {"TodoList"}`, resolved through `agent.tools`. A tool genuinely named `remove` keeps its deletion verdict, which is tested.

## The canary fired, in the other direction

#1483's job test pinned exactly which steps needed an operator grant, with a docstring promising it would fail loudly if a policy change made a pipe filter need a grant again. It failed loudly the other way: `mkdir -p greeter/src` and running the binary the job had just built now need nothing.

Needing a standing `Bash(co *)` to run `mkdir` was the shape of the problem, not a boundary anyone would defend. `test_the_two_grants_are_the_only_two_the_job_needs` is now `test_the_job_needs_no_grant_at_all`, which is a better thing to pin. Grants still bind for commands the rules hold back, covered in `test_auto_approve_policy.py`.

## #1488, the pipe

An operator writes `Bash(co browser *)` and the command runs. Pipe it into `head -40` and it is refused: `check_bash_chain_permitted` treated "no pattern matched this segment" as "this segment is not permitted", so the grant was defeated by the filter it was piped through. `head` is permitted alone and refused one character later, as `| head`.

The chain checker now asks the single-command classifier about a segment nobody granted. If it would have run on its own it needs no grant here either; the segment the policy holds back still does, answered by the same classifier, so `&& co email send` is no more permitted inside a chain than outside one.

The lenient reading is **opt-in**, and only the approval paths ask for it. The plain question this function answers — does a pattern cover every segment — is also what decides whether one pattern is broader than another, and conflating the two made `git status` look granted by a pattern that never mentions it. With the flag on, "permitted" also requires that *some* segment was actually granted, so a chain nobody wrote a grant for is never reported as an operator decision.

## Measured on the job that was failing

The calls a LinkedIn round makes, with **no grants at all**, headless:

| | refused |
|---|---|
| published 1.8.5a1 | 12 of 17 |
| this branch | 4 of 13 |

Three of the four are `python3 -c`, `co email send` and `rm -rf build`. The fourth is a `cd` into a project, which is allowed when the agent starts where a launchd job starts it (the home directory is then the workspace) and asks when it starts inside a narrower sub-project — checked both ways, and `cd /etc && cat passwd` still asks in both.

## Evidence

```
tests/unit              8333 passed, 13 skipped   (23s)
tests/e2e                597 passed,  7 skipped   (49s)
```

`tests/unit/test_policy_default_allow.py` (43 cases) and `tests/unit/test_chain_consults_the_classifier.py` (14 cases), all written failing first. It has a class per claim: an ordinary command runs; **every previously-drawn line is re-asserted**; the read-only list is gone; a known gap is recorded; and every TodoList method is allowed while a non-TodoList `remove` is still denied.

Tests in `test_auto_approve_policy.py` that pinned the allowlist design are updated with a comment each saying what moved and why — labels mostly (`read` → `command` where nothing consults a name list), plus `tee out.txt`, which changes list on purpose.

**One known gap, recorded rather than guessed at:** `gh pr create` is allowed. `create` is too generic for the outward list — `co create my-agent` is local work — and a pull request is a reversible proposal in the operator's own repository. There is a test asserting this, so it is a decision and not an oversight.

`test_co_command_works` and `test_native_egress_preflight_real_driver` fail on this machine for reasons unrelated to this branch (the first fails identically on a clean `origin/main`; the second needs real network).

## Checklist
- [x] I proposed a target version and release window above
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published — yes: #1483 is on main
- [ ] Maintenance-branch forward-port tracker — N/A, mainline work
- [x] Evidence the linked issues ask for: test counts, the rule table, the re-asserted denials, and the gap that is not covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3VJDT8R3Sr69BzfEBxT6
