### PR TITLE
feat(inbox): record which consumer handled each message

### DIFF
--- a/connectonion/cli/co_ai/listen.py
+++ b/connectonion/cli/co_ai/listen.py
@@ -17,10 +17,10 @@ than corrupting it.
 """
 
 import threading
-from pathlib import Path
-from typing import Callable, List, Optional, Sequence
+from typing import Callable, Optional, Sequence
 
-from ...inbox import Inbox, provider as _provider
+from ...inbox import Inbox
+from ...inbox import provider as _provider
 from ...inbox.settings import Channel
 
 
@@ -67,9 +67,11 @@ def _handler(channel: Channel, inbox: Inbox, provider, agent, sessions: dict, gu
         try:
             sent = provider.send(message.chat, reply, reply_to=message.id)
         except Exception as exc:
-            inbox.record_sent(chat=message.chat, text=reply, reply_to=message.id, error=str(exc))
+            inbox.record_sent(chat=message.chat, text=reply, reply_to=message.id,
+                              error=str(exc), by="co-ai")
             raise RuntimeError(f"reply failed: {exc}") from exc
-        inbox.record_sent(chat=message.chat, text=reply, reply_to=message.id, provider_id=sent)
+        inbox.record_sent(chat=message.chat, text=reply, reply_to=message.id,
+                          provider_id=sent, by="co-ai")
 
     return answer
 
@@ -95,7 +97,7 @@ def listen(channels: Sequence[Channel], agent_factory: Callable, *,
         loops.append(threading.Thread(
             target=inbox.serve, args=(handler,),
             kwargs={"workers": workers, "idle_seconds": idle_seconds,
-                    "should_stop": stop, "once": once},
+                    "should_stop": stop, "once": once, "by": "co-ai"},
             name=f"listen-{channel.provider}", daemon=True))
 
     for loop in loops:

--- a/connectonion/cli/commands/listen_commands.py
+++ b/connectonion/cli/commands/listen_commands.py
@@ -8,7 +8,6 @@ LLM-Note:
   Errors: a missing credential prints the item and the next action and exits 3 | a provider refusal prints its own words and exits 1 | nothing is printed on the success path of listen (Rule of Silence); the log has it
 """
 
-import json
 import os
 import shutil
 import subprocess
@@ -66,7 +65,7 @@ def _listener_or_exit(inbox: Inbox) -> None:
 
 def handle_done(name: str, message_id: str) -> None:
     """Forget a taken message without replying, so it does not come back."""
-    Inbox(name).done(message_id)
+    Inbox(name).done(message_id, by="done")
 
 
 def handle_listen(name: str, raw: bool = False) -> None:
