### PR TITLE
Release ConnectOnion 1.8.5a2: a command runs unless a rule holds it back

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -58,7 +58,19 @@ See [1.8.4 notes](docs/releases/1.8.4.md) for migration and acceptance limits.
 The planned 1.8.4b1 was not published separately; its reviewed changes are included
 in 1.8.4. Publication is performed and verified by the immutable-tag workflow.
 
-## Release candidate: 1.8.5a1 (preview, published)
+## Release candidate: 1.8.5a2 (preview)
+
+`1.8.5a1` let an unattended agent read its own output by adding thirty
+command names to a list. This preview stops keeping the list: an ordinary
+command runs, and what holds one back is a category of consequence —
+destroys files, reaches credentials, writes outside the workspace, leaves
+the machine, runs a program the policy cannot read. A filter no longer
+needs a grant of its own, so `Bash(co browser *)` is not defeated by
+`| head -40` (#1488), and a planning tool is recognised by what owns it
+rather than by method names that collide with delete and read tools
+(#1447). See [1.8.5a2 notes](docs/releases/1.8.5a2.md).
+
+### Superseded: 1.8.5a1 (preview, published)
 
 An unattended agent could not run `head`. In Auto only eleven test/build
 commands auto-approved, so a scheduled run died on
@@ -116,9 +128,18 @@ Stable remains 1.8.3; this does not authorize final 1.8.4 or cloud provisioning.
 See [1.8.4a2 notes](docs/releases/1.8.4a2.md) and the
 [local acceptance record](docs/acceptance/1.8.4-live-followup/README.md).
 
-## Current Version: 1.8.5a1
+## Current Version: 1.8.5a2
 
 ### Version History
+- 1.8.5a2 (**opt-in preview: a command runs unless a rule holds it back.**
+  `1.8.5a1` answered #1481 with a longer allowlist; this replaces the list.
+  Everything it refused is still refused, and three rules the list had been
+  enforcing by omission are written down: a command whose argument is a
+  program asks, a command that sends something to somebody asks, and a
+  command that writes through its arguments gets the workspace check. Also
+  fixes #1488, a grant defeated by the filter it was piped through, and
+  #1447, 438 refused TodoList calls in six days. Stable remains 1.8.4;
+  the Feishu inbox is not in this preview.)
 - 1.8.5a1 (**opt-in preview: an unattended agent can read its own output.** In
   Auto only eleven test/build commands auto-approved, so everything else asked
   — and with nobody to ask, asking is refusing. A scheduled run died on

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.8.5a1"
+__version__ = "1.8.5a2"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -22,15 +22,17 @@ co env
 
 ## Current preview
 
-Preview **1.8.5a1** fixes a refusal that stopped unattended agents: in Auto
-only eleven test/build commands auto-approved, so a scheduled run died on
-`co browser … get_text | head -40`. Read-only commands now run; `sed` and
-`awk` deliberately still ask, because they take a program. It is a preview
-because it widens a security default. See
-[1.8.5a1 release notes](releases/1.8.5a1.md).
+Preview **1.8.5a2** stops keeping a list of safe command names. An ordinary
+command runs; what holds one back is a category of consequence — it destroys
+files, reaches credentials, writes outside the workspace, leaves the machine,
+or runs a program the policy cannot read. A filter no longer needs a grant of
+its own, so `Bash(co browser *)` is not defeated by `| head -40`. It is a
+preview because it widens a security default. See
+[1.8.5a2 release notes](releases/1.8.5a2.md); `1.8.5a1` answered the same
+issue with a longer allowlist and is superseded.
 
 ```bash
-python -m pip install --pre connectonion==1.8.5a1
+python -m pip install --pre connectonion==1.8.5a2
 co --version
 ```
 

--- a/docs/releases/1.8.5a2.md
+++ b/docs/releases/1.8.5a2.md
@@ -1,0 +1,99 @@
+# ConnectOnion 1.8.5a2 — opt-in preview
+
+Preview, 11 September 2026. `1.8.5a1` let an unattended agent read its own
+output by adding thirty command names to a list. This preview stops keeping the
+list.
+
+Stable stays **1.8.4**. This is not Latest and needs an explicit pin or
+`--pre`:
+
+```bash
+python -m pip install --pre connectonion==1.8.5a2
+co --version
+```
+
+## Why a second preview
+
+The question that produced it was one sentence: *if the default were allow,
+what would the list be for?*
+
+Nothing. Enumerating what may run and enumerating what may not are
+alternatives, not layers, and the first cannot be finished — a list of safe
+command names is a list somebody has to extend for every tool anyone installs,
+and the way you learn it needs extending is that a scheduled job dies at two in
+the morning. `1.8.5a1` made that list longer. This preview replaces it.
+
+Two checks that shaped the decision. Neither reference tool on the maintainer's
+machine keeps a command allowlist: Claude Code's allow, ask and deny lists are
+all empty, and Codex has no command list at all — both constrain by boundary
+and by a reviewer. And the list was not buying what it looked like: it excluded
+`awk` and `sed` because they take a *program*, while allowing `make`, `cargo`
+and `npm`, whose Makefile, `build.rs` and `postinstall` are arbitrary
+execution.
+
+## Changes
+
+- **An ordinary command runs.** A command nobody thought of is no longer
+  refused for not being on a list. What holds one back is now a category of
+  consequence: it destroys files, reaches credentials, writes outside the
+  workspace, rewrites an authorization control file, leaves the machine, runs a
+  program the policy cannot read, or reads outside the workspace. Everything
+  `1.8.5a1` refused is still refused.
+
+- **A filter no longer needs a grant of its own.** `Bash(co browser *)` written
+  in `host.yaml` carried the command and was then defeated by `| head -40`,
+  because the chain checker read "no pattern matched this segment" as "this
+  segment is not permitted". `head` was permitted alone and refused one
+  character later. The chain checker now asks the same classifier the single
+  command would have faced; the segment the policy holds back still needs its
+  grant, so `&& co email send` is no more permitted in a chain than outside
+  one.
+
+- **A planning tool is recognised by what owns it.** `TodoList` registers
+  `add`, `start`, `complete`, `update`, `list`, `remove` and `clear`, and the
+  workflow list held `todo_list`, which is never a tool name — 438 `add` calls
+  refused in six days. Matching the method names would be wrong in both
+  directions, since `remove` is a deletion and `list` is a read for every other
+  tool, so the owning class is what marks it.
+
+- **Three rules the old list had been enforcing by omission are written down.**
+  A command whose argument is a program asks (`bash`, `python3 -c`, `awk`,
+  `sed`, and `uv run python -c`). A command that sends something to somebody
+  asks (`send`, `reply`, `post`, `publish`, `deploy`, `push`, `transfer`,
+  `pay`). A command that writes or deletes through its arguments gets the
+  workspace check (`tee`, `cp`, `mv`, `find -delete`). Each was found by the
+  flip allowing something it should not have.
+
+- **`ping`, `nc`, `telnet`, `dig` and `traceroute` join the external
+  commands.** They reached the network and were refused only because nothing
+  had named them; with the default flipped, "nobody listed it" stops being a
+  reason.
+
+- **An unnarrowed build tool asks.** `make`, `cargo`, `go`, `npm`, `gradle` and
+  `mvn` run a file of commands whenever they are not one of the verification
+  runs the policy allows by name. The policy no longer refuses `awk` while
+  running `make install`.
+
+## Measured
+
+The calls a scheduled LinkedIn round makes, with no grants at all, headless:
+
+| | refused |
+|---|---|
+| 1.8.5a1 | 12 of 17 |
+| 1.8.5a2 | 4 of 13 |
+
+Three of the four are `python3 -c`, `co email send` and `rm -rf build`.
+
+## What is not in this preview
+
+The Feishu and Lark inbox — `co feishu listen`, `co auth feishu`, the Host
+consumer — is still on its own branch and is not here. `1.8.5` stable waits for
+it and for the live reconnect-gap gate it has not yet passed.
+
+## Upgrading
+
+Nothing to change. A policy that refused more than it should now refuses less,
+and an operator grant that was being ignored is honoured. If a grant in your
+`host.yaml` was written to work around a refusal that no longer happens, it is
+harmless and can stay.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.8.5a1"
+version = "1.8.5a2"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.8.5a1"
+version = "1.8.5a2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
- **Proposed target version:** 1.8.5a2
- **Estimated release window:** now — this is the version bump; tag `v1.8.5a2` on the merge commit

Publishes **1.8.5a2**, an opt-in preview. Stable stays 1.8.4.

## Why a second preview four hours after the first

`1.8.5a1` answered #1481 by adding thirty read-only command names to an eleven-name allowlist. The maintainer's question undid it: *if the default were allow, what would the list be for?*

Nothing. This preview replaces the list. It carries #1485 (merged, `523b2fbd`) and #1487 (merged, `12b5205e`), which are both on `main` and neither of which is in a published artifact yet.

## What a user gets

- **An ordinary command runs.** A command nobody thought of is no longer refused for not being on a list. What holds one back is a category of consequence: destroys files, reaches credentials, writes outside the workspace, rewrites an authorization control file, leaves the machine, runs a program the policy cannot read, reads outside the workspace. **Everything `1.8.5a1` refused is still refused.**
- **A filter no longer needs a grant of its own** (#1488). `Bash(co browser *)` carried the command and was defeated by `| head -40`; `head` was permitted alone and refused one character later.
- **A planning tool is recognised by what owns it** (#1447). 438 `add` calls refused in six days, because `todo_list` was in the workflow list and is never a tool name.
- **Every refusal says why, how to allow it, and to think again** (#1487, already on main).
- `ping`, `nc`, `telnet`, `dig`, `traceroute` join the external commands; an unnarrowed `make` / `cargo` / `npm` asks, so the policy no longer refuses `awk` while running `make install`.

## Measured

Calls a scheduled LinkedIn round makes, with no grants at all, headless:

| | refused |
|---|---|
| 1.8.5a1 | 12 of 17 |
| this | 4 of 13 |

Three of the four are `python3 -c`, `co email send` and `rm -rf build`.

## Files

The four the checklist names — `connectonion/_version.py`, `pyproject.toml`, `VERSIONING.md`, `uv.lock` — plus `docs/releases/1.8.5a2.md` and the preview channel in `docs/releases.md`. `1.8.5a1` is kept in VERSIONING.md under a "Superseded" heading rather than deleted.

## Not in this preview

The Feishu and Lark inbox — `co feishu listen`, `co auth feishu`, the Host consumer — is on #1472 → #1480 → #1484 and is not here. `1.8.5` stable waits for it and for the live reconnect-gap gate in #1462, which has not passed.

## Evidence

```
tests/unit              8333 passed, 13 skipped   (24s)
tests/e2e                597 passed,  7 skipped   (49s)
```

`test_uv_lock_names_the_version_being_shipped` caught the lockfile before this was pushed, which is what it is for.

## Checklist
- [x] I proposed a target version and release window above
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] This PR ships its dev-blog post under docs/blog/ — the two posts for this content shipped with #1485 and #1487; a version bump has no story of its own
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published — yes: #1485 and #1487 are on main
- [ ] Maintenance-branch forward-port tracker — N/A, mainline work
- [x] Evidence the linked issues ask for: the measured before/after, and what is explicitly not in this preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3VJDT8R3Sr69BzfEBxT6
