### PR TITLE
Release ConnectOnion 1.8.5b1: the Feishu inbox, complete and frozen

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -58,7 +58,18 @@ See [1.8.4 notes](docs/releases/1.8.4.md) for migration and acceptance limits.
 The planned 1.8.4b1 was not published separately; its reviewed changes are included
 in 1.8.4. Publication is performed and verified by the immutable-tag workflow.
 
-## Release candidate: 1.8.5a2 (preview)
+## Release candidate: 1.8.5b1 (beta)
+
+Everything 1.8.5 is meant to contain is in one package: the Feishu and Lark
+inbox (`co feishu listen | receive | send | reply`, `co auth feishu`, the
+Host consumer lifespan and `co ai --listen`), and the permission work from
+the two previews. The surface is complete and frozen; what is missing is
+evidence, not code. The no-loss-across-a-reconnect gate in #1462 has not
+passed — the repair in `inbox/recovery.py` is offline-tested and has not
+been run against a real group — so 1.8.5 stable waits for it.
+See [1.8.5b1 notes](docs/releases/1.8.5b1.md).
+
+### Superseded: 1.8.5a2 (preview, published)
 
 `1.8.5a1` let an unattended agent read its own output by adding thirty
 command names to a list. This preview stops keeping the list: an ordinary
@@ -128,9 +139,17 @@ Stable remains 1.8.3; this does not authorize final 1.8.4 or cloud provisioning.
 See [1.8.4a2 notes](docs/releases/1.8.4a2.md) and the
 [local acceptance record](docs/acceptance/1.8.4-live-followup/README.md).
 
-## Current Version: 1.8.5a2
+## Current Version: 1.8.5b1
 
 ### Version History
