### PR TITLE
co auth feishu --app-id: authorize the bot you already have

### DIFF
--- a/connectonion/cli/commands/feishu_auth.py
+++ b/connectonion/cli/commands/feishu_auth.py
@@ -16,19 +16,32 @@ the scanner's tenant and returns its credentials to whoever started the flow.
 The request that begins it carries no client identity, so this is a public
 protocol and not a private channel for the official CLI.
 
-What one scan does not do: it cannot list the applications you already own —
-no such API exists — so this always creates a new one rather than offering a
-choice. Which application it becomes is decided on Feishu's own confirmation
-page, which is the right place for that decision to be made.
+What one scan does not do: no API lists the applications you own, so the
+choice of which application this becomes is made on Feishu's own confirmation
+page. `--app-id` names one up front, which is how you reuse a bot that is
+already in the group with its permissions set instead of creating one that is
+in no group at all.
+
+Where that id comes from, if `lark-cli` is installed: its `config.json` records
+an app id per application in plain text. The *secret* beside it is a keychain
+reference, and this never reads it. Copying a keychain entry into a plaintext
+env file is a downgrade wearing the word "import" (#1497); scanning gets the
+same credential with the platform's consent instead of the operating system's.
 """
 
 import io
+import re
 import sys
+from pathlib import Path
+from typing import Optional
 
 from ...environment import display_path, selected_env_file
 from ...env_file import upsert_env
 
 SDK_MISSING = "The Feishu SDK is not installed. Run: pip install lark-oapi"
+
+# What the platform issues. Checked so a typo fails now rather than on a page.
+_APP_ID = re.compile(r"^cli_[A-Za-z0-9]{8,}$")
 
 # Shown on Feishu's confirmation page, so that a person looking at their list
 # of applications a month from now knows what this one is and who made it.
@@ -47,6 +60,48 @@ def _register_app():
     return register_app
 
 
+def lark_cli_applications() -> list:
+    """Application ids `lark-cli` has configured, from its plaintext config.
+
+    Ids only. `appSecret` there is `{"source": "keychain", "id": …}` and is
+    left alone. A config that is missing, unreadable or not JSON yields
+    nothing: this is a convenience, and a broken one must not stop a scan.
+    """
+    import json
+
+    config = Path.home() / ".lark-cli" / "config.json"
+    try:
+        data = json.loads(config.read_text(encoding="utf-8"))
+        apps = data.get("apps") or []
+    except Exception:
+        return []
+    found = []
+    for app in apps:
+        if not isinstance(app, dict) or not app.get("appId"):
+            continue
+        users = app.get("users") or []
+        user = users[0].get("userName") if users and isinstance(users[0], dict) else None
+        found.append({"app_id": str(app["appId"]),
+                      "brand": str(app.get("brand") or ""),
+                      "user": user})
+    return found
+
+
+def _offer_existing() -> None:
+    """Say that a reusable application is already configured, before creating one."""
+    apps = lark_cli_applications()
+    if not apps:
+        return
+    print(f"lark-cli has {len(apps)} application(s) configured on this machine:")
+    for app in apps:
+        who = f"  ({app['user']})" if app["user"] else ""
+        print(f"  {app['app_id']}  {app['brand']}{who}")
+    print("To authorize one of those instead of creating a new one, and keep the")
+    print("groups and permissions it already has:")
+    print(f"  co auth feishu --app-id {apps[0]['app_id']}")
+    print()
+
+
 def _qr(url: str) -> str:
     import qrcode
 
@@ -59,16 +114,28 @@ def _qr(url: str) -> str:
     return out.getvalue()
 
 
-def handle_feishu_auth(brand: str = "feishu") -> None:
-    """Create the application by scanning, and save what it needs to run."""
+def handle_feishu_auth(brand: str = "feishu", app_id: Optional[str] = None) -> None:
+    """Create the application by scanning, or authorize one you already have."""
+    if app_id is not None:
+        # Checked before the scan: a typo here sends someone to a page that
+        # cannot work, and they find out after waiting for a QR to expire.
+        if not _APP_ID.match(app_id):
+            print(f"{app_id!r} is not an application id. They look like cli_a1b2c3d4e5f6g7h8 "
+                  "and are shown by `co auth feishu` when lark-cli has any configured.")
+            raise SystemExit(2)
     try:
         register_app = _register_app()
     except RuntimeError as error:
         print(str(error))
         raise SystemExit(3)
 
-    print("Creating a Feishu application. Scan this with the Feishu or Lark app,")
-    print("or open the link, and approve it. The application is yours, in your tenant.")
+    if app_id is None:
+        _offer_existing()
+        print("Creating a Feishu application. Scan this with the Feishu or Lark app,")
+        print("or open the link, and approve it. The application is yours, in your tenant.")
+    else:
+        print(f"Authorizing {app_id}. Scan this with the Feishu or Lark app, or open")
+        print("the link, and approve it. Its groups and permissions are unchanged.")
     print()
 
     def show(info) -> None:
@@ -79,11 +146,15 @@ def handle_feishu_auth(brand: str = "feishu") -> None:
         print("Waiting for approval. Ctrl-C to stop.")
 
     try:
-        result = register_app(
-            on_qr_code=show,
-            app_preset=dict(APP_PRESET),
-            source="connectonion",
-        )
+        options = {"source": "connectonion"}
+        if app_id is None:
+            # A preset only pre-fills the creation page, so it is meaningless
+            # — and confusing — when the application already exists and has a
+            # name its owner chose.
+            options["app_preset"] = dict(APP_PRESET)
+        else:
+            options["app_id"] = app_id
+        result = register_app(on_qr_code=show, **options)
     except KeyboardInterrupt:
         print("Stopped. Nothing was saved.")
         raise SystemExit(1)

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -230,10 +230,15 @@ def deploy(
 
 @app.command()
 def auth(service: Optional[str] = typer.Argument(None, help="Service: google, microsoft, feishu, lark"),
-         scopes: Optional[str] = typer.Option(None, "--scopes", help="Google: comma-separated limited scopes. Default: Gmail, Calendar, Drive and YouTube.")):
+         scopes: Optional[str] = typer.Option(None, "--scopes", help="Google: comma-separated limited scopes. Default: Gmail, Calendar, Drive and YouTube."),
+         app_id: Optional[str] = typer.Option(None, "--app-id", metavar="cli_…",
+                                              help="Feishu/Lark: authorize an application you already have, keeping its groups and permissions")):
     """Authenticate with OpenOnion."""
     if scopes is not None and service != "google":
         print("--scopes is only supported for Google. Next: co auth google --help")
+        raise typer.Exit(2)
+    if app_id is not None and service not in ("feishu", "lark"):
+        print("--app-id is only supported for Feishu and Lark. Next: co auth feishu --help")
         raise typer.Exit(2)
     if service == "google":
         from .commands.auth_commands import handle_google_auth
@@ -243,7 +248,7 @@ def auth(service: Optional[str] = typer.Argument(None, help="Service: google, mi
         handle_microsoft_auth()
     elif service in ("feishu", "lark"):
         from .commands.feishu_auth import handle_feishu_auth
-        handle_feishu_auth(brand=service)
+        handle_feishu_auth(brand=service, app_id=app_id)
     else:
         from .commands.auth_commands import handle_auth
         handle_auth()

--- a/docs/cli/feishu.md
+++ b/docs/cli/feishu.md
@@ -18,7 +18,15 @@ co auth feishu
 
 `co auth feishu` prints a QR code and a link. Scan it with Feishu or Lark,
 approve, and the application exists — in your own tenant, owned by you — with
-its credentials written to `~/.co/keys.env`. There is no developer console to
+its credentials written to `~/.co/keys.env`.
+
+**Already have a bot?** `co auth feishu --app-id cli_…` authorizes that one
+instead of creating a new one, so it keeps the groups it is already in and the
+permissions already granted to it — which is usually what you want, since a new
+application is in no group at all. If `lark-cli` is installed, `co auth feishu`
+lists the application ids it has configured so you can copy one. It reads only
+the ids: the secret beside them is a keychain reference, and copying that into
+a plaintext file would be a downgrade (#1497). There is no developer console to
 visit and nothing to copy. It starts on Feishu and moves to Lark by itself if
 that is where your tenant lives, so there is nothing to choose first either.
 

--- a/tests/unit/test_feishu_auth_existing.py
+++ b/tests/unit/test_feishu_auth_existing.py
@@ -1,0 +1,140 @@
+"""
+LLM-Note: Tests for authorizing an application you already have —
+`co auth feishu --app-id`. The point is reuse: a bot that is already in the
+group with its permissions set, rather than a new one that is in no group.
+Also the lark-cli hint, which reads app ids from a plaintext config and never
+touches the secret those ids are keyed to.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from connectonion.cli.commands import feishu_auth
+
+
+class FakeRegistration:
+    def __init__(self, brand="feishu"):
+        self.kwargs = None
+        self.brand = brand
+
+    def __call__(self, on_qr_code, on_status_change=None, **kwargs):
+        self.kwargs = kwargs
+        on_qr_code({"url": "https://open.feishu.cn/page/cli?user_code=ABC", "expire_in": 600})
+        return {"client_id": kwargs.get("app_id") or "cli_new",
+                "client_secret": "secret-x",
+                "user_info": {"open_id": "ou_me", "tenant_brand": self.brand}}
+
+
+@pytest.fixture
+def rig(tmp_path, monkeypatch):
+    # conftest's _never_touch_the_real_home already points HOME at its own
+    # temp directory, and that is the one Path.home() resolves to. Writing a
+    # fake lark-cli config anywhere else would be writing where nothing looks.
+    monkeypatch.setenv("AGENT_CONFIG_PATH", str(tmp_path / ".co"))
+    (tmp_path / ".co").mkdir(parents=True, exist_ok=True)
+    written = {}
+    monkeypatch.setattr(feishu_auth, "upsert_env",
+                        lambda path, values: written.setdefault(str(path), {}).update(values))
+    return tmp_path, written
+
+
+def lark_cli_config(apps):
+    directory = Path.home() / ".lark-cli"
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "config.json").write_text(json.dumps({"currentApp": apps[0]["appId"], "apps": apps}))
+    return directory / "config.json"
+
+
+class TestAuthorizingAnApplicationYouAlreadyHave:
+    def test_the_app_id_is_passed_to_the_scan(self, rig, monkeypatch):
+        register = FakeRegistration()
+        monkeypatch.setattr(feishu_auth, "_register_app", lambda: register)
+        feishu_auth.handle_feishu_auth(app_id="cli_existing")
+        assert register.kwargs["app_id"] == "cli_existing"
+
+    def test_its_credentials_are_what_gets_saved(self, rig, monkeypatch):
+        tmp_path, written = rig
+        register = FakeRegistration()
+        monkeypatch.setattr(feishu_auth, "_register_app", lambda: register)
+        feishu_auth.handle_feishu_auth(app_id="cli_existing")
+        values = next(iter(written.values()))
+        assert values["FEISHU_APP_ID"] == "cli_existing"
+        assert values["FEISHU_APP_SECRET"] == "secret-x"
+
+    def test_creating_a_new_one_passes_no_app_id(self, rig, monkeypatch):
+        register = FakeRegistration()
+        monkeypatch.setattr(feishu_auth, "_register_app", lambda: register)
+        feishu_auth.handle_feishu_auth()
+        assert register.kwargs.get("app_id") is None
+
+    def test_an_app_id_that_is_not_one_is_refused_before_the_scan(self, rig, monkeypatch, capsys):
+        register = FakeRegistration()
+        monkeypatch.setattr(feishu_auth, "_register_app", lambda: register)
+        with pytest.raises(SystemExit) as exit:
+            feishu_auth.handle_feishu_auth(app_id="not-an-app-id")
+        assert exit.value.code == 2
+        assert register.kwargs is None, "the scan started before the id was checked"
+        assert "cli_" in capsys.readouterr().out
+
+
+class TestTheHintFromLarkCli:
+    """Reading app ids from lark-cli's plaintext config. Never the secret:
+    that lives in the OS keychain, keyed by an id in this same file, and
+    copying it out would downgrade it into a plaintext env file."""
+
+    def test_configured_applications_are_offered(self, rig, monkeypatch, capsys):
+        tmp_path, _ = rig
+        lark_cli_config([
+            {"appId": "cli_aaa", "brand": "lark",
+             "appSecret": {"source": "keychain", "id": "appsecret:cli_aaa"},
+             "users": [{"userName": "xie Aaron"}]},
+            {"appId": "cli_bbb", "brand": "feishu", "appSecret": {"source": "keychain"}},
+        ])
+        register = FakeRegistration()
+        monkeypatch.setattr(feishu_auth, "_register_app", lambda: register)
+        feishu_auth.handle_feishu_auth()
+        out = capsys.readouterr().out
+        assert "cli_aaa" in out and "cli_bbb" in out
+        assert "--app-id" in out
+
+    def test_the_secret_is_never_read_or_shown(self, rig, monkeypatch, capsys):
+        tmp_path, _ = rig
+        lark_cli_config([
+            {"appId": "cli_aaa", "brand": "lark",
+             "appSecret": {"source": "keychain", "id": "appsecret:cli_aaa"}},
+        ])
+        register = FakeRegistration()
+        monkeypatch.setattr(feishu_auth, "_register_app", lambda: register)
+        feishu_auth.handle_feishu_auth()
+        out = capsys.readouterr().out
+        assert "appsecret:" not in out
+        assert "keychain" not in out.lower()
+
+    def test_no_lark_cli_means_no_hint_and_no_error(self, rig, monkeypatch, capsys):
+        register = FakeRegistration()
+        monkeypatch.setattr(feishu_auth, "_register_app", lambda: register)
+        feishu_auth.handle_feishu_auth()
+        assert "--app-id" not in capsys.readouterr().out
+
+    def test_a_config_that_does_not_parse_is_not_an_error(self, rig, monkeypatch):
+        directory = Path.home() / ".lark-cli"
+        directory.mkdir()
+        (directory / "config.json").write_text("{ not json")
+        register = FakeRegistration()
+        monkeypatch.setattr(feishu_auth, "_register_app", lambda: register)
+        feishu_auth.handle_feishu_auth()          # must not raise
+        assert register.kwargs is not None
+
+    def test_reading_it_finds_the_ids(self, rig):
+        tmp_path, _ = rig
+        lark_cli_config([
+            {"appId": "cli_aaa", "brand": "lark", "users": [{"userName": "xie Aaron"}]},
+            {"appId": "cli_bbb", "brand": "feishu"},
+        ])
+        found = feishu_auth.lark_cli_applications()
+        assert [a["app_id"] for a in found] == ["cli_aaa", "cli_bbb"]
+        assert found[0]["brand"] == "lark"
+        assert found[0]["user"] == "xie Aaron"
+        assert "secret" not in json.dumps(found).lower()


