### PR TITLE
Release ConnectOnion 1.8.5b3: two ways a browser could waste an afternoon

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -58,7 +58,19 @@ See [1.8.4 notes](docs/releases/1.8.4.md) for migration and acceptance limits.
 The planned 1.8.4b1 was not published separately; its reviewed changes are included
 in 1.8.4. Publication is performed and verified by the immutable-tag workflow.
 
-## Release candidate: 1.8.5b2 (beta)
+## Release candidate: 1.8.5b3 (beta)
+
+Two fixes an unattended agent paid for before we found them. `co browser wait`
+takes seconds while every neighbouring knob is named in milliseconds, so
+`wait 2500` meant forty-one minutes holding a tab's lock — capped at 60s and
+refused before the lock. And a daemon pinned to an engine refused every bare
+command, `close` included, while telling you to run `close`: `auto` is no
+preference now, page-less verbs are never gated, and a refusal names only
+commands that daemon would accept. Stable remains 1.8.4: the reconnect-gap gate
+in #1462 has not passed.
+See [1.8.5b3 notes](docs/releases/1.8.5b3.md).
+
+### Superseded: 1.8.5b2 (beta, published)
 
 Four things `b1` made you type or guess: `co browser config` sets a default
 engine so `--engine` is an override rather than the only way in; the paid
@@ -150,9 +162,18 @@ Stable remains 1.8.3; this does not authorize final 1.8.4 or cloud provisioning.
 See [1.8.4a2 notes](docs/releases/1.8.4a2.md) and the
 [local acceptance record](docs/acceptance/1.8.4-live-followup/README.md).
 
-## Current Version: 1.8.5b2
+## Current Version: 1.8.5b3
 
 ### Version History
