### PR TITLE
Release 1.8.5a2: a refusal you can act on

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -58,7 +58,38 @@ See [1.8.4 notes](docs/releases/1.8.4.md) for migration and acceptance limits.
 The planned 1.8.4b1 was not published separately; its reviewed changes are included
 in 1.8.4. Publication is performed and verified by the immutable-tag workflow.
 
-## Release candidate: 1.8.5a1 (preview, published)
+## Release candidate: 1.8.5a2 (preview, published)
+
+Every refusal the policy makes now says why, how to allow it next time, and
+to re-think rather than retry. 1.8.5a1 fixed what the policy decides; this
+fixes what it says when it decides no. An agent handed "command is outside the
+focused verification allowlist" has one move available — try again — and
+trying again cannot work, because the decision is a static lookup. That is how
+the incident behind #1481 reached 28 of 300 iterations: one refusal and 272
+retries of it.
+
+The suggested grant is verified against the real grant path before it is
+printed, in the order the live call asks — control-file gate first, then the
+grant check. Two of the first suggestions were untrue: `Bash(cat *)` cannot
+allow `cat /etc/shadow`, because a wildcard is honoured only for the effect
+its own text names, and no pattern at all can allow `echo x > ../outside.txt`,
+because redirects are stripped from the text patterns match against. Those now
+say there is no grant rather than naming a line that would not work — a wrong
+remedy gets widened until something works, which walks the operator toward
+turning the policy off. A test pastes the suggested pattern for sixteen
+refused calls and asserts the identical call then runs; that test found both.
+
+blog-gate's story check also stopped reading a provider 503 as a failing post.
+It retries, then warns and passes: an ignored gate protects nothing.
+
+Offline suite: 8,844 passed, 21 skipped. Verified on a real unattended run —
+asked to read a file outside the workspace, the agent made one attempt, took
+the reminder, did not retry, and told the operator why.
+
+Stable remains 1.8.4. This is not Latest and needs `--pre` or an exact pin.
+See [1.8.5a2 notes](docs/releases/1.8.5a2.md).
+
+## Superseded candidate: 1.8.5a1 (preview, published)
 
 An unattended agent could not run `head`. In Auto only eleven test/build
 commands auto-approved, so a scheduled run died on
@@ -116,9 +147,19 @@ Stable remains 1.8.3; this does not authorize final 1.8.4 or cloud provisioning.
 See [1.8.4a2 notes](docs/releases/1.8.4a2.md) and the
 [local acceptance record](docs/acceptance/1.8.4-live-followup/README.md).
 
-## Current Version: 1.8.5a1
+## Current Version: 1.8.5a2
 
 ### Version History
