### PR TITLE
fix(tools): prune ignored dirs during grep walk and cap files visited

### DIFF
--- a/connectonion/useful_tools/file_tools/grep.py
+++ b/connectonion/useful_tools/file_tools/grep.py
@@ -13,6 +13,8 @@ Usage:
     grep("import", output_mode="count")        # Count imports per file
 """
 
+import fnmatch
+import os
 import re
 from pathlib import Path
 from typing import Literal, Optional
@@ -29,6 +31,7 @@ def grep(
     context_lines: int = 0,
     ignore_case: bool = False,
     max_results: int = 50,
+    max_files: int = 20000,
 ) -> str:
     """
     Search for content in files using regex.
@@ -44,6 +47,7 @@ def grep(
         context_lines: Number of lines to show before/after match (for content mode)
         ignore_case: Case insensitive search
         max_results: Maximum number of results to return
+        max_files: Maximum number of candidate files to visit before stopping with a truncation note
 
     Returns:
         Search results based on output_mode
@@ -69,13 +73,24 @@ def grep(
     # Collect files to search
     if base.is_file():
         files = [base]
+        capped = False
     else:
-        if file_pattern:
-            files = list(base.glob(f"**/{file_pattern}"))
-        else:
-            files = list(base.glob("**/*"))
-
-        files = [f for f in files if f.is_file() and not _should_ignore(f) and _is_text_file(f)]
+        files = []
+        capped = False
+        for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [d for d in dirnames if not _is_ignored_dir(d)]
+            for name in filenames:
+                if file_pattern and not fnmatch.fnmatch(name, file_pattern):
+                    continue
+                f = Path(dirpath) / name
+                if not f.is_file() or _should_ignore(f) or not _is_text_file(f):
+                    continue
+                files.append(f)
+                if len(files) == max_files:
+                    capped = True
+                    break
+            if capped:
+                break
 
     results = []
     total_matches = 0
@@ -127,12 +142,17 @@ def grep(
                     break
 
     if not results:
+        if capped:
+            return f"No matches found for '{pattern}'\n\n... stopped after visiting {max_files} files (max_files); narrow `path` or pass `file_pattern`"
         return f"No matches found for '{pattern}'"
 
     output = "\n".join(results)
 
     if total_matches >= max_results:
         output += f"\n\n... results truncated at {max_results}"
+
+    if capped:
+        output += f"\n\n... stopped after visiting {max_files} files (max_files); narrow `path` or pass `file_pattern`"
 
     return output
 
@@ -146,6 +166,16 @@ def _should_ignore(path: Path) -> bool:
         for ignore in IGNORE_DIRS:
             if "*" in ignore and Path(part).match(ignore):
                 return True
+    return False
+
+
+def _is_ignored_dir(name: str) -> bool:
+    """Check if a directory name should be pruned during the walk."""
+    if name in IGNORE_DIRS:
+        return True
+    for ignore in IGNORE_DIRS:
+        if "*" in ignore and Path(name).match(ignore):
+            return True
     return False
 
 

--- a/docs/blog/2026-09-12-the-search-that-had-already-happened.md
+++ b/docs/blog/2026-09-12-the-search-that-had-already-happened.md
@@ -1,0 +1,53 @@
+# The search that had already happened
+
+A `grep()` that takes twenty-six minutes and then gets killed does not look like a bug.
+It looks like the model being slow, or the machine being busy, or a round that was
+always going to be tight. The round it happened in reported nothing unusual: it simply
+stopped at iteration 2 and never mentioned why.
+
+What the tool actually did was simple enough to be embarrassing. Asked to search a
+directory, it walked the whole thing first and decided what to ignore afterwards:
+
+```python
+files = list(base.glob("**/*"))
+files = [f for f in files if f.is_file() and not _should_ignore(f) and _is_text_file(f)]
+```
+
+`_should_ignore` knew about `node_modules`, `.git`, `target`, `.venv` — thirteen
+directories' worth of hard-won knowledge — and every one of them was consulted only
+after the walk had finished. The filter was correct and completely useless. A search
+from `$HOME` entered every project, every `Library`, every cache, in-process, with no
+cap and no timeout, because the only barrier was a sentence in a prompt asking the
+model not to grep directories. The prompt lost. It had lost twice.
+
+The fix is two lines of shape and one of them is the whole lesson: prune `dirnames`
+**in place**, inside the walk, so the ignored subtree is never entered rather than
+entered and discarded.
+
+```python
+for dirpath, dirnames, filenames in os.walk(base):
+    dirnames[:] = [d for d in dirnames if not _is_ignored_dir(d)]
+```
+
+The second half is a cap on how many candidate files the walk will collect, because
+pruning bounds the common case and not the pathological one — a directory with no
+ignored children still walks forever. When the cap trips, the walk stops and says so.
+
+That "says so" turned out to be the part worth keeping. An unfinished walk that returns
+"no matches found" is indistinguishable from a finished walk that found nothing, and
+the second is a legitimate answer that must stay legitimate. So the truncation note is
+emitted even when there are no matches at all: an empty result from a walk that stopped
+early must never be allowed to look like an empty result from a walk that finished.
+That was the failure mode in the report — a killed call with no diagnostic — and it is
+the one thing a cap could plausibly make worse if it were written the obvious way.
+
+What the tests pin down is the mechanism and not the output: one test monkeypatches
+`Path.glob` to raise, so the day someone reintroduces an eager materialisation the
+suite says so by name; another checks that a capped search with zero hits still reports
+the cap. Reverting only the collection block back to `base.glob("**/*")` fails exactly
+those two and passes the other two — which is the shape a regression guard should have.
+
+The `max_depth` argument the issue mentions as "ideally" is deliberately missing. There
+is no default in the issue, and silently changing how deep a search goes would break
+the deep searches that are supposed to work. A vague improvement is worse than a
+missing one.

--- a/tests/unit/test_grep_tool.py
+++ b/tests/unit/test_grep_tool.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+import pytest
+
+from connectonion.useful_tools.file_tools.grep import grep
+
+
+class TestGrepPrunedWalk:
+    def test_ignored_directories_are_pruned_and_not_searched(self, tmp_path):
+        (tmp_path / "node_modules" / "pkg").mkdir(parents=True)
+        (tmp_path / "node_modules" / "pkg" / "hit.py").write_text("NEEDLE")
+        (tmp_path / "src").mkdir(parents=True)
+        (tmp_path / "src" / "hit.py").write_text("NEEDLE")
+        (tmp_path / ".git").mkdir(parents=True)
+        (tmp_path / ".git" / "config").write_text("NEEDLE")
+
+        result = grep("NEEDLE", str(tmp_path))
+
+        assert "src" in result
+        assert "node_modules" not in result
+        assert ".git" not in result
+
+    def test_no_eager_materialisation_via_path_glob(self, tmp_path, monkeypatch):
+        (tmp_path / "a.txt").write_text("hello")
+
+        def _forbidden_glob(self, pattern):
+            raise AssertionError("eager Path.glob must not be used by grep")
+
+        monkeypatch.setattr(Path, "glob", _forbidden_glob)
+
+        result = grep("x", str(tmp_path))
+
+        assert isinstance(result, str)
+
+    def test_max_files_cap_truncates_and_says_so(self, tmp_path):
+        for i in range(12):
+            (tmp_path / f"f{i:02d}.txt").write_text("TOKEN")
+
+        result = grep("TOKEN", str(tmp_path), max_files=5)
+
+        assert "max_files" in result
+        assert "f11.txt" not in result
+
+        nomatch_dir = tmp_path / "nomatch"
+        nomatch_dir.mkdir()
+        for i in range(3):
+            (nomatch_dir / f"n{i}.txt").write_text("nothing here")
+
+        result2 = grep("ABSENT", str(nomatch_dir), max_files=2)
+
+        assert "No matches found" in result2
+        assert "max_files" in result2
+
+    def test_file_pattern_and_normal_search_still_work(self, tmp_path):
+        nested = tmp_path / "nested"
+        nested.mkdir(parents=True)
+        (nested / "a.py").write_text("TOKEN")
+        (nested / "a.md").write_text("TOKEN")
+
+        filtered = grep("TOKEN", str(tmp_path), file_pattern="*.py")
+
+        assert "a.py" in filtered
+        assert "a.md" not in filtered
+
+        unfiltered = grep("TOKEN", str(tmp_path))
+
+        assert "a.py" in unfiltered
+        assert "a.md" in unfiltered


### PR DESCRIPTION
## What

`grep()` built the complete recursive listing of `path` with `base.glob("**/*")` **before** `_should_ignore` was ever consulted, so a search from `$HOME` walked every project, `node_modules`, `Library` and cache in-process — with no cap and no timeout. The issue reports one such call running 26 minutes and another sitting for six minutes with the iteration counter frozen at 43/300.

This walks the tree incrementally instead, prunes `IGNORE_DIRS` from `dirnames` in place so ignored directories are never descended into, and caps the candidate files with a new `max_files` argument.

## Why

`_should_ignore` was a post-filter over a fully materialised list, so it made the *results* correct but did nothing for the *cost*: the walk had already happened. A cap alone would have bounded the run but still paid for the traversal; pruning alone would have bounded the common case but not a directory with no ignored children. Both halves are here.

## How

`connectonion/useful_tools/file_tools/grep.py`

- Top-down `os.walk(base)` replaces the two `base.glob(...)` calls. `dirnames[:] = [d for d in dirnames if not _is_ignored_dir(d)]` prunes in place, so ignored subtrees are never entered.
- `_is_ignored_dir(name)` handles both the plain names in `IGNORE_DIRS` and the glob patterns in it (`*.egg-info`), mirroring the matching `_should_ignore` already does for files. `_should_ignore` is kept and still applied per file.
- `file_pattern` keeps its existing meaning: matched against the file **name** with `fnmatch.fnmatch`, which is what `**/{file_pattern}` did. No change to how a pattern is interpreted.
- New `max_files: int = 20000` keyword argument (last, defaulted, so the signature stays backward compatible) caps the number of candidate files. When it trips, the walk stops and the output ends with a truncation note containing `max_files`. The note is emitted **even when the walk ends with no matches**, because an empty result from an unfinished walk must not look like "no matches found" — that was the failure mode in the issue's report (a killed call with no diagnostic).
- `max_depth` from the issue's "ideally" bullet is deliberately **not** added: the issue gives no concrete default, and silently changing traversal depth would break legitimate deep searches. Happy to add it as a follow-up if you want a specific default.
- The result-formatting loop is untouched.

## Tests

New `tests/unit/test_grep_tool.py`, class `TestGrepPrunedWalk`:

- `test_ignored_directories_are_pruned_and_not_searched` — a match inside `node_modules/` and one inside `.git/` are not returned, a match in `src/` is.
- `test_no_eager_materialisation_via_path_glob` — monkeypatches `Path.glob` to raise; `grep()` on a directory must still work. This is the regression guard for the reported 26-minute walk: the traversal must be incremental, not a materialised glob.
- `test_max_files_cap_truncates_and_says_so` — `max_files=5` over 12 matching files caps the search and reports it; and a no-match directory with `max_files=2` returns both `No matches found` and the `max_files` note.
- `test_file_pattern_and_normal_search_still_work` — `file_pattern="*.py"` selects only the `.py` file, and an unfiltered search still reaches both.

```
.venv/bin/python -m pytest tests/unit/test_grep_tool.py -q
4 passed in 0.63s

.venv/bin/python -m pytest tests/unit -q
11 failed, 9305 passed, 11 skipped, 18 deselected in 273.01s
```

The 11 failures are pre-existing in this sandbox and unrelated to the change — they reproduce on the untouched tree and cover admin log routes, the GitHub action, bash process groups and session-history paths (`test_admin_logs_reads_the_log_the_agent_writes.py`, `test_github_action.py`, `test_shell_tool.py`, `test_the_session_history_belongs_to_the_project.py`, `test_what_the_agent_serves_comes_from_the_project.py`). None of them import `file_tools`.

### Mutation check

Reverting only the collection block to the original `base.glob("**/*")` code, with the new test file left in place:

```
FAILED tests/unit/test_grep_tool.py::TestGrepPrunedWalk::test_no_eager_materialisation_via_path_glob
FAILED tests/unit/test_grep_tool.py::TestGrepPrunedWalk::test_max_files_cap_truncates_and_says_so
2 failed, 2 passed in 1.85s
```

Restoring the fix: `4 passed`. So the new tests fail on the pre-fix code for the intended reasons.

### AI-generated code disclosure

The implementation was produced with AI assistance (OpenCode + muse-spark) from the analysis in the issue, then reviewed, run and mutation-checked locally as described above. I reviewed every line and can explain why each change is there.

## Labels and target release (required)

- **Suggested labels:** bug, tests
- **Proposed target version:** next patch (1.8.x)
- **Estimated release window:** next alpha
- **Milestone:** maintainer assigns the confirmed release milestone
- **Why this release:** the issue is filed against 1.8/main and the reported symptom (a 26-minute in-process walk, a killed round with no diagnostic) is a live cost in every unattended round that greps a directory. It is a contained change to one tool: no API break (new argument is last and defaulted), no compatibility surface, no migration. Rollback risk is low — reverting the walk restores the old behaviour exactly, at the cost of the reported stalls.
- **Forward-port tracking issue (stable patches only):** N/A — mainline work

## Dev Blog (required)

Blog file in this PR: `docs/blog/2026-09-12-the-search-that-had-already-happened.md`

## How this was written

- [x] AI-assisted — I reviewed every line and can explain why each change is there

**Which model?** muse-spark 1.3 via OpenCode, from the issue's root-cause analysis; the commit, the tests, the mutation check and this description were reviewed and run by me.

- **Least confident about:** the `max_files` default of 20000 is a judgement call, not a measurement — I have no data on what a legitimate large-tree search needs, so it may be too high to protect the reported case or too low for someone's monorepo.
- **Not verified:** the actual 26-minute scenario (a walk of a real `$HOME`) — I verified the mechanism with small trees, a `Path.glob` monkeypatch and a forced cap, not with a 26-minute reproduction. The 11 pre-existing unit failures also remain unexplained; I confirmed they reproduce independently of this change but did not diagnose them.
- **If this is wrong, what breaks first:** a `file_pattern` whose intended meaning was a full-path match rather than a basename match. Today `base.glob("**/{file_pattern}")` matches the name, and `fnmatch` on the basename preserves that — but if any caller was passing a pattern with a slash in it, that was already broken and stays broken differently.

Fixes #1453
