### PR TITLE
a pinned daemon must never refuse the command it tells you to run (#1510, #1501)

### DIFF
--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -2,7 +2,7 @@
 Purpose: Persistent concurrent browser daemon — owns one AsyncBrowserCore/event loop and dispatches authenticated CLI requests over POSIX Unix sockets or Windows named pipes.
 LLM-Note:
   Dependencies: asyncio + bounded Windows transport executor + AsyncBrowserCore + browser_agent.transport; private mode lazily imports EgressGateway and its immutable launch-policy factory; BrowserAutomation remains the public help/schema source | imported by browser_agent.client and browser_commands | tested by daemon, engine, transport, and Remote Browser runtime suites
-  Data flow: typed OIP 0.2 BrowserCommand argv (bounded wire-v1 migration reader retained) → immutable engine check → private gateway-health check → atomic registry/claim admission → awaited async browser verb → text result or committed Artifact Stream; private mode forces engine=onion before any paid session or page effect
+  Data flow: typed OIP 0.2 BrowserCommand argv (bounded wire-v1 migration reader retained) → immutable engine check (exempting the verbs that touch no page — close/closetab/status/engine_status/help/`tab ls`/`tab close` — so a mismatched pin is always escapable) → private gateway-health check → atomic registry/claim admission → awaited async browser verb → text result or committed Artifact Stream; private mode forces engine=onion before any paid session or page effect
   State/Effects: one asyncio-owned AsyncBrowserCore and persistent context | private mode starts its gateway, canonical credential file, and fixed paid launch policy before IPC bind; gateway loss rejects before browser mutation; shutdown closes browser, removes credentials, then stops gateway | independent tab tasks interleave behind per-tab locks | bounded POSIX/Windows transports and lifetime ownership sidecars preserve admission and cleanup
   Integration: launched detached via `python -m connectonion.cli.browser_agent.daemon <address> [--headless] [--engine=MODE] [--profile-dir=PATH] [--authkey-file=PATH] [--remote-egress]`; dispatch() remains the non-loop compatibility seam
   Performance: page operations on separate tabs overlap; same-tab work queues; browser/model/image blocking work never owns the event-loop thread; first browser launch remains 1-3s
@@ -140,6 +140,29 @@ def _key(name):
 
 def _tab_label(key) -> str:
     return "main" if key is None else key
+
+
+def _engine_label(mode: str) -> str:
+    """What a person types for this engine. `onion` is only the wire spelling."""
+    return "wtf" if mode == "onion" else mode
+
+
+# Verbs that neither drive nor create a page: which browser is running does not
+# change what they do, so the engine pin must not gate them. `close` above all —
+# it is the documented way out of a mismatched pin, and guarding it is what made
+# #1510 unrecoverable rather than merely annoying. `tab open` is deliberately NOT
+# here: it allocates a page, and on a paid pin that spends money.
+_ENGINE_AGNOSTIC_VERBS = ("close", "closetab", "status", "engine_status", "help")
+_ENGINE_AGNOSTIC_TAB_SUBCOMMANDS = ("ls", "close")
+
+
+def _engine_agnostic(verb: str, tokens: list) -> bool:
+    if verb in _ENGINE_AGNOSTIC_VERBS:
+        return True
+    if verb != "tab":
+        return False
+    # A bare `tab` prints usage, which no engine can get wrong.
+    return len(tokens) < 2 or tokens[1] in _ENGINE_AGNOSTIC_TAB_SUBCOMMANDS
 
 
 def _owner_alive(sock_path: str) -> bool:
@@ -328,6 +351,78 @@ class BrowserDaemon:
     # the CLI answers it locally.
     READONLY = ("tab", "status", "engine_status", "use", "switch")
 
+    async def _engine_conflict(self, requested_engine: str) -> str | None:
+        """The refusal text when this request cannot use the pinned engine, else None.
+
+        `auto` means "no preference", and the guard used to read it as a
+        conflicting preference — which is why every bare `co browser <verb>`
+        was refused by a daemon someone had once started with --engine wtf
+        (#1501, #1510).  A named engine that differs is a real conflict and
+        still refuses.
+
+        The one case where `auto` must still ask is money.  A *running* paid
+        session is consent already given: while it is up, `auto` rides it and
+        nothing further is charged.  Once it has ended, serving `auto` would
+        silently open a new billing interval, so the caller has to say.
+        """
+        if requested_engine == self.engine_mode:
+            return None
+        if requested_engine != "auto":
+            return self._engine_pin_refusal(requested_engine)
+        if self.engine_mode != "onion":
+            return None
+        if await self._paid_browser_is_live():
+            return None
+        return self._paid_relaunch_refusal()
+
+    async def _paid_browser_is_live(self) -> bool:
+        """Is the paid session this daemon was pinned for still open?"""
+        is_alive = getattr(self.browser, "is_alive", None)
+        if is_alive is None:
+            return False
+        try:
+            result = is_alive()
+            if inspect.isawaitable(result):
+                result = await result
+        except Exception:
+            return False
+        return bool(result)
+
+    def _paid_relaunch_refusal(self) -> str:
+        """A bare command must not restart a paid browser on the caller's behalf."""
+        # Only commands this daemon would actually accept, in this state. The pin
+        # is immutable while the daemon lives, so `--engine system` here would be
+        # refused as a conflict — offering it would be the #1510 circle again.
+        return (
+            "browser daemon is pinned to engine=wtf and its paid session is no "
+            "longer open. Starting it again bills, so a command with no engine "
+            "of its own has to say:\n\n"
+            "Start a new paid session:\n"
+            "  co browser --engine wtf <verb> ...\n\n"
+            "Or close this daemon — the next command then picks its own engine, "
+            "and your logins are still there:\n"
+            "  co browser close"
+        )
+
+    def _engine_pin_refusal(self, requested_engine: str) -> str:
+        """Say which engine is running, and name only commands that would work.
+
+        Every `co browser ...` on this page is admitted by the guard above; a
+        remedy the guard itself rejects sends the reader in a circle with the
+        confidence of an instruction, which is how #1510 became unrecoverable.
+        """
+        pinned = _engine_label(self.engine_mode)
+        return (
+            f"browser daemon is pinned to engine={pinned}; this request asked for "
+            f"engine={_engine_label(requested_engine)}.\n\n"
+            f"Run this command on the engine that is running:\n"
+            f"  co browser --engine {pinned} <verb> ...\n\n"
+            f"Stop repeating the flag — make it this machine's default:\n"
+            f"  co browser config {pinned}\n\n"
+            f"Or start over on the engine you asked for:\n"
+            f"  co browser close"
+        )
+
     def dispatch(self, raw: str) -> tuple:
         """Synchronous test/embedding bridge; production uses ``dispatch_async``.
 
@@ -369,12 +464,11 @@ class BrowserDaemon:
             self._gateway is None or not self._gateway.is_running
         ):
             return False, "EGRESS_GATEWAY_UNAVAILABLE"
-        if requested_engine != self.engine_mode:
-            return 6, (
-                f"browser daemon is pinned to engine={self.engine_mode}; this request asked "
-                f"for engine={requested_engine}. Close it with `co browser close`, then retry."
-            )
         verb = tokens[0]
+        if not _engine_agnostic(verb, tokens):
+            conflict = await self._engine_conflict(requested_engine)
+            if conflict is not None:
+                return 6, conflict
 
         # -t targeting: each task drives its OWN tab. Unknown-tab is only an error for a
         # command that would DRIVE the tab — read-only/lifecycle verbs may name a tab that

--- a/connectonion/cli/commands/browser_commands.py
+++ b/connectonion/cli/commands/browser_commands.py
@@ -3,7 +3,7 @@ Purpose: Thin CLI handler for `co browser` — parses -t/--tab targeting, forwar
 LLM-Note:
   Dependencies: imports from [sys, shlex, browser_agent.client.send | lazy: command_tips.rotating_tip for the success tip, browser_agent.daemon.list_functions for help] | imported by [cli/main.py via browser()] | tested by [tests/e2e/cli/test_browser_daemon.py]
   Data flow: receives args: list[str] (+ headless and engine_mode) from CLI → validates auto/system/onion → exact `install-onion` runs the signed private-client bootstrap and returns before daemon contact → `help`/`--list` printed locally by introspecting BrowserAutomation (no browser launched) → else _extract_tab() pulls the LEADING -t/--tab NAME run (stops at the verb, so a -t that is a function's own arg passes through; empty --tab= is a usage error) → shlex.join(remaining args) + tab + engine mode → client.send() → a mode-pinned daemon runs it → payload/exit code surfaced by the client
-  State/Effects: `install-onion` explicitly installs a signature/checksum-verified wheel into the current Python environment | otherwise no local state except a best-effort rotating-tip index at ~/.co/.browser_tip (a garbled index resets to the first tip) | the success tip is printed to STDERR (stdout stays pure data) | `help` introspects the class only | direct verbs delegate to the daemon; `do` runs its model loop in this CLI process and delegates each tool call
+  State/Effects: `install-onion` explicitly installs a signature/checksum-verified wheel into the current Python environment | otherwise no local state except a best-effort rotating-tip index at ~/.co/.browser_tip (a garbled index resets to the first tip) | a session-starting verb on the paid engine prints a billing notice to STDERR BEFORE the command is sent | the success tip is printed to STDERR (stdout stays pure data) | `help` introspects the class only | direct verbs delegate to the daemon; `do` runs its model loop in this CLI process and delegates each tool call
   Integration: exposes _extract_tab(args) -> (tab|None, remaining|None), _next_tip(), handle_browser(args, headless=False, engine_mode="auto") -> int | called from main.py browser command | USAGE/TIPS document the tab lifecycle, engine modes, and exit-code contract
   Performance: direct verbs do not import the browser-owning daemon, Agent, or Playwright; `help` lazily imports the schema (no socket, no Chrome) | other verbs: one socket round-trip, first call spawns the daemon
   Errors: no-args / bad -t → prints usage to stderr, exit 2 | daemon errors come back as ERR[ <code>] → stderr + the mirrored exit code (0 ok · 1 failure · 2 usage · 3 unknown tab · 4 tab busy)
@@ -51,6 +51,11 @@ TIPS = [
     "Run without a visible window:  co browser --headless <function>",
     "The browser stays open between commands, one shared session, until you run:  co browser close",
 ]
+
+
+def _starts_a_session(args: list) -> bool:
+    """True for the verbs that open a browser, i.e. that begin a paid interval."""
+    return args[0] in ("newtab", "open_browser") or args[:2] == ["tab", "open"]
 
 
 def _next_tip():
@@ -137,6 +142,17 @@ def handle_browser(args, headless: bool = False, engine_mode: str = "auto") -> i
             print("--stdin needs piped or redirected text", file=sys.stderr)
             return 2
         args = [*args[:-1], sys.stdin.read()]
+    if engine_mode == "onion" and _starts_a_session(args):
+        # Before the spend, not in the receipt. The Airbnb round of 2026-09-12
+        # ran an authenticated host dashboard on the paid engine for 40 minutes,
+        # then finished the same work on the free one with the logins intact —
+        # nothing anywhere had said which engine was about to bill (#1510).
+        print(
+            "⏱  The WTF Browser bills for the session this starts.\n"
+            "   A site you are already logged into rarely needs it:  "
+            "co browser --engine system <verb>",
+            file=sys.stderr,
+        )
     code = send(shlex.join(args), headless=headless, tab=tab, engine_mode=engine_mode)
     from .command_tips import tips_enabled
     if code == 0 and tips_enabled():

--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -49,10 +49,24 @@ except ImportError:
 
 
 class PaidSessionEndedError(RuntimeError):
-    """A paid session ended upstream; its browser must not keep serving."""
+    """A paid session ended upstream; its browser must not keep serving.
+
+    The reason alone ("browser_exited") reads as a diagnostic to a human and as
+    a dead end to an agent, which is what it was in #1510: the tabs are gone
+    with the session, so the next command fails on the missing tab instead, and
+    nothing in either message says how to get back to work. Name the way out.
+    """
 
     def __init__(self, reason: str):
-        super().__init__(f"paid browser session ended: {reason}")
+        super().__init__(
+            f"paid browser session ended: {reason}\n\n"
+            f"The session is over and its tabs went with it. Start a new one:\n"
+            f"  co browser close\n"
+            f"  co browser tab open <name> --for \"<what you are doing>\"\n\n"
+            f"If this task does not need anti-detection, the free engine keeps "
+            f"your logins and costs nothing:\n"
+            f"  co browser --engine system tab open <name> --for \"<what you are doing>\""
+        )
         self.reason = reason
 
 

--- a/tests/unit/test_browser_engine_cli.py
+++ b/tests/unit/test_browser_engine_cli.py
@@ -75,7 +75,9 @@ def test_warm_daemon_refuses_engine_hot_swap():
     code, message = daemon.dispatch(request)
     assert code == 6
     assert "pinned to engine=system" in message
-    assert "asked for engine=onion" in message
+    # The request carried the wire spelling `onion`; the refusal reports the name
+    # a person types, because the reader's next step is to retype the command.
+    assert "asked for engine=wtf" in message
 
 
 def test_client_probes_warm_daemon_before_explicit_onion_command(monkeypatch):

--- a/tests/unit/test_browser_pin_does_not_block_the_escape_hatch.py
+++ b/tests/unit/test_browser_pin_does_not_block_the_escape_hatch.py
@@ -1,0 +1,147 @@
+"""A pinned daemon must never refuse the command it tells you to run.
+
+#1510: the daemon pins its engine at startup, and every request carries the
+engine the client resolved. Once pinned to the paid engine, a bare
+`co browser <verb>` resolves to `auto` and is refused — including `tab ls`,
+`status` and `close`, none of which drive or create a page. The printed remedy
+was `co browser close`, which is refused by the same guard, so following the
+instruction literally loops forever and the browser cannot be recovered at all.
+
+Two properties are tested here:
+
+  1. The verbs that neither drive nor create a page are answered whatever the
+     pin says. Closing is the escape hatch; it cannot be behind the lock.
+  2. Every command the refusal names would itself be admitted. A remedy that
+     the guard rejects is worse than no remedy: it sends the reader in a circle
+     with the confidence of an instruction.
+"""
+
+import json
+import re
+
+import pytest
+
+from connectonion.cli.browser_agent.daemon import BrowserDaemon
+from connectonion.useful_tools.browser_tools._async_browser import AsyncBrowserCore
+
+
+def envelope(line: str, *, engine: str, caller: str = "agent", tab=None) -> str:
+    return json.dumps(
+        {
+            "v": 1,
+            "caller": caller,
+            "account": "",
+            "tab": tab,
+            "line": line,
+            "engine": engine,
+        }
+    )
+
+
+@pytest.fixture
+def pinned(tmp_path):
+    """A daemon pinned to the paid engine, as the Airbnb session's was."""
+    server = BrowserDaemon(
+        str(tmp_path / "browser.sock"), headless=True, engine_mode="onion"
+    )
+    server.browser = AsyncBrowserCore(headless=True)
+    return server
+
+
+@pytest.fixture
+def live(pinned):
+    """The same daemon with its paid browser still open."""
+
+    async def alive():
+        return True
+
+    pinned.browser.is_alive = alive
+    return pinned
+
+
+def _refusal(payload) -> bool:
+    return isinstance(payload, str) and "pinned to engine" in payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("line", ["close", "status", "tab ls", "tab close probe"])
+async def test_a_pin_never_blocks_a_verb_that_touches_no_page(pinned, line):
+    ok, payload = await pinned.dispatch_async(envelope(line, engine="auto"))
+
+    assert not _refusal(payload), f"`{line}` must be answered whatever the pin says"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("line", ["go_to example.com", "get_text", "tab open probe"])
+async def test_a_bare_command_rides_a_paid_session_that_is_already_open(live, line):
+    """`auto` is no preference, not a conflicting one (#1501).
+
+    The session is up and already paid for; another tab in it charges nothing.
+    Refusing here is what made every bare command fail against a daemon someone
+    had once started with --engine wtf.
+    """
+    ok, payload = await live.dispatch_async(envelope(line, engine="auto"))
+
+    assert not _refusal(payload), f"`{line}` costs nothing extra and must be served"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("line", ["go_to example.com", "tab open probe"])
+async def test_a_bare_command_may_not_restart_a_paid_session_that_ended(pinned, line):
+    """The one case where `auto` still has to ask: it would begin a new charge."""
+    ok, payload = await pinned.dispatch_async(envelope(line, engine="auto"))
+
+    assert _refusal(payload)
+    assert "bills" in payload, "say why the answer is no, not just that it is"
+
+
+@pytest.mark.asyncio
+async def test_a_different_named_engine_is_a_real_conflict(live):
+    ok, payload = await live.dispatch_async(envelope("get_text", engine="system"))
+
+    assert _refusal(payload), "asking for system on a paid daemon is a real conflict"
+
+
+@pytest.mark.asyncio
+async def test_the_refusal_names_the_engine_a_person_types(live):
+    ok, payload = await live.dispatch_async(envelope("get_text", engine="system"))
+
+    assert "wtf" in payload, "`onion` is the wire name; nobody types it"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fixture,engine", [("pinned", "auto"), ("live", "system")])
+async def test_every_command_a_refusal_names_would_itself_be_admitted(
+    request, fixture, engine
+):
+    """The defect that made #1510 unrecoverable, stated as a property.
+
+    Both refusals are checked: the pin mismatch, and the paid relaunch.
+    """
+    daemon = request.getfixturevalue(fixture)
+    ok, payload = await daemon.dispatch_async(envelope("get_text", engine=engine))
+    assert _refusal(payload)
+
+    suggested = re.findall(r"co browser ([^\n]+)", payload)
+    assert suggested, "a refusal with no way out is not a refusal, it is a dead end"
+
+    for command in suggested:
+        if command.startswith("config"):
+            continue  # answered by the CLI before the daemon is contacted
+        named = re.search(r"--engine (\S+)", command)
+        wire = {"wtf": "onion"}.get(named.group(1), named.group(1)) if named else "auto"
+        line = re.sub(r"--engine \S+", "", command).replace("<verb> ...", "get_text")
+        ok, reply = await daemon.dispatch_async(
+            envelope(" ".join(line.split()), engine=wire)
+        )
+        assert not _refusal(reply), (
+            f"the refusal tells you to run `co browser {command}`, then refuses it"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_matching_request_is_untouched(pinned):
+    """The guard's real job — a request on the pinned engine — still passes."""
+    ok, payload = await pinned.dispatch_async(envelope("status", engine="onion"))
+
+    assert not _refusal(payload)

--- a/tests/unit/test_the_paid_engine_says_it_is_billed.py
+++ b/tests/unit/test_the_paid_engine_says_it_is_billed.py
@@ -1,0 +1,65 @@
+"""The paid engine names its cost before spending, and its death names the way back.
+
+From #1510, after 40 minutes on the WTF Browser driving an authenticated Airbnb
+host dashboard: "anti-detection was not needed at all ... everything worked
+identically *and* the logged-in session survived the restart. So the paid engine
+contributed cost and instability and no benefit."
+
+Nothing had said which engine was about to bill. And when the paid session died
+mid-task, the error named the reason (`browser_exited`) and no way forward — the
+tabs had gone with the session, so the next command failed on a missing tab
+instead, which reads like a second, unrelated fault.
+"""
+
+import pytest
+
+from connectonion.cli.commands import browser_commands
+from connectonion.useful_tools.browser_tools._async_browser import PaidSessionEndedError
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    """Run handle_browser without a daemon, recording what it would have sent."""
+    calls = []
+    monkeypatch.setattr(
+        browser_commands, "send", lambda line, **kw: calls.append((line, kw)) or 0
+    )
+    monkeypatch.setattr(browser_commands, "tips_enabled", lambda: False, raising=False)
+    monkeypatch.setenv("CO_DISABLE_TIPS", "1")
+    return calls
+
+
+@pytest.mark.parametrize(
+    "args",
+    [["tab", "open", "work", "--for", "a task"], ["newtab"], ["open_browser"]],
+)
+def test_starting_a_paid_session_says_so_first(sent, capsys, args):
+    assert browser_commands.handle_browser(list(args), engine_mode="wtf") == 0
+
+    notice = capsys.readouterr().err
+    assert "bills" in notice, "the spend must be named before it happens"
+    assert "--engine system" in notice, "and the free alternative must be named too"
+    assert sent, "the notice must not replace the command"
+
+
+@pytest.mark.parametrize("args", [["get_text"], ["tab", "ls"], ["status"]])
+def test_an_ordinary_command_is_not_nagged(sent, capsys, args):
+    """A notice on every command is a notice nobody reads."""
+    browser_commands.handle_browser(list(args), engine_mode="wtf")
+
+    assert "bills" not in capsys.readouterr().err
+
+
+def test_the_free_engine_says_nothing_about_billing(sent, capsys):
+    browser_commands.handle_browser(["tab", "open", "work"], engine_mode="system")
+
+    assert "bills" not in capsys.readouterr().err
+
+
+def test_a_dead_paid_session_names_the_command_that_recovers_it():
+    message = str(PaidSessionEndedError("browser_exited"))
+
+    assert "browser_exited" in message, "keep the reason: it is the only upstream fact"
+    assert "co browser close" in message
+    assert "tab open" in message, "the tabs died with the session; say how to get one back"
+    assert "--engine system" in message, "and that the free engine keeps the logins"


### PR DESCRIPTION
Closes #1510. Closes #1501.

## The loop

The engine pin gated **every** request. A daemon someone had once started with
`--engine wtf` therefore refused every bare `co browser <verb>` — including
`tab ls`, `status` and `close`, none of which drive or create a page. And the
refusal said:

> Close it with `co browser close`, then retry.

which is refused by the same guard. Following the printed instruction literally
loops forever. Only `co browser --engine onion close` works, and the message
never mentions it. Net effect from #1510: "the browser is gone, the daemon is
unusable, and the printed instructions cannot get you out."

## Three changes

**1. `auto` is no preference, not a conflicting one.** This is #1501's second
ask, and it is the root of defect 1. A bare command resolves to `engine=auto`,
which means *whatever you have running*. The guard read it as a demand for a
different engine. Now only a **named** engine that differs conflicts.

The exception is money, and it is narrow: a *running* paid session is consent
already given — while it is up, `auto` rides it and nothing further is charged.
Once it has ended, serving `auto` would silently open a new billing interval, so
that one case still asks. (#1501's first ask, `CO_BROWSER_ENGINE`, shipped in
#1504 / 1.8.5b2.)

**2. Verbs that touch no page are never gated.** `close`, `closetab`, `status`,
`engine_status`, `help`, `tab ls`, `tab close`. `tab open` is deliberately *not*
among them: it allocates a page, and on a paid pin that spends money.

**3. Both refusals name only commands this daemon would actually accept**, and
name the engine a person types (`wtf`), not the wire spelling (`onion`):

```
browser daemon is pinned to engine=wtf; this request asked for engine=system.

Run this command on the engine that is running:
  co browser --engine wtf <verb> ...

Stop repeating the flag — make it this machine's default:
  co browser config wtf

Or start over on the engine you asked for:
  co browser close
```

This is tested as a property, not as a string: every `co browser ...` a refusal
prints is dispatched back at the daemon and must be admitted. That test earned
its keep immediately — it caught my first draft of the paid-relaunch message
offering `--engine system`, which a wtf-pinned daemon refuses. Same circle,
reintroduced, found before review.

## The other two asks from #1510

- **`PaidSessionEndedError`** said `browser_exited` and nothing else. The tabs
  died with the session, so the next command failed on a missing tab instead —
  reading as a second, unrelated fault. It now names the way back.
- **No notice that the engine is billed.** A session-starting verb
  (`tab open` / `newtab` / `open_browser`) on the paid engine now prints one line
  to stderr *before* the command is sent. The round that filed this spent 40
  minutes on the paid engine driving an authenticated Airbnb host dashboard, then
  finished the same work on the free one with the logins intact.

## Not fixed here

Defect 3's other half: the tab registry still dies with the browser, and there is
no auto-reconnect. That needs reconnect semantics, not a better message, so it is
filed separately rather than rushed into a beta.

## Tests

- `tests/unit/test_browser_pin_does_not_block_the_escape_hatch.py` — 14 tests.
  Verified red first: 6 failed against `main`, including the
  every-suggested-command-is-admitted property.
- `tests/unit/test_the_paid_engine_says_it_is_billed.py` — 8 tests. 3 verified red
  before the notice existed.
- `test_warm_daemon_refuses_engine_hot_swap` updated: it asserted the wire
  spelling appeared in the refusal, which is exactly what this changes.

798 browser unit tests pass; full local suite 9924 passed.

**Proposed target version:** 1.8.5b3
**Estimated release window:** today, 2026-09-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3VJDT8R3Sr69BzfEBxT6