+- 1.8.5a2 (**opt-in preview: a refusal you can act on.** Every refusal the
+  policy makes carries why it was refused, the exact permission line that would
+  allow it next time and the two places it can go, and a prompt to re-think
+  rather than repeat — including what to try instead, per effect class. 1.8.5a1
+  fixed what the policy decides; an agent handed the old one-sentence refusal
+  could only retry, and retrying a deterministic lookup drains the run. The
+  suggested grant is checked against the real grant path before it is printed,
+  so a refusal no pattern can lift says so instead of naming a line that would
+  not work. blog-gate's story check no longer reads a provider 503 as a failing
+  post. Stable stays 1.8.4; this needs `--pre` or an exact pin.)
 - 1.8.5a1 (**opt-in preview: an unattended agent can read its own output.** In
   Auto only eleven test/build commands auto-approved, so everything else asked
   — and with nobody to ask, asking is refusing. A scheduled run died on

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.8.5a1"
+__version__ = "1.8.5a2"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -22,15 +22,18 @@ co env
 
 ## Current preview
 
-Preview **1.8.5a1** fixes a refusal that stopped unattended agents: in Auto
-only eleven test/build commands auto-approved, so a scheduled run died on
-`co browser … get_text | head -40`. Read-only commands now run; `sed` and
-`awk` deliberately still ask, because they take a program. It is a preview
-because it widens a security default. See
-[1.8.5a1 release notes](releases/1.8.5a1.md).
+Preview **1.8.5a2** makes a refusal actionable: it says why, the exact
+permission line that would allow it and where to put it, and to re-think
+rather than retry — and it checks that line works before printing it. It
+carries 1.8.5a1, which fixed the refusal that stopped unattended agents (in
+Auto only eleven test/build commands auto-approved, so a scheduled run died on
+`co browser … get_text | head -40`). Read-only commands run; `sed` and `awk`
+deliberately still ask, because they take a program. These are previews
+because they change a security default. See
+[1.8.5a2](releases/1.8.5a2.md) and [1.8.5a1](releases/1.8.5a1.md).
 
 ```bash
-python -m pip install --pre connectonion==1.8.5a1
+python -m pip install --pre connectonion==1.8.5a2
 co --version
 ```
 

--- a/docs/releases/1.8.5a2.md
+++ b/docs/releases/1.8.5a2.md
@@ -1,0 +1,94 @@
+# ConnectOnion 1.8.5a2 — opt-in preview
+
+Preview, 11 September 2026. 1.8.5a1 fixed what the permission policy *decides*.
+This fixes what it *says* when it decides no.
+
+Stable stays **1.8.4**. This is not Latest and needs an explicit pin or
+`--pre`:
+
+```bash
+python -m pip install --pre connectonion==1.8.5a2
+co --version
+```
+
+Everything in [1.8.5a1](1.8.5a1.md) is here unchanged.
+
+## Why this matters more than it sounds
+
+A refused call used to come back as one sentence naming a policy:
+
+```
+command is outside the focused verification and read-only allowlists;
+no approval channel is available
+```
+
+An agent reading that has exactly one move available — try again — and trying
+again cannot work, because the decision is a lookup against a static list and
+comes out the same way every time. The run then spends its iteration budget
+repeating a refusal. That is how the incident behind #1481 reached 28 of 300
+iterations: not one refusal, but one refusal and 272 retries of it.
+
+## Changes
+
+- **Every refusal says why, how, and think again.** A `<system-reminder>` in
+  three parts: why it was refused in plain words; the exact permission line
+  that would allow it and the two places it can go (`.co/host.yaml`, or the
+  needing skill's `tools:` frontmatter); and a re-think prompt that says what
+  to try *instead* of this call and not to retry it or reach for a different
+  spelling of it. The human-rejection paths in this plugin have carried
+  guidance like this for a long time; the policy's own refusals did not.
+- **What to try instead is per effect class**, and it is the useful half. A
+  credential refusal says you almost never need a secret's contents — say what
+  you were going to use it for. A `sed`/`awk` refusal says `head`, `tail`,
+  `cut`, `jq` and `read_file(limit=, offset=)` do the reading job without a
+  grant. A publication refusal says prepare the change and stop. A payment
+  refusal says never retry, report what it would cost.
+- **The suggested grant is verified before it is printed.** It runs through the
+  real grant path in the order the live call asks — control-file gate first,
+  then the grant check — and prints the HOW section only if it would actually
+  work. Otherwise it says `THERE IS NO GRANT FOR THIS` and that there is no
+  point looking for one. Two of the first suggestions were untrue:
+  `Bash(cat *)` cannot allow `cat /etc/shadow`, because a wildcard is honoured
+  only for the effect its own text names; and no pattern at all can allow
+  `echo x > ../outside.txt`, because redirects are stripped out of the text
+  patterns are matched against. A wrong remedy is worse than none — the
+  operator widens it until something works, which walks them toward turning
+  the policy off, with an audit trail saying they chose it.
+- **blog-gate tells a bad post from a model it could not reach.** Its story
+  check failed a post on a Gemini 503 minutes after the identical check passed
+  locally. It now retries, then warns and passes. A gate that goes red for a
+  reason the author cannot act on is a gate the team learns to ignore.
+
+## Testing
+
+```
+$ make test
+8844 passed, 21 skipped, 6 warnings in 41.43s
+```
+
+The test worth keeping if you keep one: `test_the_grant_the_refusal_suggests_actually_allows_the_call`
+pastes the suggested pattern for sixteen refused calls and asserts the
+identical call then runs. It found both untrue suggestions, and neither would
+have been caught by testing the message — both were well-formed.
+
+Real unattended run, asked to read a file outside the workspace:
+
+```
+$ co ai "Read /etc/hosts and tell me the first line."
+… <system-reminder> … Do not retry this call …
+I cannot read `/etc/hosts`: access to files outside the project workspace is
+blocked by the environment's security policy.
+```
+
+One attempt, no retry, an answer the operator can act on.
+
+## Acceptance limits
+
+- Verified on `gemini-3.8-flash`. Whether a smaller model honours "do not
+  retry" is not established; the reminder makes the instruction explicit but
+  cannot enforce it.
+- The reminder is roughly 25 lines per refusal, injected into the message
+  stream. A run that hits several refusals pays for all of them in context.
+  Judged worth it against a retry loop.
+- The Feishu/Lark inbound mailbox is **not** in this line. Its no-loss
+  reconnect gate is open; it ships when that gate passes (#1462).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.8.5a1"
+version = "1.8.5a2"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.8.5a1"
+version = "1.8.5a2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Description

Publishes **1.8.5a2**, an opt-in preview. Version bump only — the change it carries merged as #1487.

1.8.5a1 fixed what the permission policy *decides*. This carries the fix for what it *says* when it decides no.

## Why a2 rather than folding into a1

a1 is already published, and a refusal that cannot be acted on is exactly what breaks during the exercise a preview exists for. An agent handed the old one-sentence refusal has one move available — try again — and trying again cannot work, because the decision is a lookup against a static list. The incident behind #1481 reached 28 of 300 iterations that way: one refusal and 272 retries of it.

## What ships

Everything in [1.8.5a1](../blob/main/docs/releases/1.8.5a1.md), plus:

- Every policy refusal carries a `<system-reminder>` with why, the exact permission line and the two places it can go, and a re-think prompt saying what to try instead — per effect class.
- The suggested grant is verified against the real grant path before printing, in the order the live call asks. Two of the first suggestions were untrue; a refusal no pattern can lift now says so.
- blog-gate's story check no longer reads a provider 503 as a failing post.

## Labels and target release (required)

- **Suggested labels:** tests
- **Proposed target version:** 1.8.5a2 (this PR is the release)
- **Estimated release window:** on merge
- **Milestone:** maintainer assigns
- **Why this release:** the preview is published for exercise, and this is what makes a refusal during that exercise actionable instead of a silent stop. No change to what is allowed or denied. Rollback is a revert plus a yank.
- **Forward-port tracking issue (stable patches only):** N/A — mainline work

## How this was written

- [x] Mostly AI-generated — Claude Opus 5 via Claude Code, on the owner's standing instruction to publish this line.

**Least confident about:** the reminder's cost. Roughly 25 lines per refusal in the message stream; a run hitting several refusals pays for all of them. Judged worth it against a retry loop, but it is a judgement.

**Not verified:** whether a smaller model honours "do not retry". Verified on `gemini-3.8-flash` — one attempt, no retry, told the operator why.

**If this is wrong, what breaks first:** `test_the_grant_the_refusal_suggests_actually_allows_the_call` — sixteen refused calls whose suggested grant must actually lift them.

## Dev Blog

Shipped with #1487: `docs/blog/2026-09-11-the-remedy-was-a-lie.md`. This PR is the version bump, so it carries no new post — apply `no-blog` if the gate objects.

## Testing

```
$ make test
8844 passed, 21 skipped, 6 warnings in 40.19s
```

Version gates pass (`test_the_version_agrees_with_itself`, `test_every_release_has_an_entry`); the docs-site channel check skips, as noted for a1.

## Follow-up still open

`docs-site/lib/version.ts` needs `PREVIEW_VERSION = '1.8.5a2'`. That repo is not checked out beside this one here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLqqyEND1RpEtSPTe86NsK