### PR DESCRIPTION
- **Proposed target version:** 1.8.5 (with stable, or the next preview)
- **Estimated release window:** next preview

## The case the default gets wrong

`co auth feishu` creates an application. That is right for a first setup and wrong for the case that comes up most: **the bot is already in the group**, with its permissions granted and its name known to the people there. A newly created application is in no group at all, so using it means inviting it everywhere again and re-granting everything.

```bash
co auth feishu --app-id cli_a1b2c3d4e5f6g7h8
```

authorizes that one. The SDK passes the id to the confirmation page as `clientID`, so the page authorizes an existing application rather than creating another, and the poll returns its credentials. Its groups and permissions are untouched.

## Where the id comes from

If `lark-cli` is installed, `co auth feishu` now lists the applications in its `config.json`:

```
lark-cli has 2 application(s) configured on this machine:
  cli_aa0036322bba1e18  lark  (xie Aaron)
  cli_aa0651973ef89e14  lark
To authorize one of those instead of creating a new one, and keep the
groups and permissions it already has:
  co auth feishu --app-id cli_aa0036322bba1e18
```

**It reads only the ids.** The original request was to import the credential outright, and the honest answer is that we should not: `lark-cli` keeps its secret in the OS keychain — the config holds `{"source": "keychain", "id": "appsecret:cli_…"}` — and copying a keychain entry into a plaintext env file is a downgrade wearing the word "import". Scanning obtains the same credential with the **platform's** consent rather than the **operating system's**, needs no crypto reimplementation, prompts nobody's keychain, and works on a machine that never had `lark-cli`. Moving our own secrets the other way, into the keychain, is filed as #1497 for 2.5.

