### PR TITLE
`wait` takes seconds, so a millisecond argument must say so (#1509)

### DIFF
--- a/connectonion/useful_skills/co-browser/SKILL.md
+++ b/connectonion/useful_skills/co-browser/SKILL.md
@@ -236,6 +236,10 @@ command **starts** the daemon (`status` shows `headless=true/false`). To switch:
 - Wrap **direct functions** that might block in `timeout 60 ...`; never `timeout` a `do`.
 - Take the data line with `tail -1` when output includes env banners.
 - Batch related commands in one tool call; never spend a whole call on a bare wait.
+- **`wait` is in seconds** — every other settle knob here is milliseconds
+  (`--wait_ms=2500`), so `wait 2500` looks right and means 41 minutes. It is
+  capped at 60s and refuses anything longer. For a settle longer than a second or
+  two you want a condition, not a sleep: `wait_for_element` / `wait_for_text`.
 - Uploads: try `upload_file_by_selector 'input[type="file"]' <path>` first; if the
   input is hidden behind a button, `upload_file_after_click_by_selector '<button selector>' <path>`.
 

--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -48,6 +48,31 @@ except ImportError:
     ASYNC_BROWSER_AVAILABLE = False
 
 
+# `wait` is the one verb whose argument can buy an unbounded hold on a shared
+# tab, and its unit is guessable: every *other* settle knob in this codebase is
+# named in milliseconds (`wait_ms`, `timeout_ms`), so `wait 2500` reads as 2.5s
+# to a caller and means 41 minutes here. The cap exists to bound that mistake,
+# not to ration waiting — nothing that needs more than a minute of stillness
+# should be a blocking sleep on a tab other agents may be queued behind.
+MAX_WAIT_SECONDS = 60
+
+
+def wait_argument_error(seconds: float) -> ValueError:
+    """Refuse an over-long wait in the terms the caller most likely meant."""
+    guess = (
+        f"  Did you mean `wait {seconds / 1000:g}`?\n"
+        if seconds >= 1000 and seconds / 1000 <= MAX_WAIT_SECONDS
+        else ""
+    )
+    return ValueError(
+        f"wait takes seconds, not milliseconds: {seconds:g} seconds is "
+        f"{seconds / 60:.0f} minutes, over the {MAX_WAIT_SECONDS}s limit.\n"
+        f"{guess}"
+        "  A wait holds the tab, so anything longer belongs in a condition, not a "
+        "sleep:  wait_for_element(<description>)  ·  wait_for_text(<text>)"
+    )
+
+
 class PaidSessionEndedError(RuntimeError):
     """A paid session ended upstream; its browser must not keep serving."""
 
@@ -1897,6 +1922,10 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
             return f"Found text: '{text}'"
 
     async def wait(self, seconds: float) -> str:
+        # Before the tab lock, deliberately: the whole cost of #1509 was that a
+        # bad argument was admitted first and only found out 41 minutes later.
+        if seconds > MAX_WAIT_SECONDS:
+            raise wait_argument_error(seconds)
         async with self._tab_operation():
             if self.page is None:
                 return "Browser not open"

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -52,6 +52,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from . import element_finder, humanize
+# The wait limit is defined with the async core because that is the path where a
+# long wait blocks OTHER agents' commands. Both spellings of the verb share it so
+# `co browser wait` and a direct library call cannot disagree about the unit.
+from ._async_browser import MAX_WAIT_SECONDS, wait_argument_error
 from .browser_config import CHROME_DEFAULT_ARGS, IGNORE_DEFAULT_ARGS
 from .chrome_finder import find_system_chrome
 
@@ -2187,6 +2191,8 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
 
     def wait(self, seconds: float) -> str:
         """Wait for a specified number of seconds."""
+        if seconds > MAX_WAIT_SECONDS:
+            raise wait_argument_error(seconds)
         if not self.page:
             return "Browser not open"
         self.page.wait_for_timeout(seconds * 1000)

--- a/tests/unit/test_browser_wait_takes_seconds.py
+++ b/tests/unit/test_browser_wait_takes_seconds.py
@@ -1,0 +1,133 @@
+"""`wait` takes seconds, and a millisecond-shaped argument says so immediately.
+
+#1509: three unattended LinkedIn rounds died because `wait 2500` was read as
+milliseconds by the caller and as seconds by the verb.  Forty-one minutes of
+`page.wait_for_timeout` held the tab's operation lock, so every later command on
+that tab queued behind it and hit the client's 120s ceiling.  From outside it
+looked like a wedged daemon: `status` answered, other tabs worked, and a health
+probe found nothing to restart.
+
+The damage is not that the number was wrong.  It is that a wrong number bought a
+silent forty-one minute hold on a shared resource.  A cap turns it into one line
+of text before anything is acquired.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from connectonion.cli.browser_agent.daemon import BrowserDaemon
+from connectonion.useful_tools.browser_tools._async_browser import (
+    MAX_WAIT_SECONDS,
+    AsyncBrowserCore,
+)
+from connectonion.useful_tools.browser_tools.browser import LegacyBrowserAutomation
+
+
+def envelope(line: str, *, caller: str, tab: str | None = None) -> str:
+    return json.dumps(
+        {"v": 1, "caller": caller, "account": "", "tab": tab, "line": line}
+    )
+
+
+@pytest.fixture
+def daemon(tmp_path):
+    server = BrowserDaemon(str(tmp_path / "browser.sock"), headless=True)
+    server.browser = AsyncBrowserCore(headless=True)
+    return server
+
+
+class _CountingPage:
+    """Stands in for the Playwright page so a passing wait can be observed."""
+
+    def __init__(self):
+        self.slept_ms = []
+
+    async def wait_for_timeout(self, ms):
+        self.slept_ms.append(ms)
+
+
+def _core_with_page():
+    """A core whose bound tab has a page, without starting a real browser."""
+    core = AsyncBrowserCore(headless=True)
+    page = _CountingPage()
+    core._pages[core._bound_session_key()] = page
+    return core, page
+
+
+def test_a_millisecond_argument_is_refused_by_the_async_core():
+    core, page = _core_with_page()
+
+    with pytest.raises(ValueError) as caught:
+        asyncio.run(core.wait(2500))
+
+    message = str(caught.value)
+    assert "seconds" in message
+    assert "2.5" in message, "it must name the value the caller almost certainly meant"
+    assert page.slept_ms == [], "nothing may be slept on before the refusal"
+
+
+def test_the_refusal_happens_before_the_browser_is_even_consulted():
+    """A unit mistake is a unit mistake with or without a page open."""
+    core = AsyncBrowserCore(headless=True)
+
+    with pytest.raises(ValueError):
+        asyncio.run(core.wait(2500))
+
+
+def test_an_ordinary_wait_still_waits():
+    core, page = _core_with_page()
+
+    assert asyncio.run(core.wait(2.5)) == "Waited for 2.5 seconds"
+    assert page.slept_ms == [2500]
+
+
+def test_the_cap_itself_is_allowed_and_one_second_past_it_is_not():
+    core, page = _core_with_page()
+
+    asyncio.run(core.wait(MAX_WAIT_SECONDS))
+    assert page.slept_ms == [MAX_WAIT_SECONDS * 1000]
+
+    with pytest.raises(ValueError):
+        asyncio.run(core.wait(MAX_WAIT_SECONDS + 1))
+
+
+def test_the_legacy_sync_implementation_refuses_the_same_argument():
+    """The public facade delegates to the async core, so it is covered above.
+
+    The pre-asyncio implementation is still shipped as the comparison oracle for
+    the verb contract, and a limit the two disagree about is not a limit.  Called
+    unbound on purpose, past the browser-thread decorator: the guard must fire
+    before `self.page` is read, so it needs nothing from a started browser.
+    """
+
+    class _NothingStarted:
+        pass
+
+    with pytest.raises(ValueError) as caught:
+        LegacyBrowserAutomation.wait.__wrapped__(_NothingStarted(), 2500)
+
+    assert "seconds" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_the_tab_is_free_the_moment_the_bad_wait_is_refused(daemon):
+    """The point of the fix: the mistake costs a round trip, not the tab."""
+    ok, payload = await daemon.dispatch_async(
+        envelope("tab open probe --who agent --for testing", caller="agent")
+    )
+    assert ok is True, payload
+
+    ok, payload = await daemon.dispatch_async(
+        envelope("wait 2500", caller="agent", tab="probe")
+    )
+    assert ok is not True, "a 41-minute sleep must not be accepted"
+    assert "seconds" in payload
+
+    # If the wait had been admitted, this would queue behind it for 41 minutes.
+    ok, payload = await asyncio.wait_for(
+        daemon.dispatch_async(envelope("status", caller="agent", tab="probe")),
+        timeout=10,
+    )
+    assert ok is True, payload


### PR DESCRIPTION
Closes #1509.

## What was actually wrong

Not the daemon. `co browser wait <n>` takes **seconds**, and the caller passed
`2500` meaning milliseconds — every other settle knob in this codebase is named
in milliseconds (`wait_ms`, `timeout_ms`, `--wait_ms=2500`), so `wait 2500` reads
as 2.5s and means 41 minutes.

Those 41 minutes were spent inside `_tab_operation()`, holding that tab's lock.
Same-tab commands are serialized on purpose (`test_same_tab_operations_are_serialized`),
so every later command on that tab queued behind the sleep and died at the
client's 120s ceiling. `status` kept answering and other tabs kept working, which
is why the next round's health probe found nothing to restart and the whole thing
read as a wedged daemon.

Measured cost on the 18:00 round of 2026-09-12: seven 120s timeouts, 14 minutes,
one comment out of 43 extracted posts.

## The fix

Cap `wait` at 60s and refuse anything longer **before the tab lock is acquired**,
with an error that names the value the caller almost certainly meant:

```
ValueError: wait takes seconds, not milliseconds: 2500 seconds is 42 minutes, over the 60s limit.
  Did you mean `wait 2.5`?
  A wait holds the tab, so anything longer belongs in a condition, not a sleep:
  wait_for_element(<description>)  ·  wait_for_text(<text>)
```

The cap is not rationing. Nothing that needs more than a minute of stillness
should be a blocking sleep on a tab other agents may be queued behind — that is
what `wait_for_element` / `wait_for_text` are for.

Both spellings of the verb get the guard: the async core the daemon runs, and the
pre-asyncio implementation still shipped as the verb-contract oracle. A limit the
two disagree about is not a limit.

`co-browser/SKILL.md` now states the unit in Scripting hygiene, because the
mistake was made by an agent reading that file.

## What this does not change

Same-tab serialization stays. Queueing behind your own previous command is the
documented contract; the bug was that a single argument could make the queue
41 minutes long.

## Tests

`tests/unit/test_browser_wait_takes_seconds.py` — 6 tests. Verified red first:
raising the cap to 10**9 fails 4 of the 6, including
`test_the_tab_is_free_the_moment_the_bad_wait_is_refused`, which is the one that
reproduces the #1509 damage through `dispatch_async`.

794 browser unit tests pass.

**Proposed target version:** 1.8.5b3
**Estimated release window:** today, 2026-09-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3VJDT8R3Sr69BzfEBxT6