+- 1.8.5b3 (**beta: two ways a browser could waste an afternoon.** `wait` takes
+  seconds while everything around it is named in milliseconds, so `wait 2500`
+  held a tab for 41 minutes and every command behind it timed out while
+  `status` kept answering — capped at 60s and refused before the lock, naming
+  the value you meant. And an engine-pinned daemon refused every bare command
+  including the `close` its own error told you to run: `auto` is no preference
+  now, page-less verbs are never gated, and a refusal names only commands that
+  daemon would accept. A dead paid session names its recovery, and the paid
+  engine says it bills before it spends. Stable remains 1.8.4.)
 - 1.8.5b2 (**beta: the settings b1 made you repeat.** `co browser config`
   gives the browser engine a default so `--engine` becomes an override; the
   paid engine is `wtf`, not `onion`; `co <provider> serve` is `consume`;

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.8.5b2"
+__version__ = "1.8.5b3"

--- a/docs/blog/2026-09-12-the-way-out-was-behind-the-lock.md
+++ b/docs/blog/2026-09-12-the-way-out-was-behind-the-lock.md
@@ -1,0 +1,124 @@
+# The way out was behind the lock
+
+The browser daemon pins its engine when it starts. Every request carries the
+engine the client resolved, and a mismatch was refused:
+
+```
+browser daemon is pinned to engine=onion; this request asked for engine=auto.
+Close it with `co browser close`, then retry.
+```
+
+Read that carefully, because it is a closed loop.
+
+A bare `co browser <verb>` resolves to `engine=auto`. So does
+`co browser close`. If your daemon is pinned to the paid engine, the command
+the message tells you to run is refused by the guard that printed the message.
+Follow the instruction literally and you do it forever.
+
+The escape existed — `co browser --engine onion close` — and nothing anywhere
+named it. An agent working a task on an Airbnb host dashboard spent the end of
+its session discovering that by hand, after the browser had gone and `tab ls`,
+`status` and `close` were all refused with the same paragraph.
+
+## Three separate mistakes wearing one costume
+
+It is tempting to call this a bad error message. It is three things.
+
+**The guard was reading `auto` wrong.** `auto` means *no preference*. The
+daemon treated it as a preference that conflicts. That single misreading is why
+every bare command against a warm paid daemon failed, and it had already been
+filed separately as its own issue before this one existed.
+
+**The guard was gating verbs that do not use an engine.** `tab ls` lists a
+registry. `status` reads state. `close` tears the whole thing down. None of
+them care which browser is running, and one of them is the documented way out.
+Putting `close` behind the lock is what turned "annoying" into "unrecoverable".
+
+**The remedy was untrue.** Not vague, not unhelpful — false. It named a command
+that could not work.
+
+## What `auto` should mean
+
+The rule now: only a **named** engine that differs is a conflict. Ask for
+`--engine system` on a paid daemon and you get refused, because you asked for
+something specific and it is not what is running. Send a bare command and it
+rides whatever is up.
+
+There is exactly one exception, and it is money.
+
+A running paid session is consent that was already given — somebody typed
+`--engine wtf` to start it, and another tab inside it charges nothing further.
+But once that session has ended, serving `auto` would quietly open a *new*
+billing interval on behalf of a command that never asked to spend anything. So
+that one case still asks:
+
+```
+browser daemon is pinned to engine=wtf and its paid session is no longer open.
+Starting it again bills, so a command with no engine of its own has to say:
+```
+
+Consent is the live session, not the flag someone typed an hour ago.
+
+`tab open` stays guarded for the same reason. It reads like a bookkeeping verb
+and is not: it allocates a page, and on a paid pin that spends.
+
+## The test that earned its keep in five minutes
+
+The messages now name only commands this daemon would accept in this state, and
+they use the name a person types — `wtf`, the product's name — rather than
+`onion`, which is only how the wire spells it.
+
+That is easy to assert badly. A test that checks for the substring `close` tells
+you a word is present, not that the advice is true. So the property is tested
+directly: take every `co browser ...` line a refusal prints, dispatch each one
+back at the same daemon, and require that none of them is refused.
+
+It failed on the first run. My draft of the paid-relaunch message offered:
+
+```
+Free, and your logins are still there:
+  co browser --engine system <verb> ...
+```
+
+which a `wtf`-pinned daemon refuses as a named conflict. The exact bug being
+fixed, reintroduced in the fix for it, caught before review by a test written
+because of it. The real remedy is `close` first — the pin is immutable while
+the daemon lives — so that is what the message says now.
+
+## The cheapest part was the one nobody asked for first
+
+Filed under "lower priority" in the report: nothing said which engine was about
+to bill.
+
+The session that hit all of this ran an authenticated host dashboard on the paid
+anti-detection browser for forty minutes, lost the session twice, and then —
+after being forced onto the free engine by the failure — finished the identical
+work with the logins still intact. The paid engine contributed cost and
+instability and no benefit, and there was no moment where anything said so.
+
+So a session-starting verb on the paid engine now prints one line before the
+command is even sent:
+
+```
+⏱  The WTF Browser bills for the session this starts.
+   A site you are already logged into rarely needs it:  co browser --engine system <verb>
+```
+
+Before the spend, not in the receipt.
+
+## Not fixed, and said out loud
+
+When the paid browser exits on its own, the tab registry goes with it, and the
+next command fails on a missing tab — which reads as a second, unrelated fault.
+The error now names the way back. The registry surviving a crash, and
+reconnecting at all, is a design change about what a tab entry means with no
+page behind it, and for the paid engine a reconnect is a new billing interval,
+which drags it back onto the consent question above. That is filed, not rushed
+into a beta.
+
+## The rule
+
+An error message is a promise. Print a command and you have asserted it works.
+If you cannot test that assertion, you are not writing a remedy — you are
+writing a plausible sentence, and a plausible wrong sentence costs more than
+silence, because the reader trusts it enough to repeat it.

--- a/docs/blog/2026-09-12-two-thousand-five-hundred-of-what.md
+++ b/docs/blog/2026-09-12-two-thousand-five-hundred-of-what.md
@@ -1,0 +1,128 @@
+# Two thousand five hundred of what
+
+Three unattended LinkedIn rounds died on the same afternoon. Each one's first
+timeout was a `wait` call, and from that moment every command against the
+round's tab timed out at the client's 120-second ceiling — including the
+`tab close` that would have released it. The 18:00 round spent fourteen
+minutes and seven timeouts to post one comment out of forty-three extracted
+posts.
+
+Everything you would check said the browser was fine. `co browser status`
+answered. Other tabs kept working. A second agent on the same browser saw no
+problem at all. So the next round's health probe found nothing to restart, and
+the diagnosis went first to a prompt regression and then to a duplicate daemon.
+An hour, before anyone tried `wait` on its own.
+
+The command was:
+
+```bash
+co browser -t <tab> wait 2500
+```
+
+`wait` takes seconds.
+
+## The unit was guessable, and we guessed wrong for them
+
+This is not a typo. Look at every other settle knob in the same tool:
+
+```
+click_element_near_selector(..., wait_ms=1000, ...)
+upload_file_after_click_by_selector(..., timeout_ms=5000)
+```
+
+and the skill that teaches the workflow:
+
+```
+--require_anchor_text=true --wait_ms=2500 --verify_anchor_text_cleared=true
+```
+
+Milliseconds, milliseconds, milliseconds — and then one verb, spelled `wait`,
+in seconds. An agent reading those files and writing `wait 2500` is not being
+careless. It is being consistent with everything around it.
+
+Two thousand five hundred seconds is forty-one minutes.
+
+## What the mistake actually bought
+
+Forty-one minutes of `page.wait_for_timeout` is not, by itself, interesting.
+The interesting part is where those minutes were spent: inside the tab's
+operation lock.
+
+Same-tab commands are serialized on purpose. That is a contract with a test
+holding it in place — one tab is one task, ordered, so two steps of the same
+job cannot interleave on one page. It is the right design. It also means a
+single argument could make the queue behind you forty-one minutes long, and
+that the queue is invisible from outside: the daemon is not stuck, it is
+working, on exactly the thing it was asked to do.
+
+So the failure had no shape anyone could recognise. A wedged process looks
+wedged. This looked healthy.
+
+## The fix is a cap, and the cap is not about rationing
+
+`wait` is now capped at sixty seconds, and refuses past it:
+
+```
+ValueError: wait takes seconds, not milliseconds: 2500 seconds is 42 minutes,
+over the 60s limit.
+  Did you mean `wait 2.5`?
+  A wait holds the tab, so anything longer belongs in a condition, not a sleep:
+  wait_for_element(<description>)  ·  wait_for_text(<text>)
+```
+
+The limit is not there to ration waiting. Nothing that needs more than a minute
+of stillness should be a blocking sleep on a resource other agents may be
+queued behind — that is what `wait_for_element` and `wait_for_text` are for,
+and they return the moment the condition holds instead of burning the whole
+budget every time.
+
+Two details in the implementation are the whole point.
+
+**The refusal happens before the lock is acquired.** A guard inside the
+critical section would still have cost the round its tab. The check runs first,
+touches nothing, and returns.
+
+**The message names the value you meant.** `2500 / 1000 = 2.5`, and 2.5 is
+under the cap, so the error says `Did you mean wait 2.5?`. An error that only
+says no leaves the reader to work out the unit from the same files that misled
+them in the first place.
+
+## Both spellings, or it is not a limit
+
+The verb exists twice: the async core the daemon runs, and the pre-asyncio
+implementation still shipped as the oracle for the verb contract. Both got the
+guard. A limit the two disagree about is not a limit — it is a limit plus a
+way around it, and the way around it is the one nobody is testing.
+
+## What we measured
+
+The regression test was run against unguarded code first. Four of its six
+assertions fail there, including the one that reproduces the damage through the
+daemon: open a tab, send `wait 2500`, then send `status` to the same tab and
+give it ten seconds. Unguarded, that test waits out the full sleep. Guarded, it
+returns immediately.
+
+Then the same command on a real paid browser session:
+
+```
+22:39:27  co browser -t w2 wait 2500
+          ValueError: wait takes seconds, not milliseconds...
+22:39:27  co browser -t w2 get_current_url
+          https://example.com/
+22:39:27
+```
+
+Same second, all three. Before this change, that first line held the tab until
+23:20.
+
+## The lesson that generalises
+
+The unit was documented. `co browser help` printed `wait(seconds)` the whole
+time. Documentation loses to consistency: when nine neighbouring parameters say
+milliseconds, the tenth one's docstring is not what gets read.
+
+So the question to ask about any argument is not "is the unit written down"
+but "what does being wrong about it cost". `wait_ms=2500` on a click is a
+two-and-a-half second pause nobody notices. `wait 2500` was three dead rounds
+and an hour of misdirected debugging, because the same mistake, in a place that
+holds a lock, is a different mistake.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -22,25 +22,32 @@ co env
 
 ## Current preview
 
-Beta **1.8.5b2** adds the settings `b1` made you repeat. `co browser config`
-gives the browser engine a default, so `--engine` is an override rather than
-the only way in, and the paid engine is called `wtf` — its product name — where
-the flag used to say `onion`. `co <provider> serve` is now `consume`, and
-`co auth feishu --app-id` authorizes a bot already in your groups instead of
-creating one that is in none. Every exit on the inbox surface names a command
-to run next.
+Beta **1.8.5b3** fixes two ways the browser could waste an afternoon, both
+found by an unattended agent. `co browser wait` takes seconds while every
+neighbouring knob is named in milliseconds, so `wait 2500` meant forty-one
+minutes holding a tab's lock — every command behind it timed out while
+`status` kept answering, so nothing looked broken. It is capped at 60 seconds
+now and refuses before taking the lock, naming the value you meant. And a
+daemon pinned to an engine refused every bare command, `close` included, while
+its own error told you to run `close`: `auto` is no preference now, verbs that
+touch no page are never gated, and a refusal names only commands that daemon
+would accept. A dead paid session names its recovery, and the paid engine says
+it bills before it spends.
+
+It carries everything from `b2`: `co browser config`, the paid engine called
+`wtf`, `consume`, and `co auth feishu --app-id`.
 
 It is a beta because the no-loss-across-a-reconnect gate has not passed: the
 repair is offline-tested and has not been run against a real group. The release
 notes list what else to decide before putting it on a machine other people use.
-See [1.8.5b2 release notes](releases/1.8.5b2.md).
+See [1.8.5b3 release notes](releases/1.8.5b3.md).
 
 ```bash
-python -m pip install --pre connectonion==1.8.5b2
+python -m pip install --pre connectonion==1.8.5b3
 co --version
 ```
 
-The 1.8.5a1, 1.8.5a2 and 1.8.5b1 previews are superseded; 1.8.4a1 and 1.8.4a2
+The 1.8.5a1, 1.8.5a2, 1.8.5b1 and 1.8.5b2 previews are superseded; 1.8.4a1 and 1.8.4a2
 are historical, and the planned 1.8.4b1 was folded into the stable release. The
 tag workflow builds and verifies the public package before documentation is
 deployed. Google authorization from 1.8.3 is retained; TikTok remains deferred.

--- a/docs/releases/1.8.5b3.md
+++ b/docs/releases/1.8.5b3.md
@@ -1,0 +1,102 @@
+# ConnectOnion 1.8.5b3 — beta
+
+Beta, 12 September 2026. Two fixes on top of `1.8.5b2`, both found by an
+unattended agent losing a whole afternoon to them.
+
+Stable stays **1.8.4**. This is not Latest and needs an explicit pin or
+`--pre`:
+
+```bash
+python -m pip install --pre connectonion==1.8.5b3
+co --version
+```
+
+## Changes
+
+**`co browser wait` takes seconds, and now says so instead of sleeping.** Every
+other settle knob in the browser tools is named in milliseconds — `wait_ms`,
+`timeout_ms`, `--wait_ms=2500` — so `wait 2500` reads as two and a half seconds
+and meant forty-one minutes. Those minutes were spent holding the tab's
+operation lock, and same-tab commands are serialized on purpose, so every later
+command against that tab queued behind the sleep and died at the client's
+120-second ceiling. Meanwhile `status` kept answering and other tabs kept
+working, so a health probe found nothing to restart. Three unattended rounds
+died this way; one spent fourteen minutes on seven timeouts to do one item's
+work.
+
+`wait` is capped at 60 seconds and refuses past it **before acquiring the
+lock**:
+
+```
+ValueError: wait takes seconds, not milliseconds: 2500 seconds is 42 minutes,
+over the 60s limit.
+  Did you mean `wait 2.5`?
+  A wait holds the tab, so anything longer belongs in a condition, not a sleep:
+  wait_for_element(<description>)  ·  wait_for_text(<text>)
+```
+
+The cap is not rationing. A settle longer than a second or two wants a
+condition — `wait_for_element`, `wait_for_text` — which returns when the
+condition holds instead of spending the whole budget every time.
+
+**A pinned browser daemon no longer refuses the command it tells you to run.**
+The daemon pins its engine at startup and compared it against every request.
+A bare `co browser <verb>` resolves to `engine=auto`, so once a daemon was
+started with `--engine wtf`, every bare command was refused — including
+`tab ls`, `status` and `close`, none of which touch a page. And the refusal's
+own remedy was `co browser close`, refused by the same guard. Following it
+literally loops forever; only `co browser --engine onion close` worked, and
+nothing named it.
+
+Three changes:
+
+- **`auto` is no preference, not a conflicting one.** Only a *named* engine that
+  differs is a conflict now. This is also the second half of the configurable
+  default work: a bare command rides whatever is running.
+- **Verbs that touch no page are never gated** — `close`, `closetab`, `status`,
+  `engine_status`, `help`, `tab ls`, `tab close`. `tab open` is deliberately not
+  among them: it allocates a page, and on a paid pin that spends.
+- **Refusals name only commands that daemon would accept in that state**, using
+  the name a person types (`wtf`), not the wire spelling (`onion`).
+
+The one place `auto` still has to ask is money. A *running* paid session is
+consent already given — another tab in it charges nothing further. Once it has
+ended, serving `auto` would silently open a new billing interval, so that case
+asks which engine you want.
+
+**A dead paid session names the way back.** `PaidSessionEndedError` reported
+`browser_exited` and nothing else; its tabs died with it, so the next command
+failed on a missing tab instead, reading as a second unrelated fault. It now
+names `co browser close` and `co browser tab open`, and points at the free
+engine, which keeps your logins.
+
+**The paid engine says it bills before it spends.** A session-starting verb
+(`tab open`, `newtab`, `open_browser`) on the WTF Browser prints one line to
+stderr before the command is sent. The session that reported all of this drove
+an authenticated dashboard on the paid engine for forty minutes, then finished
+the identical work on the free one with the logins intact — nothing had said
+which engine was about to charge.
+
+## Known limits
+
+Unchanged from `b2`: the no-loss-across-a-reconnect gate in #1462 has not
+passed, which is why stable is still 1.8.4. A chat message can command the
+agent and there is no sender allowlist until 1.9.
+
+New and deliberately not fixed here: a browser that exits on its own takes the
+tab registry with it, and there is no auto-reconnect. The errors are now
+self-explaining, but you retype the two commands. Reconnect semantics — and
+what a tab entry means with no page behind it — need a design, not a message,
+and for the paid engine a reconnect is a new billing interval, so it lands back
+on the consent rule above. Tracked in #1513 for 1.8.6.
+
+## Verification
+
+Both fixes were checked against a real paid WTF Browser session, not only in
+tests: the bare command a `wtf`-pinned daemon used to refuse is served, and
+`wait 2500` returns in the same second it was issued with the tab immediately
+usable afterwards.
+
+Each regression suite was run against unguarded code first — 4 of 6 and 6 of 14
+assertions fail there, including the two that reproduce the original damage
+through the daemon.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.8.5b2"
+version = "1.8.5b3"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.8.5b2"
+version = "1.8.5b3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Two fixes on top of `1.8.5b2`, both found by an unattended agent losing an
afternoon to them. Closes nothing new — #1509, #1510 and #1501 were closed by
#1511 and #1512; this publishes them.

## What ships

**`co browser wait` takes seconds, and says so instead of sleeping** (#1509).
Every other settle knob in the browser tools is named in milliseconds —
`wait_ms`, `timeout_ms`, `--wait_ms=2500` — so `wait 2500` read as 2.5 seconds
and meant forty-one minutes, spent holding the tab's operation lock. Same-tab
commands are serialized on purpose, so every later command against that tab
queued behind the sleep and died at the client's 120s ceiling, while `status`
kept answering and other tabs kept working. Capped at 60s, refused before the
lock is acquired, naming the value the caller meant.

**A pinned daemon no longer refuses the command it tells you to run**
(#1510, #1501). `auto` is no preference rather than a conflicting one; verbs
that touch no page are never gated; refusals name only commands that daemon
would accept in that state, using `wtf` rather than the wire spelling `onion`.
The one case `auto` still asks is money: a running paid session is consent
already given, an ended one would open a new billing interval.

Plus the two smaller asks from #1510: `PaidSessionEndedError` names its
recovery, and a session-starting verb on the paid engine says it bills before
the command is sent.

## Version surface

`_version.py`, `pyproject.toml`, `VERSIONING.md` (candidate section + history),
`docs/releases.md`, `docs/releases/1.8.5b3.md`, `uv.lock`.

Stable stays **1.8.4** — the no-loss-across-a-reconnect gate in #1462 has not
passed. The release notes carry a Known limits section naming #1513 (a browser
that exits on its own takes the tab registry with it) as deliberately deferred
to 1.8.6.

## The blog posts

Two Design Journal posts, one per fix. #1511 and #1512 waived the gate with
`no-blog`; that label is for typos and lockfiles, and those two were not. This
pays it back rather than leaving the site short two entries.

## Verification

Both fixes were checked against a **real paid WTF Browser session**, not only
in tests — a bare command a `wtf`-pinned daemon used to refuse is served, and
`wait 2500` returns in the same second it was issued with the tab immediately
usable. Each regression suite was run against unguarded code first (4 of 6, and
6 of 14, fail there).

864 version + browser unit tests pass locally.

**Proposed target version:** 1.8.5b3
**Estimated release window:** today, 2026-09-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3VJDT8R3Sr69BzfEBxT6
