### PR TITLE
Release ConnectOnion 1.8.5b2: the settings b1 made you repeat

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -58,7 +58,18 @@ See [1.8.4 notes](docs/releases/1.8.4.md) for migration and acceptance limits.
 The planned 1.8.4b1 was not published separately; its reviewed changes are included
 in 1.8.4. Publication is performed and verified by the immutable-tag workflow.
 
-## Release candidate: 1.8.5b1 (beta)
+## Release candidate: 1.8.5b2 (beta)
+
+Four things `b1` made you type or guess: `co browser config` sets a default
+engine so `--engine` is an override rather than the only way in; the paid
+engine is called `wtf`, its product name; `serve` is `consume`; and
+`co auth feishu --app-id` authorizes a bot you already have. Every exit on
+the inbox surface now names a command to run next, and a `co-inbox` skill
+ships with a test that diffs it against `--help`. Stable remains 1.8.4: the
+reconnect-gap gate in #1462 has not passed.
+See [1.8.5b2 notes](docs/releases/1.8.5b2.md).
+
+### Superseded: 1.8.5b1 (beta, published)
 
 Everything 1.8.5 is meant to contain is in one package: the Feishu and Lark
 inbox (`co feishu listen | receive | send | reply`, `co auth feishu`, the
@@ -139,9 +150,15 @@ Stable remains 1.8.3; this does not authorize final 1.8.4 or cloud provisioning.
 See [1.8.4a2 notes](docs/releases/1.8.4a2.md) and the
 [local acceptance record](docs/acceptance/1.8.4-live-followup/README.md).
 
-## Current Version: 1.8.5b1
+## Current Version: 1.8.5b2
 
 ### Version History
+- 1.8.5b2 (**beta: the settings b1 made you repeat.** `co browser config`
+  gives the browser engine a default so `--engine` becomes an override; the
+  paid engine is `wtf`, not `onion`; `co <provider> serve` is `consume`;
+  `co auth feishu --app-id` reuses a bot already in your groups. Every exit
+  on the inbox surface names a command, and a co-inbox skill ships with a
+  two-way parity test. Stable remains 1.8.4.)
 - 1.8.5b1 (**beta: the Feishu and Lark inbox, and the consumers that answer
   from it.** `co auth feishu` creates the application by QR instead of
   eleven console steps; `co <provider> listen` writes every message into

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.8.5b1"
+__version__ = "1.8.5b2"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -22,24 +22,27 @@ co env
 
 ## Current preview
 
-Beta **1.8.5b1** completes 1.8.5: the Feishu and Lark inbox, the consumers that
-answer from it, and the permission work from the two alphas. `co auth feishu`
-creates the application by scanning a QR instead of eleven console steps;
-`co <provider> listen` writes every message into `~/.co/inbox/<provider>/`, and
-`co ai` answers the channels named in `~/.co/host.yaml` with no flags at all.
-The surface is complete and frozen. It is a beta rather than stable because the
-no-loss-across-a-reconnect gate has not passed: the repair is offline-tested and
-has not been run against a real group. See
-[1.8.5b1 release notes](releases/1.8.5b1.md).
+Beta **1.8.5b2** adds the settings `b1` made you repeat. `co browser config`
+gives the browser engine a default, so `--engine` is an override rather than
+the only way in, and the paid engine is called `wtf` — its product name — where
+the flag used to say `onion`. `co <provider> serve` is now `consume`, and
+`co auth feishu --app-id` authorizes a bot already in your groups instead of
+creating one that is in none. Every exit on the inbox surface names a command
+to run next.
+
+It is a beta because the no-loss-across-a-reconnect gate has not passed: the
+repair is offline-tested and has not been run against a real group. The release
+notes list what else to decide before putting it on a machine other people use.
+See [1.8.5b2 release notes](releases/1.8.5b2.md).
 
 ```bash
-python -m pip install --pre connectonion==1.8.5b1
+python -m pip install --pre connectonion==1.8.5b2
 co --version
 ```
 
-The 1.8.5a1 and 1.8.5a2 previews are superseded; 1.8.4a1 and 1.8.4a2 are
-historical, and the planned 1.8.4b1 was folded into the stable release. The tag
-workflow builds and verifies the public package before documentation is
+The 1.8.5a1, 1.8.5a2 and 1.8.5b1 previews are superseded; 1.8.4a1 and 1.8.4a2
+are historical, and the planned 1.8.4b1 was folded into the stable release. The
+tag workflow builds and verifies the public package before documentation is
 deployed. Google authorization from 1.8.3 is retained; TikTok remains deferred.
 The sections below are historical notes.
 

--- a/docs/releases/1.8.5b2.md
+++ b/docs/releases/1.8.5b2.md
@@ -1,0 +1,81 @@
+# ConnectOnion 1.8.5b2 — beta
+
+Beta, 12 September 2026. Four changes on top of `1.8.5b1`, all of them things
+`b1` made you type or guess.
+
+Stable stays **1.8.4**. This is not Latest and needs an explicit pin or
+`--pre`:
+
+```bash
+python -m pip install --pre connectonion==1.8.5b2
+co --version
+```
+
+## Changes
+
+**`co browser config` — a default engine you set once.** `--engine onion` was
+required on every paid browser call, which a person testing the WTF Browser
+types a hundred times a day and an agent drops at one call site out of twenty.
+When it is dropped the free engine runs and reports success, so the thing under
+test was never tested.
+
+```bash
+co browser config wtf        # this machine's default, written to ~/.co/keys.env
+co browser config            # what it is, and whether it came from the file or your shell
+co browser --engine system … # free for one run, no file edited
+```
+
+With nothing configured the default is still system Chrome. `--engine`
+overrides in both directions.
+
+**The paid engine is called `wtf`.** It is the WTF Browser everywhere a person
+reads it, including in the same help line that used to spell the flag `onion`.
+`--engine onion` still works and says the new spelling once.
+
+**`co <provider> serve` is now `co <provider> consume`.** Nothing about it
+served anything: it takes messages off a queue and hands each to a program,
+which is what a consumer does. The old name is gone rather than aliased — this
+CLI ships no hidden commands — but typing it answers with the new one and the
+command to run next.
+
+**`co auth feishu --app-id cli_…`** authorizes a bot you already have instead of
+creating a new one, keeping the groups it is in and the permissions already
+granted to it. A freshly created application is in no group at all, so reusing
+one is usually what you want. If `lark-cli` is installed, `co auth feishu`
+lists the application ids it has configured; it reads only the ids, never the
+secret beside them.
+
+**Every exit on the inbox surface names a command to run next.** An audit found
+four that did not: the credential message named a web page, a timeout printed
+nothing at all, the renamed verb rendered a traceback around one sentence, and
+a usage error offered a flag. There is also now a `co-inbox` skill, and a test
+that diffs it against `--help` in both directions.
+
+## Before you put this on a server other people use
+
+Four things are true of this beta that are fine on your own laptop and are
+decisions on a shared machine. None is a defect; each is a default worth
+choosing deliberately.
+
+- **A chat message can command the agent, and anyone who can address the bot
+  can send one.** In 1.8.5 there is no sender allowlist — that is 1.9 (#1479).
+  A self-built Feishu application is scoped to one tenant and to the groups the
+  bot was invited to, so on a customer's server "anyone" means everyone in that
+  company who is in those groups. Decide which groups before the bot joins
+  them; `listen: feishu: chats: [...]` in `host.yaml` is the narrowing.
+- **An ordinary command runs without asking.** `1.8.5a2` replaced the
+  allowlist with categories of consequence: destroying files, credentials,
+  writes outside the workspace, leaving the machine and running unreadable
+  input still stop. Everything else runs. That is the right default for an
+  unattended job and a bigger blast radius on a machine that is not yours.
+- **Delivery across a reconnect is unproven.** The gate in #1462 has not
+  passed: a message sent while the listener's connection was down was not
+  recovered in the observed window. Treat a gap as possible message loss.
+- **A configured paid engine bills every browser call.** If you set
+  `CO_BROWSER_ENGINE=wtf` on a shared machine, every browser command there is a
+  paid session on your account. The log distinguishes those from ones a flag
+  asked for.
+
+## Upgrading from b1
+
+`co feishu serve` becomes `co feishu consume`. Nothing else changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.8.5b1"
+version = "1.8.5b2"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/unit/test_inbox_consumer.py
+++ b/tests/unit/test_inbox_consumer.py
@@ -126,16 +126,34 @@ class TestLease:
         inbox = box(tmp_path)
         put(inbox, "m1")
         working, release = threading.Event(), threading.Event()
+        renewals = []
+        real_renew = inbox.renew
+
+        def counted(message_id):
+            result = real_renew(message_id)
+            renewals.append(message_id)
+            return result
+
+        inbox.renew = counted
 
         def handler(message):
             working.set()
-            release.wait(5)
+            release.wait(10)
 
         stop, thread = drain(inbox, handler, lease_seconds=0.05)
-        assert working.wait(5)
-        time.sleep(0.4)
-        # A sweep with a window far shorter than the handler has been running.
-        assert inbox.release_stale(max_age=0.2) == 0, "the lease was not renewed"
+        assert working.wait(10)
+        # Wait for renewals to have demonstrably happened, not for a duration.
+        # A fixed sleep asserts that a background thread was scheduled inside
+        # a wall-clock window, which a loaded CI runner does not promise — this
+        # test failed exactly that way on 3.11 before it was written this way.
+        deadline = time.monotonic() + 10
+        while len(renewals) < 2 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert len(renewals) >= 2, "the lease was never renewed"
+
+        # The claim was made long before the last renewal, so a window that
+        # would have reclaimed it finds nothing: the timestamp moved.
+        assert inbox.release_stale(max_age=0.05) == 0, "the renewal did not move the clock"
         release.set()
         settle(inbox, stop, thread, until=lambda: inbox.completed.exists())
 

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.8.5b1"
+version = "1.8.5b2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
- **Proposed target version:** 1.8.5b2
- **Estimated release window:** now — tag `v1.8.5b2` on the merge commit

Publishes **1.8.5b2**, a beta. Stable stays 1.8.4. Carries the four changes merged since `b1`: #1495, #1498, #1500, #1504.

## What a user gets

- **`co browser config`** — a default engine, set once, written to `~/.co/keys.env`. `--engine` overrides in both directions; unset still means system Chrome.
- **The paid engine is `wtf`**, its product name. `--engine onion` still works and says the new spelling once.
- **`co <provider> consume`** replaces `serve`. The old name is gone rather than aliased, and typing it answers with the new one.
- **`co auth feishu --app-id cli_…`** authorizes a bot already in your groups instead of creating one that is in none.
- **Every exit on the inbox surface names a command**, plus a `co-inbox` skill with a two-way `--help` parity test.

## The section this release adds and `b1` did not

The maintainer is putting this on a customer's server, so the notes now say what to decide before a machine other people use:

- **A chat message can command the agent and there is no sender allowlist** until 1.9 (#1479). On a customer's tenant, "anyone who can address the bot" is everyone in the groups it joined. `listen: feishu: chats: [...]` is the narrowing, and it should be chosen before the bot joins anything.
- **An ordinary command runs without asking** (1.8.5a2). The categories that stop still stop; the blast radius is different on a machine that is not yours.
- **Delivery across a reconnect is unproven** — the #1462 gate.
- **A configured paid engine bills every browser call** on that machine.

None is a defect. Each is a default that is fine on a laptop and a decision on a shared server.

## Files

The four the checklist names, plus `docs/releases/1.8.5b2.md` and the preview channel. The PyPI development status is already `4 - Beta` from `b1`.

## Evidence

```
tests/unit              9310 passed, 12 skipped   (32s)
```

## Checklist
- [x] I proposed a target version and release window above
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] This PR ships its dev-blog post under docs/blog/ — the posts shipped with the branches this releases
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published — yes, all four are on main
- [ ] Maintenance-branch forward-port tracker — N/A, mainline work
- [x] Evidence the linked issues ask for: the test count, and what this release explicitly does not claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3VJDT8R3Sr69BzfEBxT6
