### PR TITLE
docs: the names the rename left behind, including the acceptance runbook

### DIFF
--- a/docs/acceptance/1.8.5/README.md
+++ b/docs/acceptance/1.8.5/README.md
@@ -6,7 +6,8 @@ The proposed first publication is 1.8.5a1 after review and the release gates in
 
 ## Integrated work
 
-- #1398 and #1466: shared mailbox and Feishu/Lark adapter, including prior review fixes.
+- #1398, #1466 and #1472, all now on main via #1491: the shared inbox and the
+  Feishu/Lark adapter, including prior review fixes.
 - #1464: command discovery and next-step tips, reconciled with 1.8.4 env/Outlook commands.
 - #1465: messaging schedule, with stable 1.8.4 publication status retained.
 - Integration repairs: durable completion without a sent reply, original-content
@@ -36,18 +37,31 @@ claim, completion, outbound replies and one-shot serve passed. The listener
 reconnected, but a message sent during the gap was not recovered in the observed
 window. This release gate remains open.
 
-For a repeat run, keep the app ID/secret in the local
-credential store; do not paste them into this record or commit them. Create a
-new private mailbox directory for the test. First confirm there is no existing
-WebSocket listener competing for that same application; coordinate any temporary
+For a repeat run, the credential no longer has to come out of an existing
+store by hand: `co auth feishu` creates an application by QR and writes its
+pair to the selected env file, so the test can use one of its own rather than
+borrowing the application a polling workflow is already using. Either way, do
+not paste the pair into this record or commit it. Create a new private inbox
+root for the test. If you do reuse an existing application, first confirm no
+other WebSocket listener is competing for it, and coordinate any temporary
 pause of the existing polling workflow with its owner.
 
+A fresh application has one thing to check before the run proper: add its bot
+to the test group and @-mention it once. An application created by
+`co auth feishu` opens its long connection and subscribes to
+`im.message.receive_v1`, but whether it is invitable and addressable as a group
+bot is itself untested — `/open-apis/bot/v3/info` answers `20008` on one where
+a console-made bot answers normally.
+
 1. Run `co --env-file TEST_ENV lark check` (or `feishu`) from the candidate.
-2. Run `CO_LARK_HOME=TEST_HOME co --env-file TEST_ENV lark listen` in the foreground.
+2. Run `CO_INBOX_HOME=TEST_HOME co --env-file TEST_ENV lark listen` in the
+   foreground. The provider's directory is created under that root, so the
+   test inbox is `TEST_HOME/lark/`. `CO_LARK_HOME` no longer exists; using it
+   would write to the operator's own `~/.co/inbox/lark/`.
 3. Have the tester post an @-mention containing a unique `co185-acceptance-...`
    marker. Record provider timestamp and arrival time locally; export only the
    synthetic marker, latency and pass/fail, not chat/sender IDs or other messages.
-4. Run two `receive --no-start -t 0` consumers against that mailbox. Only one may
+4. Run two `receive --no-start -t 0` consumers against that inbox. Only one may
    obtain the test message; the other times out with 124. Mark the message done.
 5. Exercise a bounded fault affecting only the test listener's connection, longer
    than its heartbeat. Verify reconnect logs and compare exact marker IDs before,

--- a/docs/cli/youtube.md
+++ b/docs/cli/youtube.md
@@ -96,7 +96,7 @@ See [videos.insert](https://developers.google.com/youtube/v3/docs/videos/insert)
 
 No search, analytics, captions, comments, playlist editing, deletion, scheduling
 or media download ships here. TikTok is excluded from this Google-only release
-and deferred until after 1.8.5.
+and remains deferred; see #1426 and the preview in #1439.
 
 Exit 0 means a read/preview/write result; exit 1 means an operational failure
 with a sanitized cause and next command; exit 2 is a Typer usage error. Preview

--- a/docs/design-decisions/063-one-directory-three-verbs.md
+++ b/docs/design-decisions/063-one-directory-three-verbs.md
@@ -49,6 +49,12 @@ seconds, retries, and documents a message id to dedupe on. Maildir solved
 "many writers, many readers, no locks, crash-safe" for mail in 1995 with a
 directory and `rename(2)`.
 
+> **Names changed after this was written.** The package is
+> `connectonion/inbox/`, the class is `Inbox`, the directory is
+> `~/.co/inbox/<provider>/` with `received.jsonl` and `sent.jsonl` inside, and
+> one `CO_INBOX_HOME` moves the whole root. The decision below is unchanged;
+> only its spelling is. See the addendum at the end (#1478).
+
 ## Decision
 
 ### The tool turns messages into files. Consumers come by themselves.


### PR DESCRIPTION
- **Proposed target version:** 1.8.5 (stable, or the next preview — docs only)
- **Estimated release window:** with 1.8.5 stable

Closes #1465. Four places still spelled things the way they were before `connectonion/inbox/` landed on main via #1491.

## The one that mattered

`docs/acceptance/1.8.5/README.md` is the procedure for the gate that is holding 1.8.5 stable, and its step 2 read:

```bash
CO_LARK_HOME=TEST_HOME co --env-file TEST_ENV lark listen
```

`CO_LARK_HOME` no longer exists. A tester following that exactly would write into the operator's own `~/.co/inbox/lark/` — next to the polling workflow the same paragraph warns about competing with — instead of the isolated directory the procedure is careful to create. It is `CO_INBOX_HOME` now, and the provider's directory is created under that root, so the test inbox is `TEST_HOME/lark/`.

The same runbook told the tester to keep the app id and secret in an existing credential store, because when it was written there was no other way to get them. `co auth feishu` shipped in `1.8.5b1`, so a repeat run can create an application of its own by QR rather than borrowing the one the polling workflow is using — which removes the competing-listener warning's main cause rather than working around it. It gains one step for the thing that is untested about such an application: whether it can be invited to a group and @-mentioned at all.

## The other three

- **DD-063**'s Decision section still names `connectonion/listen/` and `CO_FEISHU_HOME`. A decision record is not rewritten when the thing it decided gets renamed, so this adds a note where the reader meets the old names, pointing at the addendum that records the new ones.
- **`docs/cli/youtube.md`** said TikTok was deferred "until after 1.8.5", which is a date in the past rather than a schedule. Now points at #1426 and #1439.
- **`docs/releases/google-1.8.3-checklist.md`** already carries its own correction note and is left alone, which is the right pattern for a historical record.

## Evidence

```
tests/unit              9247 passed, 13 skipped   (28s)
```

Docs only; no source file is touched. Verified by grep that no `CO_LARK_HOME`, `CO_FEISHU_HOME` or `connectonion/listen` reference remains outside `docs/blog/` (where posts are dated records) and the DD's own historical body.

## Checklist
- [x] I proposed a target version and release window above
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — this is that change
- [ ] This PR ships its dev-blog post under docs/blog/ — a stale-name sweep has no story
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published — yes: #1491 and 1.8.5b1
- [ ] Maintenance-branch forward-port tracker — N/A, mainline work
- [x] Evidence the linked issue asks for: the grep, and what was deliberately left alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3VJDT8R3Sr69BzfEBxT6