## Details worth the line they cost

- An id that is not one is refused **before** the scan starts. Otherwise the failure is a page that cannot work and a QR that expires while you wait for it.
- `--app-id` on `co auth google` exits 2 and says which services take it, matching how `--scopes` already behaves.
- No `app_preset` is sent when an application already exists: a preset only pre-fills the creation page, so sending one is meaningless and the name it suggests is not the name its owner chose.
- A `lark-cli` config that is missing, unreadable or not JSON yields nothing and stops nothing. This is a convenience; a broken one must not block a scan.

## Evidence

```
tests/unit              9258 passed, 13 skipped   (27s)
```

`tests/unit/test_feishu_auth_existing.py`, 9 cases written failing first, including two that pin what is *not* read: the printed output never contains `appsecret:` or the word keychain, and the parsed result has no field with "secret" in it.

CLI surface, against a built CLI in a temp HOME:

| check | result |
|---|---|
| `co auth --help` carries `--app-id` | yes |
| `--app-id` on `co auth google` | exit 2, names Feishu and Lark |
| a malformed app id | exit 2, shows the shape |
| `--scopes` still Google-only | exit 2 |

One test-authoring note: the fixture writes the fake `lark-cli` config into `Path.home()` rather than `tmp_path`, because conftest's `_never_touch_the_real_home` already repoints HOME and that is the directory the code resolves. Writing anywhere else was writing where nothing looks — the first version of these tests failed for exactly that reason.

## Checklist
- [x] I proposed a target version and release window above
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] This PR ships its dev-blog post under docs/blog/ — a flag on an existing command; the story shipped with `co auth feishu` itself
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published — yes: `co auth feishu` is in 1.8.5b1
- [ ] Maintenance-branch forward-port tracker — N/A, mainline work
- [x] Evidence the linked issue asks for: the test counts, the CLI table, and what this deliberately does not read

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3VJDT8R3Sr69BzfEBxT6