@@ -158,10 +157,10 @@ def handle_send(name: str, chat: str, text: Optional[str] = None, reply_to: Opti
     try:
         sent = p.send(chat, body, reply_to=reply_to)
     except Exception as exc:
-        inbox.record_sent(chat=chat, text=body, reply_to=reply_to, error=str(exc))
+        inbox.record_sent(chat=chat, text=body, reply_to=reply_to, error=str(exc), by="send")
         errors.print(str(exc), style="red")
         sys.exit(1)
-    inbox.record_sent(chat=chat, text=body, reply_to=reply_to, provider_id=sent)
+    inbox.record_sent(chat=chat, text=body, reply_to=reply_to, provider_id=sent, by="send")
     print(sent)
 
 
@@ -180,11 +179,13 @@ def handle_reply(name: str, message_id: str, text: Optional[str] = None, again: 
     try:
         sent = p.send(original.chat, body, reply_to=message_id, fresh=again)
     except Exception as exc:
-        inbox.record_sent(chat=original.chat, text=body, reply_to=message_id, error=str(exc))
+        inbox.record_sent(chat=original.chat, text=body, reply_to=message_id,
+                          error=str(exc), by="reply")
         errors.print(str(exc), style="red")
         sys.exit(1)
-    inbox.record_sent(chat=original.chat, text=body, reply_to=message_id, provider_id=sent)
-    inbox.done(message_id)
+    inbox.record_sent(chat=original.chat, text=body, reply_to=message_id, provider_id=sent,
+                      by="reply")
+    inbox.done(message_id, by="reply")
     print(sent)
 
 
@@ -217,9 +218,25 @@ def handle_ls(name: str) -> None:
         print(f"{record['id']}\t{record['chat']}\t{record.get('sender', '')}\t{text}")
 
 
+def _handled_lines(inbox: Inbox) -> List[str]:
+    """Who handled the last few messages, for `log`. Descriptive only: a
+    record from before `by` existed shows `-`, and a malformed value never
+    crashes the display."""
+    lines = []
+    for record in inbox.recent_records(inbox.sent, 5):
+        lines.append(f"sent to {record.get('chat') or '-'}"
+                     f" reply_to {record.get('reply_to') or '-'}"
+                     f" by {record.get('by') or '-'}")
+    for record in inbox.recent_records(inbox.completed, 5):
+        lines.append(f"done {record.get('id') or '-'} by {record.get('by') or '-'}")
+    return lines
+
+
 def handle_log(name: str, follow: bool = False) -> None:
     """Every message ever received; -f keeps printing new ones."""
     inbox = Inbox(name)
+    for line in _handled_lines(inbox):
+        print(line)
     inbox.received.touch()
     with inbox.received.open("r", encoding="utf-8") as handle:
         while True:
@@ -245,6 +262,7 @@ def handle_consume(name: str, command: List[str], once: bool = False, workers: i
         errors.print(f"cannot run {command[0] if command else '(no command)'}: not found or not executable", style="red")
         sys.exit(2)
     _listener_or_exit(inbox)
+    consumer = f"consume:{os.path.basename(command[0])}"
 
     def answer(message) -> None:
         env = dict(
@@ -274,15 +292,17 @@ def handle_consume(name: str, command: List[str], once: bool = False, workers: i
         try:
             sent = p.send(message.chat, reply, reply_to=message.id)
         except Exception as exc:
-            inbox.record_sent(chat=message.chat, text=reply, reply_to=message.id, error=str(exc))
+            inbox.record_sent(chat=message.chat, text=reply, reply_to=message.id,
+                              error=str(exc), by=consumer)
             raise RuntimeError(f"reply failed: {exc}") from exc
-        inbox.record_sent(chat=message.chat, text=reply, reply_to=message.id, provider_id=sent)
+        inbox.record_sent(chat=message.chat, text=reply, reply_to=message.id,
+                          provider_id=sent, by=consumer)
 
     try:
         # workers=1: a shell command written for this has always run one at a
         # time, and some of them are not safe to run twice at once. The lanes
         # still give it ordering, lease renewal and the give-up rule; anyone
         # who wants the parallelism asks for it with --workers.
-        inbox.serve(answer, workers=workers, once=once)
+        inbox.serve(answer, workers=workers, once=once, by=consumer)
     except KeyboardInterrupt:
         return

--- a/connectonion/inbox/consumer.py
+++ b/connectonion/inbox/consumer.py
@@ -16,8 +16,8 @@ strict order where a human would notice, and no waiting where they would not.
 
 import queue
 import threading
-import time
 from typing import Callable, Optional
+
 
 # What a conversation is, when the caller does not say. Two threads of one
 # group are two conversations: they are two questions, and the people asking
@@ -60,7 +60,7 @@ class _Lane:
 
 class _Loop:
     def __init__(self, inbox, handler, *, lane_key, workers, lease_seconds,
-                 max_attempts, idle_seconds, should_stop):
+                 max_attempts, idle_seconds, should_stop, by: Optional[str] = None):
         self.inbox = inbox
         self.handler = handler
         self.lane_key = lane_key
@@ -68,6 +68,10 @@ class _Loop:
         self.max_attempts = max_attempts
         self.idle_seconds = idle_seconds
         self.should_stop = should_stop or threading.Event()
+        # Who is handling: a descriptive label for done.jsonl (host, co-ai,
+        # receive, consume:<cmd>), so consumers sharing one directory leave
+        # distinguishable trails. Nothing decides on it.
+        self.by = by
         # The cap is on handlers, not on lanes: a lane costs a sleeping thread,
         # a handler costs a model call.
         self.slots = threading.Semaphore(workers)
@@ -111,7 +115,7 @@ class _Loop:
             # into an unanswered question.
             self.inbox.log(f"{message.id} not finished: {type(error).__name__}: {error}")
         else:
-            self.inbox.done(message.id)
+            self.inbox.done(message.id, by=self.by)
         finally:
             keep_alive.set()
             lease.join(timeout=1)
@@ -146,7 +150,7 @@ class _Loop:
                 # consumer too, every hour, forever.
                 self.inbox.log(
                     f"gave up on {message.id} after {attempts - 1} attempts")
-                self.inbox.done(message.id)
+                self.inbox.done(message.id, by=self.by)
                 continue
             self.dispatch(message)
             if once:
@@ -172,7 +176,8 @@ class _Loop:
 def serve(inbox, handler: Callable, *, lane_key: Optional[Callable] = None,
           workers: int = 4, lease_seconds: float = 300.0, max_attempts: int = 3,
           idle_seconds: float = 600.0, once: bool = False,
-          should_stop: Optional[threading.Event] = None) -> None:
+          should_stop: Optional[threading.Event] = None,
+          by: Optional[str] = None) -> None:
     """Take messages from `inbox` and give them to `handler`, forever.
 
     `handler(message)` owns the outcome. Returning means the message is
@@ -181,9 +186,12 @@ def serve(inbox, handler: Callable, *, lane_key: Optional[Callable] = None,
     for the sweep. That is the whole contract, which is why the same loop can
     drive a subprocess, an Agent, or a Host.
 
+    `by` names this consumer once (host, co-ai, consume:<cmd>) so its
+    done.jsonl records say who handled what. Descriptive only.
+
     Blocks until `should_stop` is set.
     """
     loop = _Loop(inbox, handler, lane_key=lane_key or default_lane, workers=workers,
                  lease_seconds=lease_seconds, max_attempts=max_attempts,
-                 idle_seconds=idle_seconds, should_stop=should_stop)
+                 idle_seconds=idle_seconds, should_stop=should_stop, by=by)
     loop.run(once=once)

--- a/connectonion/inbox/store.py
+++ b/connectonion/inbox/store.py
@@ -14,17 +14,17 @@ raw filesystem consumer still owns its claim lifetime; use receive/done for
 the coordinated lease and durable completion behavior. DD-063 has the interface.
 """
 
-import json
 import hashlib
-from contextlib import contextmanager
-from functools import wraps
+import json
 import os
 import re
 import subprocess
 import sys
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from functools import wraps
 from pathlib import Path
 from typing import Optional
 
@@ -301,13 +301,21 @@ class Inbox:
                 if (message := self._read_queue_file(path)) is not None]
 
     @_serialized
-    def done(self, message_id: str) -> None:
+    def done(self, message_id: str, *, by: Optional[str] = None) -> None:
         """Forget a message: the reply went out, or the consumer decided there
         is nothing to say. Clears the queue as well as cur/, so a reply made
         straight from `ls` without a `receive` does not leave the message
-        waiting to be handed out again."""
+        waiting to be handed out again.
+
+        `by` names the consumer that handled the message (host, co-ai,
+        receive, reply, done, consume:<cmd>). It is a descriptive label only:
+        nothing reads it to decide anything, and it is omitted when None so
+        records written before it existed still read."""
         # Persist completion before removal; silence is an outcome, not a send.
-        self._append(self.completed, json.dumps({"id": message_id, "at": _now_iso()}))
+        record = {"id": message_id, "at": _now_iso()}
+        if by is not None:
+            record["by"] = by
+        self._append(self.completed, json.dumps(record))
         wanted = _safe(message_id)
         for directory in (self.cur, self.new):
             for path in directory.iterdir():
@@ -381,7 +389,11 @@ class Inbox:
         reply_to: Optional[str] = None,
         provider_id: Optional[str] = None,
         error: Optional[str] = None,
+        by: Optional[str] = None,
     ) -> None:
+        """One line in sent.jsonl. `by` names the consumer that sent it; it is
+        a descriptive label only and is omitted when None so older records
+        still read."""
         record = {
             "at": _now_iso(),
             "chat": chat,
@@ -391,6 +403,8 @@ class Inbox:
             "ok": error is None,
             "error": error,
         }
+        if by is not None:
+            record["by"] = by
         self._append(self.sent, json.dumps(record, ensure_ascii=False, separators=(",", ":")))
 
     def already_replied(self, message_id: str) -> bool:
@@ -419,6 +433,13 @@ class Inbox:
         except FileNotFoundError:
             return []
         return [line for line in lines if line.strip()][-count:]
+
+    def recent_records(self, path: Path, count: int = 5) -> list[dict]:
+        """The last `count` well-formed records from a JSONL file. A missing
+        file reads as no records; records written before `by` existed read
+        with no `by` key."""
+        records = list(self._records(path))
+        return records[max(0, len(records) - count):]
 
     # ---- the listener lock -----------------------------------------------------
     #

--- a/connectonion/network/host/inbox.py
+++ b/connectonion/network/host/inbox.py
@@ -26,7 +26,6 @@ that reads them.
 import threading
 import uuid
 from pathlib import Path
-from typing import Optional
 
 # One session per conversation, stable across restarts: the same chat and
 # thread must name the same session tomorrow, or every reconnect starts the
@@ -45,7 +44,8 @@ def create_inbox_lifespan(co_dir: Path, create_agent, storage, result_ttl: int,
     Returns (on_startup, on_shutdown), the same pair shape the relay and the
     schedule use, so server.py can compose them.
     """
-    from ...inbox import Inbox, provider as provider_for
+    from ...inbox import Inbox
+    from ...inbox import provider as provider_for
     from ...inbox.settings import configured_channels
 
     stop = threading.Event()
@@ -82,9 +82,11 @@ def create_inbox_lifespan(co_dir: Path, create_agent, storage, result_ttl: int,
             try:
                 sent = provider.send(message.chat, reply, reply_to=message.id)
             except Exception as exc:
-                inbox.record_sent(chat=message.chat, text=reply, reply_to=message.id, error=str(exc))
+                inbox.record_sent(chat=message.chat, text=reply, reply_to=message.id,
+                                  error=str(exc), by="host")
                 raise RuntimeError(f"reply failed: {exc}") from exc
-            inbox.record_sent(chat=message.chat, text=reply, reply_to=message.id, provider_id=sent)
+            inbox.record_sent(chat=message.chat, text=reply, reply_to=message.id,
+                              provider_id=sent, by="host")
 
         return answer
 
@@ -110,7 +112,7 @@ def create_inbox_lifespan(co_dir: Path, create_agent, storage, result_ttl: int,
                 continue
             thread = threading.Thread(
                 target=inbox.serve, args=(_handler(channel, inbox, provider),),
-                kwargs={"workers": 1, "should_stop": stop},
+                kwargs={"workers": 1, "should_stop": stop, "by": "host"},
                 name=f"inbox-{channel.provider}", daemon=True)
             thread.start()
             threads.append(thread)

--- a/tests/unit/test_inbox_store.py
+++ b/tests/unit/test_inbox_store.py
@@ -15,9 +15,9 @@ Components under test:
 
 import json
 import os
-from pathlib import Path
 import threading
 import time
+from pathlib import Path
 
 import pytest
 
@@ -506,3 +506,41 @@ def test_mailbox_defaults_follow_the_global_configuration_directory(tmp_path, mo
     monkeypatch.delenv('CO_INBOX_HOME', raising=False)
     monkeypatch.setenv('AGENT_CONFIG_PATH', str(tmp_path / 'global'))
     assert default_home('lark') == (tmp_path / 'global' / 'inbox' / 'lark').resolve()
+
+
+def test_two_consumers_on_one_inbox_leave_distinguishable_records(tmp_path):
+    box = make(tmp_path)
+    box.deliver(msg(i='om_a'))
+    box.deliver(msg(i='om_b'))
+
+    box.serve(lambda message: None, once=True, by='consumer-a')
+    box.serve(lambda message: None, once=True, by='consumer-b')
+
+    done = [json.loads(line) for line in box.completed.read_text().splitlines()]
+    assert [(r['id'], r['by']) for r in done] == [('om_a', 'consumer-a'), ('om_b', 'consumer-b')]
+
+    box.record_sent(chat='oc_a', text='answer a', reply_to='om_a',
+                    provider_id='om_r1', by='consumer-a')
+    box.record_sent(chat='oc_b', text='answer b', reply_to='om_b',
+                    provider_id='om_r2', by='consumer-b')
+    sent = [json.loads(line) for line in box.sent.read_text().splitlines()]
+    assert [(r['reply_to'], r['by']) for r in sent] == [('om_a', 'consumer-a'),
+                                                       ('om_b', 'consumer-b')]
+
+    # A record written before `by` existed still reads, with the key absent.
+    box._append(box.completed, json.dumps({'id': 'om_old', 'at': '2026-01-01T00:00:00Z'}))
+    assert [r.get('by') for r in box._records(box.completed)] == ['consumer-a', 'consumer-b',
+                                                                  None]
+
+
+def test_a_message_handed_out_twice_after_lease_expiry_shows_both_consumers(tmp_path):
+    box = make(tmp_path)
+    box.deliver(msg(i='om_x'))
+
+    assert box.receive(timeout=0).id == 'om_x'  # first consumer takes it
+    box.release_stale(max_age=0)  # its lease expired; the sweep offers it again
+    box.serve(lambda message: None, once=True, by='second')  # second consumer finishes it
+    box.done('om_x', by='first')  # the first consumer finishes late
+
+    bys = [r.get('by') for r in box._records(box.completed) if r.get('id') == 'om_x']
+    assert bys == ['second', 'first']


### PR DESCRIPTION
## What

`done.jsonl` and `sent.jsonl` now carry a descriptive `by` field naming the consumer that handled or sent a message, so several consumers sharing one inbox directory leave a distinguishable trail instead of an identical one.

Values: `host`, `co-ai`, `consume:<command basename>`, and `send` / `reply` / `done` for the bare shell verbs.

## Why

Several consumers of one inbox is the design (`co ai --listen`, the Host lifespan, and `co <provider> consume -- <command>`). They cannot collide on a message — taking one is `rename(2)` — but the records they left said nothing about who did what, so "which of them had it?" was unanswerable.

## How

- `connectonion/inbox/store.py`: `done()` and `record_sent()` take an optional `by` and include it when supplied; `recent_records()` reads the last few lines of a JSONL file for the display.
- `connectonion/inbox/consumer.py`: `serve()` takes `by` and threads it to the loop, which stamps both completion paths (the success path and the give-up-after-max-attempts path).
- `connectonion/cli/commands/listen_commands.py`: shell verbs name themselves (`send`, `reply`, `done`), `consume` derives `consume:<basename>` once, and `co <provider> log` shows who handled the last few.
- `connectonion/cli/co_ai/listen.py` and `connectonion/network/host/inbox.py`: the `co-ai` and `host` consumers name themselves at their `serve()` and `record_sent()` call sites.

The field is optional, so records written by an older version still read (absent, not crashing). It is descriptive only: nothing branches on its value, and a consumer that lies only mislabels its own work.

Touched files were left clean under the repo's ruff config (import sorting; one unused `typing.Optional` import in `network/host/inbox.py`).

## Tests

`tests/unit/test_inbox_store.py` gains two tests using the existing helpers:

- two consumers on one inbox, one message each — the `done.jsonl` and `sent.jsonl` records carry the right `by`, and a record written without `by` still reads;
- a message handed out twice after a lease expiry shows both consumers in `completed`.

`python -m pytest tests/unit/test_inbox_store.py tests/unit/test_listen_commands.py -q` -> **58 passed**. `ruff check` clean on every changed file.

Mutation check: dropping the two `by` writes in `store.py` makes both new tests fail; restoring them makes them pass. The tests are load-bearing.

Fixes #1503

---
Implemented with AI assistance (OpenCode + muse-spark), then reviewed and verified locally (targeted tests, lint, mutation check) before submission.


**Proposed target version:** next minor / next alpha
**Estimated release window:** future roadmap / unknown date
