### PR TITLE
Release 1.8.5a1: an explicit grant is an approval already given (#1481)

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -92,7 +92,7 @@ an unchecked read; and an adversarial sweep refused twenty-five of
 twenty-six bypasses, the twenty-sixth being `make install`, which 1.8.4 had
 allowed as focused verification and which is now narrowed.
 
-Offline suite: 8,802 passed, 21 skipped, on Python 3.10–3.13. Verified through
+Offline suite: 8,805 passed, 21 skipped, on Python 3.10–3.13. Verified through
 the real `co ai` unattended, not only the harness: the failing production
 command works, a `.pem` read is refused by policy, and `awk` with `system()`
 is refused. The Feishu/Lark mailbox planned for this line is not in this

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -58,7 +58,48 @@ See [1.8.4 notes](docs/releases/1.8.4.md) for migration and acceptance limits.
 The planned 1.8.4b1 was not published separately; its reviewed changes are included
 in 1.8.4. Publication is performed and verified by the immutable-tag workflow.
 
-## Release candidate: 1.8.4a2 (preview, published)
+## Release candidate: 1.8.5a1 (preview, published)
+
+An unattended agent could not run `head`. In Auto only eleven test/build
+commands auto-approved, so a scheduled run died on
+`co browser … get_text | head -40` — the granted browser command, refused
+because of the filter on its output (#1481). Read-only commands now run;
+`sed` and `awk` deliberately do not, because they take a program and a
+program is code. A shell redirect is held to the write tool's rule, and key
+material is refused by path, name and suffix wherever it sits, by shell
+command and by tool alike.
+
+The other half of the same complaint is fixed here too: a grant somebody wrote
+down was being ignored. `Bash(curl *)` in an operator's own `host.yaml` was
+refused unattended and asked every time with a person present, and a skill's
+declared `tools:` bought nothing at all — eight of nine hand-written grants
+were ignored on 1.8.4. An explicit grant now runs the call for any effect
+class, while a wildcard is honoured only for the effect its own text names,
+and the 78 grants that ship in the template are marked as such so they keep
+their old narrow reading.
+
+This is a preview because it widens a security default, and a widened default
+earns a round of real use before everyone gets it on upgrade. Exercising it
+found seven further defects, six of them by running the thing rather than
+reading it: a `quiet=True` agent — every unattended run — crashed on every
+auto-approved call; the policy decision never reached the run trace;
+`read_file` allowed what `cat` refused; `cat << EOF > file` was unparseable
+and therefore refused; `awk 'BEGIN{system(...)}'` was allowed, which the pull
+request had itself named as its least-confident point; `cat $(cat which_file.txt)` was
+an unchecked read; and an adversarial sweep refused twenty-five of
+twenty-six bypasses, the twenty-sixth being `make install`, which 1.8.4 had
+allowed as focused verification and which is now narrowed.
+
+Offline suite: 8,763 passed, 21 skipped, on Python 3.10–3.13. Verified through
+the real `co ai` unattended, not only the harness: the failing production
+command works, a `.pem` read is refused by policy, and `awk` with `system()`
+is refused. The Feishu/Lark mailbox planned for this line is not in this
+preview; its no-loss reconnect gate is open (#1462).
+
+Stable remains 1.8.4. This is not Latest and needs `--pre` or an exact pin.
+See [1.8.5a1 notes](docs/releases/1.8.5a1.md).
+
+## Superseded candidate: 1.8.4a2 (preview, published)
 
 This preview fixes Gmail send-receipt recovery when Google rewrites Message-ID.
 Reviewed MIME carries a provider-preserved attempt marker; recovery requires a
@@ -73,9 +114,32 @@ Stable remains 1.8.3; this does not authorize final 1.8.4 or cloud provisioning.
 See [1.8.4a2 notes](docs/releases/1.8.4a2.md) and the
 [local acceptance record](docs/acceptance/1.8.4-live-followup/README.md).
 
-## Current Version: 1.8.4
+## Current Version: 1.8.5a1
 
 ### Version History
+- 1.8.5a1 (**opt-in preview: an unattended agent can read its own output.** In
+  Auto only eleven test/build commands auto-approved, so everything else asked
+  — and with nobody to ask, asking is refusing. A scheduled run died on
+  `co browser … get_text | head -40`: the granted browser command, refused for
+  the filter on its output, 28 iterations into 300, no comments posted, no
+  report written (#1481). Read-only commands now run, alone or as segments
+  beside a granted command, while every other segment still needs its own
+  grant. `sed` and `awk` are deliberately not on that list: they take a
+  program, and `awk 'BEGIN{system(...)}'` reads like an inspection. A shell
+  redirect is held to the write tool's rule — inside the workspace it is a
+  reversible edit, a control file or an outside path is denied — and a heredoc
+  is classified by its first line, so `cat << EOF > src/main.rs` works and
+  `bash << EOF` still asks. Key material is refused by path component,
+  filename and suffix wherever it sits, by shell and by tool, because the
+  workspace boundary does not protect a committed key or the agent's own
+  `.co/keys/`. An explicit grant — `host.yaml`, a skill's `tools:`, a human's
+  session approval — now runs the call for any effect class instead of being
+  discarded, and `co`'s strong verbs classify by verb so a wildcard over `co`
+  cannot reach them. Three defects in 1.8.4 came out of exercising it: a `quiet=True`
+  agent crashed on every auto-approved call, the policy decision never reached
+  the run trace, and `read_file` allowed what `cat` refused. Carries the second
+  wave of test-suite work (#1474) and the Control Center layout fix (#1482).
+  Stable stays 1.8.4; this is not Latest and needs `--pre` or an exact pin.)
 - 1.8.4 (**stable — explicit configuration and reviewed operations:** `co env`
   safely inspects and edits settings; Gmail preserves reviewed content and recovers
   uncertain sends; Synology verifies sharing settings and supports durable file

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -76,7 +76,9 @@ declared `tools:` bought nothing at all — eight of nine hand-written grants
 were ignored on 1.8.4. An explicit grant now runs the call for any effect
 class, while a wildcard is honoured only for the effect its own text names,
 and the 78 grants that ship in the template are marked as such so they keep
-their old narrow reading.
+their old narrow reading. A refusal also names the line to write now, in both
+places that work, because a refusal nobody can act on gets worked around
+rather than fixed.
 
 This is a preview because it widens a security default, and a widened default
 earns a round of real use before everyone gets it on upgrade. Exercising it
@@ -90,7 +92,7 @@ an unchecked read; and an adversarial sweep refused twenty-five of
 twenty-six bypasses, the twenty-sixth being `make install`, which 1.8.4 had
 allowed as focused verification and which is now narrowed.
 
-Offline suite: 8,763 passed, 21 skipped, on Python 3.10–3.13. Verified through
+Offline suite: 8,802 passed, 21 skipped, on Python 3.10–3.13. Verified through
 the real `co ai` unattended, not only the harness: the failing production
 command works, a `.pem` read is refused by policy, and `awk` with `system()`
 is refused. The Feishu/Lark mailbox planned for this line is not in this
@@ -135,7 +137,9 @@ See [1.8.4a2 notes](docs/releases/1.8.4a2.md) and the
   `.co/keys/`. An explicit grant — `host.yaml`, a skill's `tools:`, a human's
   session approval — now runs the call for any effect class instead of being
   discarded, and `co`'s strong verbs classify by verb so a wildcard over `co`
-  cannot reach them. Three defects in 1.8.4 came out of exercising it: a `quiet=True`
+  cannot reach them. A refusal carries the exact grant that would allow the
+  call, in `.co/host.yaml` or a skill's `tools:`, so an agent that gets
+  refused says what to add instead of going quiet. Three defects in 1.8.4 came out of exercising it: a `quiet=True`
   agent crashed on every auto-approved call, the policy decision never reached
   the run trace, and `read_file` allowed what `cat` refused. Carries the second
   wave of test-suite work (#1474) and the Control Center layout fix (#1482).

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.8.4"
+__version__ = "1.8.5a1"

--- a/connectonion/console.py
+++ b/connectonion/console.py
@@ -445,7 +445,9 @@ class Console:
             tool_display = self._format_tool_display(tool_name, tool_args, max_width=35)
 
         # Format source with color and location
-        if source == 'config':
+        if source == 'template':
+            source_display = f"[{DIM_COLOR}]shipped default[/{DIM_COLOR}]"
+        elif source == 'config':
             source_display = f"[{BRAND_COLOR}]config[/{BRAND_COLOR}]"
         elif source == 'user':
             source_display = f"[{SUCCESS_COLOR}]user[/{SUCCESS_COLOR}] [{DIM_COLOR}](session)[/{DIM_COLOR}]"

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -749,7 +749,20 @@ def load_permission_patterns(co_dir=None) -> dict:
             template_config = yaml.safe_load(f) or {}
         template_permissions = template_config.get('permissions')
         if template_permissions and isinstance(template_permissions, dict):
-            permissions.update(_convert_permission_patterns(template_permissions))
+            # Stamp the shipped defaults as `template`, whatever the file says.
+            # They declare `source: config`, which made them indistinguishable
+            # from a grant the operator wrote by hand — so the policy could not
+            # honour "I explicitly allowed this" without also honouring 78
+            # entries that shipped with the product. That is why the broad
+            # `Bash(co *)` needed a hardcoded narrowing. Now the question "who
+            # said this" has an answer.
+            for pattern, perm in _convert_permission_patterns(template_permissions).items():
+                # Only the shipped `config` entries are restamped. The `safe`
+                # ones name built-in read-only tools, which is a different
+                # statement and is already handled by effect class.
+                if perm.get('source') == 'config':
+                    perm = {**perm, 'source': 'template'}
+                permissions[pattern] = perm
 
     co_dir = Path(co_dir) if co_dir else project_co_dir()
     host_yaml = co_dir / 'host.yaml'

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -465,10 +465,19 @@ def check_approval(agent: 'Agent') -> None:
         if policy:
             verdict = policy.get('decision')
             if verdict == 'deny':
-                raise ValueError(
+                message = (
                     f"Tool '{tool_name}' denied by {policy.get('policy_id')}: "
                     f"{policy.get('reason', 'policy denied the call')}"
                 )
+                # A refusal that does not say how to fix it gets worked around
+                # rather than fixed: the daily digest simply stopped sending
+                # and nobody learned why for days. The model reads this string
+                # as the tool result, so it can tell the operator the line to
+                # add, and the operator reads it in the log.
+                remedy = policy.get('remedy')
+                if remedy:
+                    message = f"{message}\n\n{remedy}"
+                raise ValueError(message)
             if verdict == 'allow':
                 if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
                     _log_permission_granted(agent, 

--- a/connectonion/useful_plugins/tool_approval/bash_parser.py
+++ b/connectonion/useful_plugins/tool_approval/bash_parser.py
@@ -182,6 +182,26 @@ def check_bash_chain_permitted(command: str, permissions: dict) -> tuple[bool, s
     from .approval import matches_permission_pattern
 
     subcommands = _extract_subcommands(command)
+    return _subcommands_permitted(subcommands, permissions)
+
+
+def segment_permitted(cmd_name: str, full_cmd: str, permissions: dict) -> tuple[bool, str, str]:
+    """Whether one already-extracted segment matches a standing grant.
+
+    Callers that have split a chain themselves must not re-parse a segment's
+    text: `_extract_subcommands` returns it with quotes removed, so feeding
+    `awk BEGIN{system("x")}` back to a parser raises — and a caller that
+    swallowed the error would read "no grant" from what is really "I cannot
+    tell", which is a refusal nobody wrote down. Match the text instead.
+    """
+    return _subcommands_permitted([(cmd_name, full_cmd)], permissions)
+
+
+def _subcommands_permitted(subcommands, permissions: dict) -> tuple[bool, str, str]:
+    import fnmatch
+
+    from .approval import matches_permission_pattern
+
     unpermitted = []
     matched_source = 'config'  # Default source
 

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -523,7 +523,9 @@ def workspace_policy_for_pending(agent: "Agent", pending: dict) -> dict | None:
             f"{result['reason']}; no approval channel is available",
             result["scope"],
         )
-        result["remedy"] = grant_remedy(pending.get("name"), pending.get("arguments") or {})
+        result["remedy"] = grant_remedy(
+            pending.get("name"), pending.get("arguments") or {}, result["effect_class"]
+        )
     pending["approval_policy"] = result
     record_approval_policy(agent, pending)
     return result
@@ -545,21 +547,34 @@ _TEMPLATE_SOURCES = frozenset({"template", "safe"})
 _VALUE_LOOKING = ("-", "/", "~", ".")
 
 
-def suggested_grant_pattern(tool_name: str, args: dict) -> str:
+# Effects where a suggestion the operator pastes without reading should buy as
+# little as possible. `rm -rf build` gets `Bash(rm -rf build)`, not
+# `Bash(rm *)`: the wildcard would also cover `rm -rf /`, and a nudge in a
+# refusal message is a nudge toward exactly what it says.
+_SUGGEST_EXACTLY = {"deletion", "credentials", "payment", "authorization_control"}
+
+
+def suggested_grant_pattern(tool_name: str, args: dict, effect_class: str | None = None) -> str:
     """The permission pattern that would allow this exact call.
 
     A refusal that only says "no grant allows this" leaves the operator to
     work out the syntax, the file and the right breadth from a policy name.
-    This names the line to write. It is a suggestion, so it errs narrow: the
-    leading verb words, stopping at the first argument-looking one, capped at
-    three — `co email send --to a@b.c` becomes `Bash(co email send *)`, not
-    `Bash(co *)`.
+    This names the line to write, erring narrow: the leading verb words,
+    stopping at the first argument-looking one, capped at three — so
+    `co email send --to a@b.c` becomes `Bash(co email send *)`, not
+    `Bash(co *)`. For a deletion, a credential or a payment it errs narrower
+    still and names the command exactly.
     """
     if str(tool_name).lower() not in {"bash", "shell", "run", "run_in_dir", "run_background"}:
         return str(tool_name)
-    words = _command_words(str((args or {}).get("command", "")))
+    command = str((args or {}).get("command", "")).strip()
+    words = _command_words(command)
     while len(words) > 1 and "=" in words[0] and not words[0].startswith("-"):
         words = words[1:]          # VAR=value cmd ...
+    if not words:
+        return str(tool_name)
+    if effect_class in _SUGGEST_EXACTLY:
+        return f"Bash({' '.join(words)})"
     verb = []
     for word in words[:3]:
         if verb and (word.startswith(_VALUE_LOOKING) or any(c in word for c in "@=:")):
@@ -568,9 +583,9 @@ def suggested_grant_pattern(tool_name: str, args: dict) -> str:
     return f"Bash({' '.join(verb)} *)" if verb else str(tool_name)
 
 
-def grant_remedy(tool_name: str, args: dict) -> str:
+def grant_remedy(tool_name: str, args: dict, effect_class: str | None = None) -> str:
     """How to allow this call next time, in the two places that work."""
-    pattern = suggested_grant_pattern(tool_name, args)
+    pattern = suggested_grant_pattern(tool_name, args, effect_class)
     if pattern.startswith("Bash("):
         yaml_key = f'"{pattern}"'
     else:

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -523,6 +523,7 @@ def workspace_policy_for_pending(agent: "Agent", pending: dict) -> dict | None:
             f"{result['reason']}; no approval channel is available",
             result["scope"],
         )
+        result["remedy"] = grant_remedy(pending.get("name"), pending.get("arguments") or {})
     pending["approval_policy"] = result
     record_approval_policy(agent, pending)
     return result
@@ -539,6 +540,57 @@ def workspace_policy_for_pending(agent: "Agent", pending: dict) -> dict | None:
 # always did: an ordinary command, never a stronger effect.
 _EXPLICIT_SOURCES = frozenset({"config", "skill", "user"})
 _TEMPLATE_SOURCES = frozenset({"template", "safe"})
+
+
+_VALUE_LOOKING = ("-", "/", "~", ".")
+
+
+def suggested_grant_pattern(tool_name: str, args: dict) -> str:
+    """The permission pattern that would allow this exact call.
+
+    A refusal that only says "no grant allows this" leaves the operator to
+    work out the syntax, the file and the right breadth from a policy name.
+    This names the line to write. It is a suggestion, so it errs narrow: the
+    leading verb words, stopping at the first argument-looking one, capped at
+    three — `co email send --to a@b.c` becomes `Bash(co email send *)`, not
+    `Bash(co *)`.
+    """
+    if str(tool_name).lower() not in {"bash", "shell", "run", "run_in_dir", "run_background"}:
+        return str(tool_name)
+    words = _command_words(str((args or {}).get("command", "")))
+    while len(words) > 1 and "=" in words[0] and not words[0].startswith("-"):
+        words = words[1:]          # VAR=value cmd ...
+    verb = []
+    for word in words[:3]:
+        if verb and (word.startswith(_VALUE_LOOKING) or any(c in word for c in "@=:")):
+            break
+        verb.append(word)
+    return f"Bash({' '.join(verb)} *)" if verb else str(tool_name)
+
+
+def grant_remedy(tool_name: str, args: dict) -> str:
+    """How to allow this call next time, in the two places that work."""
+    pattern = suggested_grant_pattern(tool_name, args)
+    if pattern.startswith("Bash("):
+        yaml_key = f'"{pattern}"'
+    else:
+        yaml_key = f'"{pattern}"'
+    return (
+        f"Nothing has granted this. To allow it — including unattended — write it down once:\n"
+        f"  • in .co/host.yaml:\n"
+        f"      permissions:\n"
+        f"        {yaml_key}:\n"
+        f"          allowed: true\n"
+        f"          source: config\n"
+        f"          reason: why you want this\n"
+        f"          expires:\n"
+        f"            type: never\n"
+        f"  • or in the skill that needs it, in its SKILL.md frontmatter:\n"
+        f"      tools:\n"
+        f"        - \"{pattern}\"\n"
+        f"A grant written in either place runs the call without asking again. "
+        f"Narrow the pattern if it is broader than you meant."
+    )
 
 
 def _explicitly_granted(

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -15,7 +15,8 @@ from typing import TYPE_CHECKING
 from ...core.events import before_each_tool
 from ...core.mode import AUTO, FULL_ACCESS, READ_ONLY, mode_id, mode_of, set_mode
 from ...project import project_root
-from .bash_parser import _extract_subcommands, check_bash_chain_permitted
+from .approval import matches_permission_pattern
+from .bash_parser import _extract_subcommands, check_bash_chain_permitted, segment_permitted
 
 if TYPE_CHECKING:
     from ...core.agent import Agent
@@ -58,6 +59,19 @@ _DESTRUCTIVE_COMMANDS = {"rm", "rmdir", "shred", "truncate", "del", "erase", "fo
 _EXTERNAL_COMMANDS = {"curl", "wget", "ssh", "scp", "rsync", "mail", "sendmail"}
 _SENSITIVE_COMMANDS = {
     "env", "printenv", "security", "keychain", "gcloud", "aws", "az",
+}
+# Our own CLI is a multiplexer: `co status` and `co email send` are the same
+# binary and nothing like the same power. Classifying the second by its verb
+# is what stops a wildcard over `co` from reaching it — and it is the reason
+# `Bash(co *)` needed a hardcoded exception before. The keys are the first two
+# words; a one-word key covers every subcommand of it.
+_CO_SUBCOMMAND_EFFECTS = {
+    "email": ("external_effect", "ask", "sending mail requires human approval"),
+    "transfer": ("payment", "ask", "moving credit requires human approval"),
+    "server": ("external_effect", "ask", "creating or destroying a server requires human approval"),
+    "keys": ("credentials", "deny", "credential access is never auto-approved"),
+    "auth": ("credentials", "ask", "changing an account login requires human approval"),
+    "reset": ("deletion", "ask", "resetting a project requires human approval"),
 }
 # Commands that read, filter or print and do nothing else. They run unattended
 # in Auto, on workspace paths, with no output redirect. Before this list only
@@ -285,6 +299,11 @@ def _classify_single_command(command: str, root: Path | None = None) -> dict:
         return decision("publication", "ask", "publishing and deployment require human approval", "call", requires_human=True)
     if first in _EXTERNAL_COMMANDS:
         return decision("external_network", "ask", "external network access requires human approval", "call", requires_human=True)
+    if first == "co" and len(words) > 1:
+        effect = _CO_SUBCOMMAND_EFFECTS.get(words[1].lower())
+        if effect:
+            effect_class, verdict, reason = effect
+            return decision(effect_class, verdict, reason, "call", requires_human=(verdict == "ask"))
     if first in _SENSITIVE_COMMANDS or any(
         ".env" in token or "credential" in token or "secret" in token for token in lowered
     ) or any(_is_key_material(word) for word in words[1:] if not word.startswith("-")):
@@ -493,41 +512,71 @@ def workspace_policy_for_pending(agent: "Agent", pending: dict) -> dict | None:
             "call",
             requires_human=bool(agent.io),
         )
+    if result["decision"] in ("ask", "deny"):
+        granted = _explicitly_granted(agent, pending, result)
+        if granted is not None:
+            result = granted
     if not agent.io and result["decision"] == "ask":
-        configured = _headless_configured_command(agent, pending, result)
-        if configured is not None:
-            result = configured
-        else:
-            result = decision(
-                result["effect_class"],
-                "deny",
-                f"{result['reason']}; no approval channel is available",
-                result["scope"],
-            )
+        result = decision(
+            result["effect_class"],
+            "deny",
+            f"{result['reason']}; no approval channel is available",
+            result["scope"],
+        )
     pending["approval_policy"] = result
     record_approval_policy(agent, pending)
     return result
 
 
-def _headless_configured_command(
+# Grants that somebody wrote down on purpose: the operator's own host.yaml,
+# a skill's `tools:` frontmatter (declared by its author, not chosen by the
+# model at runtime), and a human's in-session approval. Each of these is a
+# person saying "yes, this" before the call happened, which is what an
+# approval is — so the policy honours them instead of asking again.
+#
+# `template` is deliberately absent. Those 78 entries ship with the product
+# and nobody chose them for this project, so they still buy only what they
+# always did: an ordinary command, never a stronger effect.
+_EXPLICIT_SOURCES = frozenset({"config", "skill", "user"})
+_TEMPLATE_SOURCES = frozenset({"template", "safe"})
+
+
+def _explicitly_granted(
     agent: "Agent", pending: dict, result: dict
 ) -> dict | None:
-    """Honor an operator's standing command grant without weakening Auto.
+    """An explicit grant is an approval already given. Honour it.
 
-    Only ordinary commands reach this path. Publication, deployment, network,
-    credential, deletion, and unknown effects keep their stronger verdict even
-    when a broad legacy pattern such as ``Bash(co *)`` happens to match.
+    Before this, a grant the operator wrote by hand was discarded for every
+    effect class except an unclassified command: `Bash(curl *)` in your own
+    `host.yaml` was refused unattended and asked *every time* with a person
+    present, and a skill's declared `tools:` bought nothing at all. Measured
+    on 1.8.4: nine hand-written grants, eight ignored.
+
+    What still cannot happen is a *broad* pattern stretching to a stronger
+    power than it names. The shipped `Bash(co *)` must not imply `co deploy`
+    or `co email send`, which is why template grants keep their old, narrow
+    reading and why an explicit wildcard is only honoured for the effect its
+    own text classifies to.
     """
-    if result.get("effect_class") != "command" or pending.get("name") != "bash":
-        return None
+    if pending.get("name") != "bash":
+        return _explicitly_granted_tool(agent, pending, result)
     permissions = agent.current_session.get("permissions")
     if not isinstance(permissions, dict):
         return None
-    configured = {
+    explicit = {
         pattern: permission
         for pattern, permission in permissions.items()
-        if isinstance(permission, dict) and permission.get("source") == "config"
+        if isinstance(permission, dict) and permission.get("source") in _EXPLICIT_SOURCES
     }
+    configured = dict(explicit)
+    if result.get("effect_class") == "command":
+        # An ordinary command is what the shipped defaults have always
+        # covered, so they join in for this class only.
+        configured.update({
+            pattern: permission
+            for pattern, permission in permissions.items()
+            if isinstance(permission, dict) and permission.get("source") in _TEMPLATE_SOURCES
+        })
     # A read-only segment needs no grant: `co browser ... | head -40` is the
     # granted browser command plus a filter on its output. Every other segment
     # must match a standing grant, so `co browser status && co email send ...`
@@ -537,24 +586,30 @@ def _headless_configured_command(
         root = project_root().resolve()
         segments = _extract_subcommands(command)
         needs_grant = [
-            full for _, full in segments
+            (name, full) for name, full in segments
             if _classify_single_command(full, root).get("effect_class") != "read"
         ]
         if _redirect_targets(command):
-            needs_grant = [full for _, full in segments]
-        # The shipped historical Bash(co *) grant is broader than its "safe CLI"
-        # description. Preserve the unattended browser/status compatibility
-        # users relied on without silently authorizing email, account, server,
-        # or payment commands. Operators can still name a narrower command.
-        broad_co = configured.pop("Bash(co *)", None)
-        if broad_co is not None and needs_grant and all(
-            full == "co status" or full.startswith("co browser ")
-            for full in needs_grant
-        ):
-            configured["Bash(co *)"] = broad_co
-        for full in needs_grant:
-            permitted, _, _ = check_bash_chain_permitted(full, configured)
+            needs_grant = list(segments)
+        # The shipped `Bash(co *)` is broader than its "safe CLI" description:
+        # `co` is a multiplexer, so the wildcard covers email, servers and
+        # payments as well as the browser. Keep the compatibility operators
+        # relied on — `co status` and `co browser ...` — and nothing else.
+        # An operator who wants more names it themselves.
+        if configured.get("Bash(co *)", {}).get("source") in _TEMPLATE_SOURCES:
+            if not (needs_grant and all(
+                full == "co status" or full.startswith("co browser ")
+                for _, full in needs_grant
+            )):
+                configured.pop("Bash(co *)", None)
+        for name, full in needs_grant:
+            # `segment_permitted`, not the chain checker: the segment text has
+            # had its quotes removed by the parser, so re-parsing it can raise
+            # on a command that is perfectly valid as written.
+            permitted, _, _ = segment_permitted(name, full, configured)
             if not permitted:
+                return None
+            if not _grant_names_this_effect(full, configured, root):
                 return None
     except Exception:
         return None
@@ -562,6 +617,58 @@ def _headless_configured_command(
         "configured_command",
         "allow",
         "operator-configured command allowlist",
+        "call",
+    )
+
+
+def _grant_names_this_effect(command: str, configured: dict, root: Path) -> bool:
+    """A wildcard may not reach a stronger effect than its own text names.
+
+    `Bash(curl *)` classifies as external network, and so does the command it
+    matches, so the operator plainly meant network access. `Bash(git *)` is an
+    ordinary command while `git push origin main` is a publication, so the
+    wildcard does not carry it — `Bash(git push *)` does. An exact pattern
+    always names its own effect and always passes.
+    """
+    wanted = _classify_single_command(command, root).get("effect_class")
+    for pattern, permission in configured.items():
+        if not (pattern.startswith("Bash(") and pattern.endswith(")")):
+            continue
+        if not matches_permission_pattern("bash", {"command": command}, pattern):
+            continue
+        text = pattern[5:-1]
+        if "*" not in text:
+            return True          # named exactly, nothing to stretch
+        literal = text.split("*", 1)[0].strip()
+        if not literal:
+            return True          # `Bash(*)` — the operator asked for everything
+        if _classify_single_command(literal, root).get("effect_class") == wanted:
+            return True
+    return False
+
+
+def _explicitly_granted_tool(
+    agent: "Agent", pending: dict, result: dict
+) -> dict | None:
+    """The same rule for a non-bash tool, whose pattern is its name.
+
+    `send_email` in an operator's host.yaml, or in a skill's `tools:`, is the
+    operator saying this agent may send mail. It was being discarded along
+    with everything else.
+    """
+    permissions = agent.current_session.get("permissions")
+    if not isinstance(permissions, dict):
+        return None
+    name = str(pending.get("name", ""))
+    permission = permissions.get(name)
+    if not isinstance(permission, dict) or not permission.get("allowed"):
+        return None
+    if permission.get("source") not in _EXPLICIT_SOURCES:
+        return None
+    return decision(
+        "configured_tool",
+        "allow",
+        f"explicitly granted ({permission.get('source')})",
         "call",
     )
 

--- a/docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md
+++ b/docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md
@@ -224,16 +224,76 @@ happens to contain "secret". Luck, twice, in a security path. A file argument
 containing `$(`, a backtick or `$name` now asks; a bare `$` still means
 end-of-line, so `grep 'foo$' notes.txt` is untouched.
 
+## The other half of the complaint
+
+Then the owner asked the question I should have asked myself at the start.
+
+*If the user's command explicitly allows it, or a skill allows it, shouldn't it
+just run? Isn't auto-approval the same as the user having said yes?*
+
+I went to check rather than answer. Nine grants, written by hand into a
+project's own `.co/host.yaml` — `Bash(curl *)`, `Bash(rm -rf build)`,
+`Bash(git push *)`, `Bash(co deploy)`, `Bash(cat .env)`, `send_email`, and
+three more. Unattended, eight of the nine were refused. With a person present,
+they did not auto-approve either: they opened the dialog, every time, for a
+thing the operator had already written down. And a skill that declares
+`Bash(mkdir *)` in its frontmatter got nothing at all — the identical grant ran
+as `source: config` and was refused as `source: skill`.
+
+The reason was a comment I had read a dozen times without seeing it. When the
+policy says "ask a human", the approval code throws away every grant that did
+not come from a human in this session, because a broad `Bash(co *)` must not
+silently imply `co deploy`. The concern is real. The correction was aimed at
+the source of the grant, when the thing that actually differs is its breadth.
+
+There was a second reason, and it is the more interesting one: the code could
+not tell an operator's grant from a shipped default, because all 78 entries in
+the shipped template declare `source: config` too. That is why `Bash(co *)`
+needed a hardcoded exception listing `co status` and `co browser`. Nobody could
+write the general rule, because the information the general rule needs was not
+recorded.
+
+So the template's entries are now stamped `template` at load time, and the
+question "who said this" has an answer. An explicit grant — operator file,
+skill frontmatter, human dialog — runs the call, any effect class, attended or
+not. A wildcard is honoured only for the effect its own text classifies to, so
+`Bash(git *)` does not carry `git push` and `Bash(git push *)` does. And the
+hardcoded `co` exception is gone, replaced by classifying `co`'s strong verbs
+as what they are: `co email send` is an external effect, `co transfer` a
+payment, `co keys` a credential. A wildcard over a multiplexer cannot reach
+them however it is written.
+
+One more bug fell out of building that, and it is worth naming because of how
+it looked. My first version checked each pipe segment by handing its text back
+to the chain checker, which re-parses. Segment text arrives with its quotes
+already removed, so `awk BEGIN{system("x")}` does not re-parse, bashlex raised,
+and my `except Exception: return None` turned that into "no grant" — a refusal.
+I noticed because a granted `awk '{print $1}'` was allowed while a granted
+`awk 'BEGIN{system(...)}'` was denied, and I could not explain the difference.
+The denial was the safe answer, which is exactly why it was dangerous: a
+swallowed parse error refuses whatever it cannot read, including grants the
+operator did write, and it looks like security working.
+
 ## The tally
 
-Six defects, one of them the reported bug and five found while fixing it,
-plus two pre-existing holes in code the fix sat next to. Of the eight, one
-was found by a test. The other seven were found by running the thing: an
-agent doing a real job, the real CLI in a throwaway directory, and a list of
-what an attacker would try with the verdicts printed beside it.
+Ten defects. One was the reported bug. Five came out of fixing it, two were
+pre-existing holes in the code it sat next to, one was the ignored-grant
+behaviour the owner asked about, and one I introduced and caught because its
+output had a difference I could not explain.
+
+Of the ten, one was found by a test. The other nine were found by running the
+thing: an agent doing a real job, the real CLI in a throwaway directory, a
+list of what an attacker would try with the verdicts printed beside it, and
+nine grants written into a host.yaml by hand to see which ones the product
+actually honoured.
 
 The suite is not what found them, and it was never going to be — it had sixty
 green tests on this exact policy while production was failing. What the suite
-does is hold them. Every one of the eight now has a test that was red before
-the fix, so the next person to widen this policy gets told which specific
-thing they broke, by name, in about forty seconds.
+does is hold them. Every one of the ten now has a test that was red before the
+fix, so the next person to change this policy gets told which specific thing
+they broke, by name, in about forty seconds.
+
+The question that found the last three was not a clever one. It was *does this
+actually do what we say it does* — asked about the thing in front of me, out
+loud, and then answered by running it instead of by reading the code that was
+supposed to make it true.

--- a/docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md
+++ b/docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md
@@ -274,24 +274,60 @@ The denial was the safe answer, which is exactly why it was dangerous: a
 swallowed parse error refuses whatever it cannot read, including grants the
 operator did write, and it looks like security working.
 
+## A refusal you cannot act on
+
+The owner had one more, and it is the one I would have shipped without.
+
+*If it gets refused, there should be something telling the user or the agent
+what to do. And for an unattended pipeline, do I write the permission into the
+skill?*
+
+The answer to the second is yes, and it works — a skill declaring
+`tools: ["Bash(rm -rf scratch)"]` in its frontmatter had that command executed
+by a real unattended run, destructive class and all, scoped to the turn. But
+nothing in the product said so. The refusal said:
+
+```
+command is outside the focused verification and read-only allowlists;
+no approval channel is available
+```
+
+That names a policy. It does not name a file, a syntax, a breadth, or the fact
+that a skill's frontmatter is a place you can put it. An operator reading it
+in a log at 7am has to go and read the source, and what they will actually do
+is widen something until the pipeline runs — or, as happened on the 1.7.0
+upgrade, not notice for days that the daily digest stopped sending.
+
+So a refusal now carries the line to write, in both places that work, with the
+pattern erring narrow — `Bash(co email send *)`, not `Bash(co *)`. The string
+goes back to the model as the tool result, which means the agent relays it. I
+asked a real unattended agent to send an email with no grant in place, and it
+came back with the YAML block and where to put it, unprompted.
+
+That is the smallest of the changes here and probably the one that will save
+the most time, because it is the only one that turns a silent stop into an
+instruction.
+
 ## The tally
 
-Ten defects. One was the reported bug. Five came out of fixing it, two were
+Eleven changes. One was the reported bug. Five came out of fixing it, two were
 pre-existing holes in the code it sat next to, one was the ignored-grant
-behaviour the owner asked about, and one I introduced and caught because its
-output had a difference I could not explain.
+behaviour the owner asked about, one I introduced and caught because its
+output had a difference I could not explain, and the last was a refusal that
+told nobody how to fix it.
 
-Of the ten, one was found by a test. The other nine were found by running the
+Of the eleven, one was found by a test. The rest were found by running the
 thing: an agent doing a real job, the real CLI in a throwaway directory, a
-list of what an attacker would try with the verdicts printed beside it, and
-nine grants written into a host.yaml by hand to see which ones the product
-actually honoured.
+list of what an attacker would try with the verdicts printed beside it, nine
+grants written into a host.yaml by hand to see which ones the product actually
+honoured, and a skill with one line of frontmatter to see whether the answer
+we would have given was true.
 
 The suite is not what found them, and it was never going to be — it had sixty
 green tests on this exact policy while production was failing. What the suite
-does is hold them. Every one of the ten now has a test that was red before the
-fix, so the next person to change this policy gets told which specific thing
-they broke, by name, in about forty seconds.
+does is hold them. Every one of the eleven now has a test that was red before
+the fix, so the next person to change this policy gets told which specific
+thing they broke, by name, in about forty seconds.
 
 The question that found the last three was not a clever one. It was *does this
 actually do what we say it does* — asked about the thing in front of me, out

--- a/docs/features/permissions.md
+++ b/docs/features/permissions.md
@@ -13,6 +13,10 @@ the human approval hook:
   on workspace paths are allowed, alone or as pipe segments beside a granted
   command; nothing that takes a program text is read-only, so `sed` and `awk`
   still ask (#1481);
+- an explicit grant — the operator's `host.yaml`, a skill's `tools:`, or a
+  human's session approval — runs the call for any effect class, and stops
+  asking every time; a wildcard is honoured only for the effect its own text
+  names, and the shipped template defaults are not an operator's grant (#1481);
 - deletions and credential access are denied, including reads of key material
   by path or name (`.ssh/`, `.co/keys/`, `id_rsa`, `*.pem`, ...) wherever it sits;
 - deployment, publishing, external communication, payments, outside-workspace

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -20,11 +20,25 @@ co --version
 co env
 ```
 
-No newer preview is currently recommended. The published 1.8.4a1 and 1.8.4a2
-previews are historical; the planned b1 was folded into the stable release.
-The tag workflow builds and verifies the public package before documentation
-is deployed. Google authorization from 1.8.3 is retained. TikTok and new messaging
-adapters remain deferred. The sections below are historical notes.
+## Current preview
+
+Preview **1.8.5a1** fixes a refusal that stopped unattended agents: in Auto
+only eleven test/build commands auto-approved, so a scheduled run died on
+`co browser … get_text | head -40`. Read-only commands now run; `sed` and
+`awk` deliberately still ask, because they take a program. It is a preview
+because it widens a security default. See
+[1.8.5a1 release notes](releases/1.8.5a1.md).
+
+```bash
+python -m pip install --pre connectonion==1.8.5a1
+co --version
+```
+
+The published 1.8.4a1 and 1.8.4a2 previews are historical; the planned 1.8.4b1
+was folded into the stable release. The tag workflow builds and verifies the
+public package before documentation is deployed. Google authorization from
+1.8.3 is retained. The Feishu/Lark mailbox lands when its no-loss reconnect
+gate passes; TikTok remains deferred. The sections below are historical notes.
 
 ## Historical 1.7 preview work
 

--- a/docs/releases/1.8.5a1.md
+++ b/docs/releases/1.8.5a1.md
@@ -60,7 +60,9 @@ before it is the default everyone gets on upgrade. Exercise it and report;
   policy and stop: "command is outside the focused verification allowlist". It
   now carries the exact grant that would allow the call, in both places that
   work — `.co/host.yaml` and a skill's `tools:` frontmatter — and the suggested
-  pattern errs narrow (`Bash(co email send *)`, not `Bash(co *)`). The model
+  pattern errs narrow (`Bash(co email send *)`, not `Bash(co *)`; for a
+  deletion, credential or payment, the exact command, because `Bash(rm *)`
+  would also cover `rm -rf /`). The model
   reads it as the tool result, so an agent that gets refused tells you what to
   add instead of going quiet. A refusal nobody can act on gets worked around
   rather than fixed; that is how a daily digest stopped sending on the 1.7.0
@@ -133,7 +135,7 @@ before it is the default everyone gets on upgrade. Exercise it and report;
   the unclosed sqlite, socket and file handles the run reports are closed
   (#1474).
 - The offline suite runs in parallel by default: about a minute, from four.
-  8802 tests pass on Python 3.10–3.13.
+  8805 tests pass on Python 3.10–3.13.
 
 ## Verified
 

--- a/docs/releases/1.8.5a1.md
+++ b/docs/releases/1.8.5a1.md
@@ -56,6 +56,21 @@ before it is the default everyone gets on upgrade. Exercise it and report;
   `Bash(git push *)` does. The 78 grants that ship in the template now load as
   `source: template` and buy only what they always did — which is also what
   removes the hardcoded exception that used to narrow the broad `Bash(co *)`.
+- **A refusal names the line to write.** An unattended refusal used to name a
+  policy and stop: "command is outside the focused verification allowlist". It
+  now carries the exact grant that would allow the call, in both places that
+  work — `.co/host.yaml` and a skill's `tools:` frontmatter — and the suggested
+  pattern errs narrow (`Bash(co email send *)`, not `Bash(co *)`). The model
+  reads it as the tool result, so an agent that gets refused tells you what to
+  add instead of going quiet. A refusal nobody can act on gets worked around
+  rather than fixed; that is how a daily digest stopped sending on the 1.7.0
+  upgrade and nobody learned why for days.
+- **For an unattended pipeline, the grant belongs in the skill.** `tools:` in a
+  SKILL.md frontmatter is scoped to the turn the skill runs in — the whole of a
+  one-shot `co ai "/my-skill"` — and keeps the declaration beside the procedure
+  that needs it. Verified end to end: a skill declaring
+  `tools: ["Bash(rm -rf scratch)"]` had that destructive command executed by a
+  real unattended run.
 - **`co`'s strong verbs are classified by verb.** `co email send` is an
   external effect, `co transfer` a payment, `co server` an external effect,
   `co keys` a credential, `co auth` and `co reset` ask. `co` is one binary over
@@ -118,7 +133,7 @@ before it is the default everyone gets on upgrade. Exercise it and report;
   the unclosed sqlite, socket and file handles the run reports are closed
   (#1474).
 - The offline suite runs in parallel by default: about a minute, from four.
-  8763 tests pass on Python 3.10–3.13.
+  8802 tests pass on Python 3.10–3.13.
 
 ## Verified
 

--- a/docs/releases/1.8.5a1.md
+++ b/docs/releases/1.8.5a1.md
@@ -1,0 +1,175 @@
+# ConnectOnion 1.8.5a1 — opt-in preview
+
+Preview, 11 September 2026. An unattended agent could not run `head`. This
+preview fixes that and hardens what the fix opened, before the change to a
+security default is called stable.
+
+Stable stays **1.8.4**. This is not Latest and needs an explicit pin or
+`--pre`:
+
+```bash
+python -m pip install --pre connectonion==1.8.5a1
+co --version
+```
+
+## Why a preview
+
+The change widens what an agent may run without asking. That is the right
+fix — the policy stopped an unattended run on `head`, which is not a defensible
+place to stop one — but a widened security default earns a round of real use
+before it is the default everyone gets on upgrade. Exercise it and report;
+1.8.5 stable follows.
+
+## Changes
+
+- **An unattended agent can read its own output.** In Auto, only eleven
+  test/build commands auto-approved; everything else asked, and with nobody to
+  ask, asking is refusing. A scheduled run died on
+  `co browser … get_text | head -40` — the granted browser command, refused
+  because of the filter on its output. Read-only commands (`head`, `tail`,
+  `cat`, `grep`, `rg`, `wc`, `ls`, `sort`, `uniq`, `cut`, `tr`, `jq`, `echo`,
+  `pwd`, `cd`, …) now run, alone or as segments beside a granted command.
+  Every other segment still needs its own grant, so
+  `co browser status && co email send …` remains an email send nobody
+  authorized (#1481).
+- **Nothing that takes a program text is read-only.** `sed` and `awk` are
+  deliberately absent from that list, including their innocent shapes:
+  `awk 'BEGIN{system("rm -rf /")}'` reads like an inspection and is arbitrary
+  execution, GNU `sed`'s `e` flag is the same, and a rule that kept them while
+  excluding their execution constructs would be a parser in a security path.
+  Both ask, as they did before this release. The inspection they get reached
+  for is covered by `head`, `tail`, `cut`, `jq` and `read_file(limit=,
+  offset=)`.
+- **A read whose target the policy cannot resolve is not a checked read.**
+  `cat $(cat which_file.txt)` reads whatever that file names and
+  `head $HOME/x` whatever `HOME` is, so both ask. A bare `$` names nothing, so
+  `grep 'foo$' notes.txt` is unaffected.
+- **An explicit grant is an approval already given.** A grant somebody wrote
+  down — the operator's `.co/host.yaml`, a skill's `tools:` frontmatter, a
+  human's session approval — now runs the call for any effect class, with or
+  without a person present. Before this it was discarded for everything except
+  an unclassified command: `Bash(curl *)` in your own `host.yaml` was refused
+  unattended and asked *every single time* with a person there, and a skill's
+  declaration bought nothing at all. Nine hand-written grants were measured on
+  1.8.4; eight were ignored. A wildcard is still honoured only for the effect
+  its own text names, so `Bash(git *)` does not carry `git push` while
+  `Bash(git push *)` does. The 78 grants that ship in the template now load as
+  `source: template` and buy only what they always did — which is also what
+  removes the hardcoded exception that used to narrow the broad `Bash(co *)`.
+- **`co`'s strong verbs are classified by verb.** `co email send` is an
+  external effect, `co transfer` a payment, `co server` an external effect,
+  `co keys` a credential, `co auth` and `co reset` ask. `co` is one binary over
+  very different powers, and this is what keeps a wildcard over it from
+  reaching them.
+- **A shell redirect is held to the write tool's rule.** `echo x > notes.txt`
+  and `cat << 'EOF' > src/main.rs` are what a model reaches for instead of the
+  write tool: inside the workspace they are reversible edits and are allowed; a
+  control file or a path outside the workspace is denied; a target that depends
+  on the environment asks. `2>&1` is not a write, and a heredoc is classified
+  by its first line, so `bash << EOF` still asks.
+- **A private key read is a credential read wherever the key sits, by shell or
+  by tool.** Key material is recognised by path component (`.ssh`, `.gnupg`,
+  `.aws`, `.azure`, `.kube`, `.docker`, `keys` — the agent's own `.co/keys/`
+  included), by filename (`id_rsa`, `id_ed25519`, `authorized_keys`, `.npmrc`,
+  `.netrc`, `.git-credentials`, `.pypirc`, `keys.env`) and by suffix (`.pem`,
+  `.key`, `.p12`, `.pfx`, `.jks`, `.keystore`, `.ppk`). Previously only the
+  workspace boundary stood in the way, which does not protect a committed key,
+  a workspace that is the home directory, or the agent's own signing key — and
+  `read_file` allowed what `cat` refused, so a model asked for the shell form
+  simply used the tool form.
+- **Auto-approval works in a quiet agent.** Six paths in the approval plugin
+  reached the logger's console directly. A `quiet=True` agent — the shape of
+  every unattended run — has none, so every auto-approved call raised
+  `AttributeError` *after* the policy allowed it, and the tool reported
+  failure.
+- **A policy decision reaches the run trace.** The recorder matched the call by
+  the wrong field, so the audit record the UI and session replay read was
+  absent in a real agent.
+- **`make` is narrowed to a named verification target.** 1.8.4 allowed
+  `make install`, bare `make` and `make -C /etc all` as "focused test, lint or
+  build" work. `cargo`, `go` and the package runners were already limited to
+  their verification subcommands; `make` was the one left open. `make test`
+  runs; the rest ask. The focused-verification category remains an execution
+  surface by design — an agent that may write a test and run it may run what
+  the test runs — so this keeps out the commands in it that are not
+  verification, not the execution the model already permits.
+- **Outside-workspace reads by shell command hold the line the read tools
+  hold.** `cat /etc/hosts` and `head ../secrets.txt` ask, as `read_file` on the
+  same path already did.
+- Control Center pages give their content room to be read (#1482).
+
+## Testing
+
+- An end-to-end test drives an unattended agent through a real job: write a
+  small Rust CLI, `cargo build`, `cargo test`, run the binary, inspect the
+  result through `head`/`wc`/`grep`. Real Agent loop, real tool executor, real
+  approval plugin, real `cargo`; only the model is scripted. It asserts which
+  rule carried each step, and a second test removes the operator's two grants
+  and asserts exactly those two steps are refused. This test found the
+  quiet-agent and trace-record defects above, on its first run against 1.8.4.
+- A real-model version of the same job is opt-in behind `real_api`. Its runs
+  found the heredoc gap and confirmed that `ping` and
+  `python3 -c "open(...).write(...)"` are still refused.
+- The event-system tests no longer replace the tool executor with a fake that
+  fired the lifecycle events itself, so a dropped or reordered event now fails
+  a test. Two TUI import tests that had skipped on every run since they were
+  written now assert. `DeprecationWarning` is no longer ignored wholesale; the
+  one real item it hid (Pillow's `getdata`, removed in Pillow 14) is fixed, and
+  the unclosed sqlite, socket and file handles the run reports are closed
+  (#1474).
+- The offline suite runs in parallel by default: about a minute, from four.
+  8763 tests pass on Python 3.10–3.13.
+
+## Verified
+
+Through the real `co ai`, unattended, in a throwaway project — not the test
+harness:
+
+```
+$ co ai "Run exactly this one shell command and show me its output verbatim: cat notes.txt | head -3"
+[co]   ⚡ bash: cat notes.txt | head -3   policy read-only command chain (2 commands)
+alpha
+beta
+gamma
+
+$ co ai "Show me the first 2 lines of server.pem, then the first 2 lines of notes.txt"
+[co] ✗ Tool 'read_file' denied by connectonion.auto: credential access is never auto-approved
+[co]   ⚡ read_file(path="notes....")   policy read-only workspace operation
+alpha
+beta
+
+$ co ai "Run exactly this one shell command with bash and show its output: awk 'BEGIN{system(\"echo pwned\")}'"
+[co] ✗ Tool 'bash' denied by connectonion.auto: command is outside the focused
+     verification and read-only allowlists
+```
+
+And with `Bash(curl *)` written into that project's own `.co/host.yaml`:
+
+```
+$ co ai "Run exactly this shell command and show the HTTP status line only: curl -s -o /dev/null -w '%{http_code}' https://example.com"
+[co]   ⚡ bash: curl -s -o /dev/null -w '%{http_...  policy operator-configured
+200
+```
+
+Every case in #1481's own table was also run directly against the shipped
+permissions with no approval channel, beside the verdict expected for it:
+twenty cases, all correct. A further adversarial sweep of twenty-six
+bypass attempts — `cd /etc && cat passwd`, exfiltration through a granted
+command, `tee`/`cp`/`dd`/`ln`, `sh -c`, `perl -e`, `python3 -c`, a read-only
+first segment carrying a payload — refused twenty-five. The twenty-sixth was
+`make install`, allowed since before this line, and is the narrowing above.
+
+## Migration
+
+No API changes. One behaviour change an operator can observe: in Auto, shell
+commands that only read now run without a dialog. If a deployment relied on
+those being refused, select `read-only`, which asks for every effectful call
+that is not explicitly permitted.
+
+## Acceptance limits
+
+- This is a preview of a security default. It has been exercised locally and by
+  the suite; it has not yet run a week of scheduled production work. That is
+  what the preview is for.
+- The Feishu/Lark inbound mailbox is **not** in this line. Its no-loss
+  reconnect gate is open; it ships in 1.8.6 when that gate passes (#1462).

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -300,7 +300,10 @@ Nothing has granted this. To allow it — including unattended — write it down
 
 The suggested pattern errs narrow: it is the leading verb words, stopping at
 the first argument-looking one and capped at three, so `co email send --to …`
-suggests `Bash(co email send *)` rather than `Bash(co *)`.
+suggests `Bash(co email send *)` rather than `Bash(co *)`. For a deletion, a
+credential or a payment it names the command exactly — `rm -rf build` suggests
+`Bash(rm -rf build)`, because `Bash(rm *)` would also cover `rm -rf /` and a
+suggestion is a nudge toward whatever it prints.
 
 ### Unattended pipelines
 

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -234,12 +234,44 @@ same Host-advertised modes.
 
 Auto-approve safe commands permanently via `host.yaml` configuration. Config permissions never expire and apply to all sessions.
 
-In a headless one-shot run, a matching operator-configured `Bash(...)` rule can
-approve an ordinary command even though no dialog exists. Auto continues to
-deny destructive, credential, publication, deployment, external-effect, and
-unknown calls. For compatibility, the shipped broad `Bash(co *)` rule is
-narrowed at this boundary to `co status` and `co browser ...`; commands such as
-`co deploy`, `co publish`, and `co email send` do not inherit silent authority.
+### An explicit grant is an approval already given
+
+A grant somebody wrote down on purpose runs the call, with or without a person
+present, for any effect class:
+
+| source | who wrote it | scope |
+|---|---|---|
+| `config` | the operator, in `.co/host.yaml` — a control file the agent may not write | until removed |
+| `skill` | a skill author, in its `tools:` frontmatter | that turn |
+| `user` | a human answering a dialog | that session |
+| `template` | nobody; it ships with the product | ordinary commands only |
+
+So `Bash(curl *)` in your own `host.yaml` fetches URLs unattended and stops
+asking you every time, `Bash(rm -rf build)` cleans your build directory, and a
+skill that declares `Bash(mkdir *)` can make directories. Before 1.8.5 none of
+those worked: an explicit grant was discarded for every effect class except an
+unclassified command, so eight of nine hand-written grants were ignored and a
+skill's declaration bought nothing at all (#1481).
+
+Two things still cannot happen.
+
+**A wildcard is honoured only for the effect its own text names.**
+`Bash(curl *)` classifies as external network and so does the command it
+matches, so the operator plainly meant network access. `Bash(git *)` is an
+ordinary command while `git push origin main` publishes, so the wildcard does
+not carry it — `Bash(git push *)` does. An exact pattern always names its own
+effect.
+
+**The shipped defaults are not your grant.** The template's 78 `Bash(...)`
+entries load as `source: template` and buy only what they always did. The
+broad `Bash(co *)` reaches `co status` and `co browser ...`, and nothing else:
+`co` is a multiplexer, and its strong verbs are classified by verb — `co email
+send` is an external effect, `co transfer` a payment, `co keys` a credential —
+so a wildcard over `co` cannot reach them however it is written.
+
+A third-party skill installed with `co copy` can declare whatever `tools:` it
+likes, and those grants are honoured. That is the same trust you extend by
+installing it; read a skill's frontmatter before you install it.
 
 ### Configuration
 

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -273,6 +273,54 @@ A third-party skill installed with `co copy` can declare whatever `tools:` it
 likes, and those grants are honoured. That is the same trust you extend by
 installing it; read a skill's frontmatter before you install it.
 
+### A refusal names the line to write
+
+Without a grant, an unattended refusal used to name a policy — "command is
+outside the focused verification allowlist" — and leave the operator to work
+out the syntax, the file and the right breadth. It now carries the remedy, so
+the agent can relay it and the operator can read it in the log:
+
+```
+Tool 'bash' denied by connectonion.auto: sending mail requires human approval;
+no approval channel is available
+
+Nothing has granted this. To allow it — including unattended — write it down once:
+  • in .co/host.yaml:
+      permissions:
+        "Bash(co email send *)":
+          allowed: true
+          source: config
+          reason: why you want this
+          expires:
+            type: never
+  • or in the skill that needs it, in its SKILL.md frontmatter:
+      tools:
+        - "Bash(co email send *)"
+```
+
+The suggested pattern errs narrow: it is the leading verb words, stopping at
+the first argument-looking one and capped at three, so `co email send --to …`
+suggests `Bash(co email send *)` rather than `Bash(co *)`.
+
+### Unattended pipelines
+
+For a scheduled run, put the grant in the skill that needs it. `tools:` in the
+SKILL.md frontmatter is scoped to the turn the skill runs in, which is the
+whole of a one-shot `co ai "/my-skill"`, and it keeps the declaration next to
+the procedure that depends on it:
+
+```yaml
+---
+name: daily-digest
+description: Email me what happened today.
+tools:
+  - "Bash(co email send *)"
+---
+```
+
+`.co/host.yaml` is the other place, for grants that outlive any one skill.
+Either way it is written down once and the pipeline stops stopping.
+
 ### Configuration
 
 Add permissions to `.co/host.yaml`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.8.4"
+version = "1.8.5a1"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -25,7 +25,7 @@ keywords = [
     "xray",
 ]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -958,3 +958,76 @@ def test_a_quoted_program_does_not_read_as_ungranted(tmp_path, monkeypatch):
 
     result = instance.current_session["pending_tool"]["approval_policy"]
     assert result["decision"] == "allow", result
+
+
+# ---------------------------------------------------------------------------
+# A refusal says how to fix it.
+#
+# "command is outside the focused verification allowlist" tells an operator
+# nothing about what to write, where. The daily digest stopped sending on the
+# 1.7.0 upgrade and nobody learned why for days, because the refusal named a
+# policy instead of a remedy.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("co email send --to a@b.c hi", "Bash(co email send *)"),   # not Bash(co *)
+        ("curl https://example.com", "Bash(curl *)"),
+        ("rm -rf build", "Bash(rm *)"),
+        ("git push origin main", "Bash(git push origin *)"),
+        ("CO_WHO=x co browser get_text", "Bash(co browser get_text *)"),
+        ("sed -i s/a/b/ notes.txt", "Bash(sed *)"),
+        ("ping -c 1 8.8.8.8", "Bash(ping *)"),
+    ],
+)
+def test_the_suggested_grant_names_the_verb_not_the_binary(command, expected):
+    from connectonion.useful_plugins.tool_approval.policy import suggested_grant_pattern
+
+    assert suggested_grant_pattern("bash", {"command": command}) == expected
+
+
+def test_a_non_bash_tool_is_suggested_by_its_name():
+    from connectonion.useful_plugins.tool_approval.policy import suggested_grant_pattern
+
+    assert suggested_grant_pattern("send_email", {"to": "a@b.c"}) == "send_email"
+
+
+def test_an_unattended_refusal_names_the_line_to_write(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False, permissions=load_permission_patterns(tmp_path / ".co"))
+    instance.current_session["pending_tool"] = {
+        "name": "bash",
+        "arguments": {"command": "co email send --to aaron@example.com digest"},
+    }
+
+    apply_auto_approve_policy(instance)
+
+    policy = instance.current_session["pending_tool"]["approval_policy"]
+    assert policy["decision"] == "deny"
+    remedy = policy["remedy"]
+    assert "Bash(co email send *)" in remedy
+    assert ".co/host.yaml" in remedy
+    assert "SKILL.md frontmatter" in remedy
+
+    # And the model reads it, because it is in the error it gets back.
+    with pytest.raises(ValueError) as refusal:
+        check_approval(instance)
+    assert "Bash(co email send *)" in str(refusal.value)
+    assert "tools:" in str(refusal.value)
+
+
+def test_a_granted_call_carries_no_remedy(tmp_path, monkeypatch):
+    """Nothing to fix, nothing to say."""
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False, permissions=_granted("Bash(co email send *)"))
+    instance.current_session["pending_tool"] = {
+        "name": "bash",
+        "arguments": {"command": "co email send --to a@b.c hi"},
+    }
+
+    apply_auto_approve_policy(instance)
+
+    policy = instance.current_session["pending_tool"]["approval_policy"]
+    assert policy["decision"] == "allow"
+    assert "remedy" not in policy

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -193,12 +193,6 @@ def test_auto_honors_only_the_exact_co_ai_managed_delegation_grant(
     [
         {
             "allowed": True,
-            "source": "config",
-            "reason": "managed delegation owns inner approval",
-            "expires": {"type": "never"},
-        },
-        {
-            "allowed": True,
             "source": "safe",
             "reason": "arbitrary safe grant",
             "expires": {"type": "never"},
@@ -220,6 +214,28 @@ def test_auto_does_not_treat_near_match_claude_grants_as_managed_delegation(
 
     assert result["decision"] == "ask"
     assert instance.io.sent[0]["type"] == "approval_needed"
+
+
+def test_an_operators_own_grant_for_a_delegate_is_not_managed_delegation():
+    """An explicit host.yaml grant runs the tool, but by its own authority.
+
+    The distinction matters for the audit line: managed delegation means
+    "co ai injected this and the inner agent owns approval", while a config
+    grant means "the operator wrote this down". Both allow; they are not the
+    same statement, and only the exact runtime grant may claim the first.
+    """
+    instance = agent(permissions={"claude_code": {
+        "allowed": True,
+        "source": "config",
+        "reason": "managed delegation owns inner approval",   # near-match wording
+        "expires": {"type": "never"},
+    }})
+
+    result = call(instance, "claude_code", {"prompt": "inspect", "cwd": "."})
+
+    assert result["decision"] == "allow"
+    assert result["effect_class"] == "configured_tool"
+    assert instance.io.sent == []
 
 
 def test_read_only_mode_keeps_the_manual_approval_contract():
@@ -336,7 +352,12 @@ def test_packaged_permissions_keep_headless_co_browser_status_working(
     [
         ("co deploy", "publication"),
         ("co publish", "publication"),
-        ("co email send --to a@example.com hi", "command"),
+        # `co` is a multiplexer, so its strong verbs classify by verb now:
+        # that, not a hardcoded exception, is what keeps `Bash(co *)` off them.
+        ("co email send --to a@example.com hi", "external_effect"),
+        ("co transfer 0xabc 5", "payment"),
+        ("co server destroy prod", "external_effect"),
+        ("co keys --reveal", "credentials"),
     ],
 )
 def test_headless_broad_co_grant_cannot_authorize_stronger_effects(
@@ -790,3 +811,150 @@ def test_make_is_not_a_way_to_run_anything(tmp_path, monkeypatch, command):
     apply_auto_approve_policy(instance)
 
     assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# An explicit grant is an approval already given.
+#
+# Measured on 1.8.4: nine grants written by hand into the operator's own
+# host.yaml, eight of them ignored. `Bash(curl *)` was denied unattended and
+# asked *every single time* with a person present. A skill's declared `tools:`
+# bought nothing at all — the same `Bash(mkdir *)` ran as `source: config` and
+# was refused as `source: skill`.
+# ---------------------------------------------------------------------------
+
+def _granted(pattern, source="config", command=None):
+    return {pattern: {
+        "allowed": True,
+        "source": source,
+        "reason": f"written by the {source}",
+        **({"when": {"command": pattern[5:-1]}} if pattern.startswith("Bash(") else {}),
+        "expires": {"type": "turn_end" if source == "skill" else "never"},
+    }}
+
+
+@pytest.mark.parametrize("source", ["config", "skill"])
+@pytest.mark.parametrize(
+    ("pattern", "command"),
+    [
+        ("Bash(curl *)", "curl https://example.com"),        # external network
+        ("Bash(rm -rf build)", "rm -rf build"),              # destructive
+        ("Bash(git push *)", "git push origin main"),        # publication
+        ("Bash(co deploy)", "co deploy"),                    # publication
+        ("Bash(cat .env)", "cat .env"),                      # credentials
+        ("Bash(sed -i *)", "sed -i s/a/b/ notes.txt"),       # takes a program
+        ("Bash(awk *)", "awk '{print $1}' notes.txt"),
+        ("Bash(mkdir *)", "mkdir -p build"),                 # ordinary
+        ("Bash(co email send *)", "co email send --to a@b.c hi"),
+    ],
+)
+def test_an_explicit_grant_runs_unattended_whatever_the_effect(
+    tmp_path, monkeypatch, source, pattern, command
+):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False, permissions=_granted(pattern, source))
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "allow", (pattern, command, result)
+    assert result["effect_class"] == "configured_command"
+
+
+@pytest.mark.parametrize("source", ["config", "skill"])
+def test_an_explicit_grant_does_not_ask_again_with_a_person_present(tmp_path, monkeypatch, source):
+    """You wrote the grant. Being asked every time is the bug (#1481)."""
+    monkeypatch.chdir(tmp_path)
+    instance = agent(permissions=_granted("Bash(curl *)", source))
+
+    result = call(instance, "bash", {"command": "curl https://example.com"})
+
+    assert result["decision"] == "allow", result
+    assert instance.io.sent == [], "a dialog was shown for a call the operator had already allowed"
+
+
+@pytest.mark.parametrize("source", ["config", "skill"])
+def test_an_explicit_grant_covers_a_non_bash_tool_too(tmp_path, monkeypatch, source):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False, permissions=_granted("send_email", source))
+    instance.current_session["pending_tool"] = {"name": "send_email", "arguments": {"to": "a@b.c"}}
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "allow", result
+    assert result["effect_class"] == "configured_tool"
+
+
+@pytest.mark.parametrize(
+    ("pattern", "command"),
+    [
+        ("Bash(git *)", "git push origin main"),      # git is ordinary, push publishes
+        ("Bash(co *)", "co deploy"),
+        ("Bash(co *)", "co email send --to a@b.c hi"),
+        ("Bash(co *)", "co keys --reveal"),
+        ("Bash(ls *)", "rm -rf build"),               # does not match at all
+    ],
+)
+def test_a_wildcard_cannot_reach_a_stronger_effect_than_it_names(tmp_path, monkeypatch, pattern, command):
+    """`Bash(curl *)` plainly means network. `Bash(git *)` does not plainly
+    mean "push", and `Bash(co *)` does not mean "send mail as me" — `co` is a
+    multiplexer whose verbs have nothing like the same power. A wildcard is
+    honoured for the effect its own text classifies to, and no further; the
+    operator who wants more names it, as `Bash(git push *)` does above."""
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False, permissions=_granted(pattern))
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
+
+    apply_auto_approve_policy(instance)
+
+    assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "deny"
+
+
+def test_the_shipped_defaults_are_not_an_operators_grant(tmp_path, monkeypatch):
+    """78 entries ship in the template declaring `source: config`, which made
+    them indistinguishable from something the operator wrote — the reason the
+    broad `Bash(co *)` needed a hardcoded exception. They load as `template`
+    now and still buy exactly what they did: `co status`, `co browser ...`."""
+    monkeypatch.chdir(tmp_path)
+    shipped = load_permission_patterns(tmp_path / ".co")
+    assert shipped["Bash(co *)"]["source"] == "template"
+
+    for command, expected in [
+        ("co status", "allow"),
+        ("co browser status", "allow"),
+        ("co deploy", "deny"),
+        ("co email send --to a@b.c hi", "deny"),
+        ("co keys --reveal", "deny"),
+    ]:
+        instance = agent(io=False, permissions=dict(shipped))
+        instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": command}}
+        apply_auto_approve_policy(instance)
+        got = instance.current_session["pending_tool"]["approval_policy"]["decision"]
+        assert got == expected, (command, got)
+
+
+def test_a_quoted_program_does_not_read_as_ungranted(tmp_path, monkeypatch):
+    """The grant check must not re-parse a segment's text.
+
+    `_extract_subcommands` returns segments with quotes removed, so feeding
+    `awk BEGIN{system("x")}` back to bashlex raises — and the first version of
+    this code swallowed that into "no grant". It happened to deny something
+    dangerous, which is how a swallowed error hides: the same path denies a
+    grant the operator did write, for a command whose text simply does not
+    re-parse.
+    """
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False, permissions=_granted("Bash(awk *)"))
+    instance.current_session["pending_tool"] = {
+        "name": "bash",
+        "arguments": {"command": 'awk \'BEGIN{system("echo hi")}\''},
+    }
+
+    apply_auto_approve_policy(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "allow", result

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -974,7 +974,6 @@ def test_a_quoted_program_does_not_read_as_ungranted(tmp_path, monkeypatch):
     [
         ("co email send --to a@b.c hi", "Bash(co email send *)"),   # not Bash(co *)
         ("curl https://example.com", "Bash(curl *)"),
-        ("rm -rf build", "Bash(rm *)"),
         ("git push origin main", "Bash(git push origin *)"),
         ("CO_WHO=x co browser get_text", "Bash(co browser get_text *)"),
         ("sed -i s/a/b/ notes.txt", "Bash(sed *)"),
@@ -985,6 +984,24 @@ def test_the_suggested_grant_names_the_verb_not_the_binary(command, expected):
     from connectonion.useful_plugins.tool_approval.policy import suggested_grant_pattern
 
     assert suggested_grant_pattern("bash", {"command": command}) == expected
+
+
+@pytest.mark.parametrize(
+    ("command", "effect", "expected"),
+    [
+        ("rm -rf build", "deletion", "Bash(rm -rf build)"),
+        ("cat .env", "credentials", "Bash(cat .env)"),
+        ("co transfer 0xabc 5", "payment", "Bash(co transfer 0xabc 5)"),
+        ("curl https://example.com", "external_network", "Bash(curl *)"),
+    ],
+)
+def test_a_dangerous_effect_is_suggested_exactly_not_as_a_wildcard(command, effect, expected):
+    """The remedy is a nudge toward whatever it prints, and an operator in a
+    hurry pastes it. `Bash(rm *)` would also cover `rm -rf /`, so a deletion,
+    a credential or a payment gets named exactly."""
+    from connectonion.useful_plugins.tool_approval.policy import suggested_grant_pattern
+
+    assert suggested_grant_pattern("bash", {"command": command}, effect) == expected
 
 
 def test_a_non_bash_tool_is_suggested_by_its_name():

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.8.4"
+version = "1.8.5a1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Description

Publishes **1.8.5a1**, an opt-in preview, and carries the second half of #1481: an explicit grant is an approval already given.

Two commits:

1. **An explicit grant is an approval already given** — the grant rule, plus the 1.8.5a1 version bump (the four files the checklist names, release notes, and the preview channel in `docs/releases.md`).
2. **A refusal names the line to write, and a skill is where a pipeline writes it** — the remedy in the refusal, and the documentation for unattended pipelines.

Refs #1481. These answer three questions the owner asked directly:

- *If the user's command explicitly allows it, or a skill allows it, shouldn't it just run?* — It should, and now does.
- *If it gets refused, shouldn't something tell the user or the agent what to do?* — It now does, naming the exact line and both places to write it.
- *For an unattended pipeline, do I write the permission into the skill?* — Yes, and that works; nothing in the product said so, and now the docs do.

## What was wrong

Measured on 1.8.4 — nine grants written by hand into a project's own `.co/host.yaml`:

| written in host.yaml | command | 1.8.4 | now |
|---|---|---|---|
| `Bash(curl *)` | `curl https://example.com` | **deny** | allow |
| `Bash(rm -rf build)` | `rm -rf build` | **deny** | allow |
| `Bash(git push *)` | `git push origin main` | **deny** | allow |
| `Bash(co deploy)` | `co deploy` | **deny** | allow |
| `Bash(cat .env)` | `cat .env` | **deny** | allow |
| `send_email` | send mail | **deny** | allow |
| `Bash(make install)` | `make install` | allow | allow |

Eight of nine ignored. With a person present they did not auto-approve either — the dialog opened **every time** for a call the operator had already written down. And a skill declaring `Bash(mkdir *)` in its `tools:` frontmatter got nothing at all: the identical grant ran as `source: config` and was refused as `source: skill`.

Two causes. When the policy says "ask a human", `check_approval` discarded every grant that did not come from a human in this session, because a broad `Bash(co *)` must not imply `co deploy` — a real concern, corrected at the grant's *source* when what actually differs is its *breadth*. And the code could not tell an operator's grant from a shipped default anyway, because all 78 template entries also declare `source: config`; that is why `Bash(co *)` needed a hardcoded exception naming `co status` and `co browser`. The general rule was unwritable because the information it needs was never recorded.

## What it does now

| source | who wrote it | scope | reach |
|---|---|---|---|
| `config` | operator, `.co/host.yaml` (a control file the agent may not write) | until removed | any effect class |
| `skill` | skill author, `tools:` frontmatter | that turn | any effect class |
| `user` | a human answering a dialog | that session | any effect class |
| `template` | nobody — ships with the product | — | ordinary commands only |

Two limits remain:

- **A wildcard is honoured only for the effect its own text names.** `Bash(curl *)` classifies as external network and so does the command, so the operator plainly meant network access. `Bash(git *)` is an ordinary command while `git push origin main` publishes, so it does not carry it; `Bash(git push *)` does.
- **`co`'s strong verbs classify by verb**, which is what replaces the hardcoded exception: `co email send` is an external effect, `co transfer` a payment, `co server` an external effect, `co keys` a credential, `co auth`/`co reset` ask. A wildcard over a multiplexer cannot reach them however it is written.

## A refusal you cannot act on

Before, an unattended refusal read:

```
command is outside the focused verification and read-only allowlists;
no approval channel is available
```

That names a policy, not a file, a syntax, a breadth, or the fact that a skill's frontmatter is a place to put it. What an operator actually does with that is widen something until the pipeline runs — or not notice for days, which is how the daily digest stopped sending on the 1.7.0 upgrade. It now reads:

```
Tool 'bash' denied by connectonion.auto: sending mail requires human approval;
no approval channel is available

Nothing has granted this. To allow it — including unattended — write it down once:
  • in .co/host.yaml:
      permissions:
        "Bash(co email send *)":
          allowed: true
          source: config
          reason: why you want this
          expires:
            type: never
  • or in the skill that needs it, in its SKILL.md frontmatter:
      tools:
        - "Bash(co email send *)"
```

The suggested pattern errs narrow: leading verb words, stopping at the first argument-looking one, capped at three. The string is the tool result the model reads, so the agent relays it — asked to send an email with no grant in place, a real unattended run came back with that YAML block and where to put it, unprompted.

## Unattended pipelines: the grant goes in the skill

`tools:` in a SKILL.md frontmatter is scoped to the turn the skill runs in, which is the whole of a one-shot `co ai "/my-skill"`. Verified end to end on a real run, in a temp project, with a destructive-class command:

```yaml
---
name: cleanup
description: Remove the scratch directory.
tools:
  - "Bash(rm -rf scratch)"
---
```

```
$ co ai "/cleanup"
[co]   ⚡ bash: rm -rf scratch         policy operator-configured command
[co]   ▸ bash(command="rm -rf scratch")                ✓ 0.01s
$ ls -d scratch
ls: scratch: No such file or directory
```

`docs/useful_plugins/tool_approval.md` previously documented neither the remedy nor this recipe.

## A bug I introduced and caught

Checking a pipe segment by handing its text back to the chain checker re-parses it, and segment text arrives with quotes already removed — so `awk BEGIN{system("x")}` failed to parse and a broad `except` turned that into "no grant". I noticed because a granted `awk '{print $1}'` was allowed while a granted `awk 'BEGIN{system(...)}'` was denied and I could not explain the difference. The denial was the safe answer, which is what made it dangerous: a swallowed parse error refuses whatever it cannot read, including grants the operator did write, and it looks like security working. `segment_permitted` matches without re-parsing; a test pins it.

## Labels and target release (required)

- **Suggested labels:** bug, tests
- **Proposed target version:** 1.8.5a1 (this PR is the release)
- **Estimated release window:** on merge
- **Milestone:** maintainer assigns
- **Why this release:** #1481 is breaking scheduled production work today. It ships as a preview rather than stable because it widens a security default, and a widened default earns a round of real use before everyone gets it on upgrade. Stable stays 1.8.4; this needs `--pre` or an exact pin. Rollback is a revert plus a yank.
- **Forward-port tracking issue (stable patches only):** N/A — mainline work

## How this was written

- [x] Mostly AI-generated — Claude Opus 5 via Claude Code, on the owner's instruction to fix #1481, verify it, and publish in 1.8.5.

**Least confident about:** letting a *skill* grant reach the deny classes. A skill installed with `co copy` can declare `Bash(cat .env)` in its frontmatter and it will be honoured. That is the owner's explicit decision and it is the same trust one extends by installing anything, but it is the widest surface in this change. `source: config` has a stronger claim — the agent cannot write `host.yaml`.

**Not verified:** the Windows path (the `bash` tool refuses Windows); a skill grant end-to-end through a real `co ai` run (the unit path and a real `host.yaml` grant were both run through the CLI).

**If this is wrong, what breaks first:** `test_a_wildcard_cannot_reach_a_stronger_effect_than_it_names` and `test_the_shipped_defaults_are_not_an_operators_grant`. Between them they pin the two limits, so a change in either direction fails with the pattern and the command named.

**One note on the remedy text:** it suggests a pattern, and a suggestion is a nudge toward whatever it says. `Bash(rm *)` is what it offers for `rm -rf build`, which is broader than the command — the text says to narrow it, but an operator in a hurry will paste it. A narrower suggestion (the exact command) would be safer and less often useful. Say the word if you want it flipped.

## Dev Blog

> docs/blog/2026-09-11-sixty-green-tests-and-a-job-that-could-not-run.md

## Testing

```
$ make test
8802 passed, 21 skipped, 6 warnings in 40.00s
```

Through the real `co ai`, unattended, with `Bash(curl *)` in that project's own `.co/host.yaml`:

```
$ co ai "Run exactly this shell command and show the HTTP status line only: curl -s -o /dev/null -w '%{http_code}' https://example.com"
[co]   ⚡ bash: curl -s -o /dev/null -w '%{http_...  policy operator-configured
200
```

Version gates: `test_the_version_agrees_with_itself.py` and `test_every_release_has_an_entry.py` pass (the docs-site check skips — see below).

## Follow-up not in this PR

`docs-site/lib/version.ts` needs `PREVIEW_VERSION = '1.8.5a1'`. That repo is not checked out beside this one here (only a stale clone on an unrelated branch at 1.8.1), so the version test skips it and I have not pushed to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLqqyEND1RpEtSPTe86NsK