+- 1.8.5b1 (**beta: the Feishu and Lark inbox, and the consumers that answer
+  from it.** `co auth feishu` creates the application by QR instead of
+  eleven console steps; `co <provider> listen` writes every message into
+  `~/.co/inbox/<provider>/` and acknowledges within the platform's
+  three-second window; `co ai --listen` and a Host lifespan answer from that
+  directory, one session per conversation, recorded with `via` and the
+  sender. Carries the permission work from 1.8.5a1 and 1.8.5a2. Stable
+  remains 1.8.4: the reconnect-gap gate in #1462 has not passed.)
 - 1.8.5a2 (**opt-in preview: a command runs unless a rule holds it back.**
   `1.8.5a1` answered #1481 with a longer allowlist; this replaces the list.
   Everything it refused is still refused, and three rules the list had been

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.8.5a2"
+__version__ = "1.8.5b1"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -22,25 +22,26 @@ co env
 
 ## Current preview
 
-Preview **1.8.5a2** stops keeping a list of safe command names. An ordinary
-command runs; what holds one back is a category of consequence — it destroys
-files, reaches credentials, writes outside the workspace, leaves the machine,
-or runs a program the policy cannot read. A filter no longer needs a grant of
-its own, so `Bash(co browser *)` is not defeated by `| head -40`. It is a
-preview because it widens a security default. See
-[1.8.5a2 release notes](releases/1.8.5a2.md); `1.8.5a1` answered the same
-issue with a longer allowlist and is superseded.
+Beta **1.8.5b1** completes 1.8.5: the Feishu and Lark inbox, the consumers that
+answer from it, and the permission work from the two alphas. `co auth feishu`
+creates the application by scanning a QR instead of eleven console steps;
+`co <provider> listen` writes every message into `~/.co/inbox/<provider>/`, and
+`co ai` answers the channels named in `~/.co/host.yaml` with no flags at all.
+The surface is complete and frozen. It is a beta rather than stable because the
+no-loss-across-a-reconnect gate has not passed: the repair is offline-tested and
+has not been run against a real group. See
+[1.8.5b1 release notes](releases/1.8.5b1.md).
 
 ```bash
-python -m pip install --pre connectonion==1.8.5a2
+python -m pip install --pre connectonion==1.8.5b1
 co --version
 ```
 
-The published 1.8.4a1 and 1.8.4a2 previews are historical; the planned 1.8.4b1
-was folded into the stable release. The tag workflow builds and verifies the
-public package before documentation is deployed. Google authorization from
-1.8.3 is retained. The Feishu/Lark mailbox lands when its no-loss reconnect
-gate passes; TikTok remains deferred. The sections below are historical notes.
+The 1.8.5a1 and 1.8.5a2 previews are superseded; 1.8.4a1 and 1.8.4a2 are
+historical, and the planned 1.8.4b1 was folded into the stable release. The tag
+workflow builds and verifies the public package before documentation is
+deployed. Google authorization from 1.8.3 is retained; TikTok remains deferred.
+The sections below are historical notes.
 
 ## Historical 1.7 preview work
 

--- a/docs/releases/1.8.5b1.md
+++ b/docs/releases/1.8.5b1.md
@@ -1,0 +1,113 @@
+# ConnectOnion 1.8.5b1 — beta
+
+Beta, 11 September 2026. Everything 1.8.5 is meant to contain is now in one
+package: the Feishu and Lark inbox, the consumers that answer from it, and the
+permission work that lets an unattended agent run at all.
+
+Stable stays **1.8.4**. This is not Latest and needs an explicit pin or
+`--pre`:
+
+```bash
+python -m pip install --pre connectonion==1.8.5b1
+co --version
+```
+
+## Why beta and not stable
+
+Beta here means the surface is complete and frozen, not that every claim is
+proven. One acceptance gate has not passed, and it is named below. Nothing in
+this release will change shape before 1.8.5 stable; what has to change is the
+evidence.
+
+## Your agent can be reached from a group chat
+
+```bash
+pip install lark-oapi
+co auth feishu          # scan the QR; the application exists, in your tenant
+```
+
+Then say which channels it answers, in `~/.co/host.yaml` beside the name and
+trust level it already keeps there:
+
+```yaml
+listen:
+  feishu:
+    chats: [oc_a1b2]      # absent or empty = every group the bot is in
+    mention_only: true    # a group needs an @; a direct message is already one
+```
+
+and start it the way you always did — `co ai`, or a deployed `co server`. No
+flags. `--listen` and `--no-listen` override the file for one run.
+
+**`co auth feishu` is the part worth trying first.** There used to be eleven
+steps: create a self-built app in the developer console, add three scopes whose
+names have to be exactly right, choose long connection, subscribe to one event,
+publish, copy an id and a password into a file. A missing scope was not an
+error at setup time — it was an error an hour later, in a log, when somebody
+@-mentioned the bot and nothing happened. Now it is a QR code in the terminal.
+
+## What a message does when it arrives
+
+`co <provider> listen` is the only long-running writer. It acknowledges the
+platform within its three-second window by doing nothing but writing files, and
+everything else reads them:
+
+```text
+~/.co/inbox/feishu/
+├── received.jsonl   every message, appended, never deleted
+├── sent.jsonl       every reply, and every send that failed
+├── new/  cur/       the queue: taking one is rename(2), so two consumers
+│                    never take the same message
+└── log
+```
+
+Consumers arrive by themselves. `ls new/` is the unread count, `tail -f
+received.jsonl` is a live view, and `co feishu serve -- <command>` hands each
+message to a program of your choosing. The agent consumers — `co ai --listen`
+and the Host lifespan — keep one session per conversation, so a follow-up
+remembers the question it follows, and a turn that fails leaves its message for
+the sweep rather than looking answered.
+
+On a Host, a message from a group is recorded in `.co/session_results.jsonl`
+beside the interactive turns, with `via: feishu` and the sender. In 1.8.5
+anyone who can address the bot can command it; a self-built application is
+scoped to one tenant and to the groups the bot was invited to. Sender
+allowlists are 1.9.
+
+## An unattended agent can do its job
+
+Carried from `1.8.5a1` and `1.8.5a2`:
+
+- A command runs unless a rule holds it back. There is no list of safe command
+  names to be on; what stops one is a category of consequence.
+- A filter no longer needs a grant of its own, so `Bash(co browser *)` is not
+  defeated by `| head -40`.
+- An explicit grant is an approval already given, in `host.yaml` or in a
+  skill's `tools:`.
+- Every refusal says why, how to allow it, and to think again before retrying.
+- A planning tool is recognised by what owns it, which ends 438 refused
+  TodoList calls in six days.
+
+## The gate this release has not passed
+
+**A message sent while the listener's connection is down.** On 8 September a
+scoped 135-second gap exceeded the 120-second heartbeat; the SDK reconnected,
+and the message sent during the gap was still absent from the inbox 175 seconds
+later, while a readback confirmed it existed on Lark.
+
+`inbox/recovery.py` is the repair — checkpointed history reconciliation for
+conversations the inbox already knows. It is offline-tested and **has not been
+run against a real group**. Until it has, treat delivery across a reconnect as
+unproven, and `1.8.5` stable waits for it.
+
+One smaller thing, also unproven: whether an application created by
+`co auth feishu` can be invited to a group and @-mentioned. Its long connection
+opens and it subscribes to `im.message.receive_v1`, but `/open-apis/bot/v3/info`
+answers `20008` on it where a console-made bot answers normally.
+
+## Upgrading
+
+Nothing to change. If you were using the preview `co feishu` commands from a
+branch, the package is now `connectonion.inbox`, the class is `Inbox`, the
+directory is `~/.co/inbox/<provider>/`, and `CO_FEISHU_HOME` is `CO_INBOX_HOME`.
+The verbs are unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.8.5a2"
+version = "1.8.5b1"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -25,7 +25,7 @@ keywords = [
     "xray",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.8.5a2"
+version = "1.8.5b1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
- **Proposed target version:** 1.8.5b1
- **Estimated release window:** now — this is the version bump; tag `v1.8.5b1` on the merge commit

Publishes **1.8.5b1**, a beta. Stable stays 1.8.4.

## Why beta

Everything 1.8.5 is meant to contain is on `main` as of #1491: the Feishu and Lark inbox, `co auth feishu`, the Host consumer lifespan, `co ai --listen`, and the permission work from `1.8.5a1` and `1.8.5a2`. The surface is complete and frozen.

Beta and not stable because one piece of **evidence** is missing, not one piece of code. The no-loss-across-a-reconnect gate in #1462 has not passed: on 8 September a scoped 135-second gap exceeded the 120-second heartbeat, the SDK reconnected, and the message sent during the gap was still absent from the inbox 175 seconds later while a readback confirmed it existed on Lark. `inbox/recovery.py` is the repair, it is offline-tested, and **it has not been run against a real group**.

Nothing in this release will change shape before 1.8.5 stable. What has to change is that run.

## What a user gets

- `co auth feishu` — scan a QR and the application exists, in your own tenant, credentials written. Replaces eleven developer-console steps whose mistakes only surfaced an hour later in a log.
- `co feishu listen | receive | send | reply | done | check | ls | log | serve`, and the same under `co lark`. The listener acknowledges the platform within its three-second window by doing nothing but writing files.
- `~/.co/inbox/<provider>/` — `received.jsonl` as the log, `new/` and `cur/` as the queue, taking one is `rename(2)`.
- `listen:` in `~/.co/host.yaml`, so `co ai` and `co server` answer channels with **no flags at all**; one session per conversation; a Host records the turn in `session_results.jsonl` with `via` and the sender.
- The permission work: a command runs unless a rule holds it back, a filter needs no grant of its own, an explicit grant is an approval already given, every refusal says how to allow it.

## Files

The four the checklist names — `connectonion/_version.py`, `pyproject.toml`, `VERSIONING.md`, `uv.lock` — plus `docs/releases/1.8.5b1.md` and the preview channel in `docs/releases.md`. The PyPI development status moves from `3 - Alpha` to `4 - Beta`, which `test_pypi_development_status_matches_the_release_phase` caught before this was pushed; that is what it is for.

## Evidence

```
tests/unit              9247 passed, 13 skipped   (27s)
tests/e2e                598 passed,  7 skipped   (58s)
```

## What this release does not claim

Delivery across a reconnect is unproven, as above. Separately: whether an application created by `co auth feishu` can be invited to a group and @-mentioned is untested — its long connection opens and it subscribes to `im.message.receive_v1`, but `/open-apis/bot/v3/info` answers `20008` on it where a console-made bot answers normally. Both are stated in the release notes rather than left for a user to discover.

## Checklist
- [x] I proposed a target version and release window above
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] This PR ships its dev-blog post under docs/blog/ — the posts for this content shipped with the branches it releases; a version bump has no story of its own
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published — yes: #1491, #1485, #1487 are on main
- [ ] Maintenance-branch forward-port tracker — N/A, mainline work
- [x] Evidence the linked issues ask for: test counts, and the gate this release explicitly does not close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3VJDT8R3Sr69BzfEBxT6
