### PR TITLE
`install-onion` says pip refused by policy, not that pip exited 1 (#1516)

### DIFF
--- a/connectonion/cli/commands/browser_commands.py
+++ b/connectonion/cli/commands/browser_commands.py
@@ -2,8 +2,8 @@
 Purpose: Thin CLI handler for `co browser` — parses -t/--tab targeting, forwards one command to the persistent browser daemon, and serves self-describing help.
 LLM-Note:
   Dependencies: imports from [sys, shlex, browser_agent.client.send | lazy: command_tips.rotating_tip for the success tip, browser_agent.daemon.list_functions for help] | imported by [cli/main.py via browser()] | tested by [tests/e2e/cli/test_browser_daemon.py]
-  Data flow: receives args: list[str] (+ headless and engine_mode) from CLI → validates auto/system/onion → exact `install-onion` runs the signed private-client bootstrap and returns before daemon contact → `help`/`--list` printed locally by introspecting BrowserAutomation (no browser launched) → else _extract_tab() pulls the LEADING -t/--tab NAME run (stops at the verb, so a -t that is a function's own arg passes through; empty --tab= is a usage error) → shlex.join(remaining args) + tab + engine mode → client.send() → a mode-pinned daemon runs it → payload/exit code surfaced by the client
-  State/Effects: `install-onion` explicitly installs a signature/checksum-verified wheel into the current Python environment | otherwise no local state except a best-effort rotating-tip index at ~/.co/.browser_tip (a garbled index resets to the first tip) | a session-starting verb on the paid engine prints a billing notice to STDERR BEFORE the command is sent | the success tip is printed to STDERR (stdout stays pure data) | `help` introspects the class only | direct verbs delegate to the daemon; `do` runs its model loop in this CLI process and delegates each tool call
+  Data flow: receives args: list[str] (+ headless and engine_mode) from CLI → validates auto/system/onion → `install-onion` (alone or with --break-system-packages) runs the signed private-client bootstrap and returns before daemon contact → `help`/`--list` printed locally by introspecting BrowserAutomation (no browser launched) → else _extract_tab() pulls the LEADING -t/--tab NAME run (stops at the verb, so a -t that is a function's own arg passes through; empty --tab= is a usage error) → shlex.join(remaining args) + tab + engine mode → client.send() → a mode-pinned daemon runs it → payload/exit code surfaced by the client
+  State/Effects: `install-onion` explicitly installs a signature/checksum-verified wheel into the current Python environment, and on an externally-managed interpreter says so and names the opt-in flag rather than reporting an exit code | otherwise no local state except a best-effort rotating-tip index at ~/.co/.browser_tip (a garbled index resets to the first tip) | a session-starting verb on the paid engine prints a billing notice to STDERR BEFORE the command is sent | the success tip is printed to STDERR (stdout stays pure data) | `help` introspects the class only | direct verbs delegate to the daemon; `do` runs its model loop in this CLI process and delegates each tool call
   Integration: exposes _extract_tab(args) -> (tab|None, remaining|None), _next_tip(), handle_browser(args, headless=False, engine_mode="auto") -> int | called from main.py browser command | USAGE/TIPS document the tab lifecycle, engine modes, and exit-code contract
   Performance: direct verbs do not import the browser-owning daemon, Agent, or Playwright; `help` lazily imports the schema (no socket, no Chrome) | other verbs: one socket round-trip, first call spawns the daemon
   Errors: no-args / bad -t → prints usage to stderr, exit 2 | daemon errors come back as ERR[ <code>] → stderr + the mirrored exit code (0 ok · 1 failure · 2 usage · 3 unknown tab · 4 tab busy)
@@ -104,15 +104,23 @@ def handle_browser(args, headless: bool = False, engine_mode: str = "auto") -> i
         print(USAGE, file=sys.stderr)
         return 2
     if args[0] == "install-onion":
-        if args != ["install-onion"]:
-            print("usage: co browser install-onion", file=sys.stderr)
+        # The flag is opt-in and named after pip's own, because it overrides a
+        # policy the OS set on its interpreter. The failure message is where a
+        # caller learns it exists; nothing chooses it for them.
+        rest = args[1:]
+        override = rest == ["--break-system-packages"]
+        if rest and not override:
+            print(
+                "usage: co browser install-onion [--break-system-packages]",
+                file=sys.stderr,
+            )
             return 2
         from connectonion.credentials import AmbientCredentialError
 
         from .onionwright_install import OnionwrightInstallError, install_onionwright
 
         try:
-            result = install_onionwright()
+            result = install_onionwright(break_system_packages=override)
         except (OnionwrightInstallError, AmbientCredentialError) as exc:
             print(f"Could not install Onionwright: {exc}", file=sys.stderr)
             return 1

--- a/connectonion/cli/commands/onionwright_install.py
+++ b/connectonion/cli/commands/onionwright_install.py
@@ -189,7 +189,33 @@ def _download_wheel(url: str, destination: Path, expected_sha256: str) -> None:
         )
 
 
-def install_onionwright() -> InstallResult:
+def _install_failure_advice(completed, break_system_packages: bool) -> str:
+    """Say why pip refused, and name the command that gets past it.
+
+    An exit code on its own sent a reader looking for a broken download when
+    the actual answer was a policy the OS applies to its own interpreter, and
+    every Homebrew and system Python answers that way. Print what pip said, then
+    the one command that works here — not a suggestion to fix pip.
+    """
+    output = f"{completed.stdout or ''}{completed.stderr or ''}".strip()
+    tail = f"\n\npip said:\n{output}" if output else ""
+    if "externally-managed-environment" in output and not break_system_packages:
+        return (
+            "this Python is externally managed, so pip will not write to it.\n\n"
+            f"  This interpreter:  {sys.executable}\n\n"
+            "Install into it anyway — the right answer when `co` itself lives "
+            "there, because\nOnionwright has to be importable by this same "
+            "interpreter:\n"
+            "  co browser install-onion --break-system-packages\n\n"
+            "Or put both in a virtualenv, where nothing needs the flag:\n"
+            "  python3 -m venv ~/.co/venv\n"
+            "  ~/.co/venv/bin/pip install --pre connectonion"
+            f"{tail}"
+        )
+    return f"pip could not install Onionwright (exit {completed.returncode}).{tail}"
+
+
+def install_onionwright(*, break_system_packages: bool = False) -> InstallResult:
     """Install the current private client into this exact Python environment."""
     current = _installed_version()
     if _is_compatible(current):
@@ -225,17 +251,24 @@ def install_onionwright() -> InstallResult:
             "install",
             "--upgrade",
             "--disable-pip-version-check",
+            *(["--break-system-packages"] if break_system_packages else []),
             str(wheel),
         ]
         try:
-            completed = subprocess.run(command, check=False)
+            # Captured rather than streamed: the wheel is ~70 KB, so there is no
+            # progress worth watching, and the exit code alone cannot tell a
+            # refusal-by-policy from a genuine failure. The output is printed
+            # back on failure, so nothing is hidden.
+            completed = subprocess.run(
+                command, check=False, capture_output=True, text=True
+            )
         except OSError as exc:
             raise OnionwrightInstallError(
                 "Could not start pip in the current Python environment."
             ) from exc
         if completed.returncode != 0:
             raise OnionwrightInstallError(
-                f"pip could not install Onionwright (exit {completed.returncode})."
+                _install_failure_advice(completed, break_system_packages)
             )
 
     installed = _installed_version()

--- a/docs/blog/2026-09-12-pip-did-not-fail-it-declined.md
+++ b/docs/blog/2026-09-12-pip-did-not-fail-it-declined.md
@@ -1,0 +1,125 @@
+# pip did not fail, it declined
+
+An old Intel MacBook is our acceptance machine for x86_64 macOS. Someone
+reported the paid browser engine would not run on it, so I went to look. The
+first thing `co` said there was:
+
+```
+BrowserEngineError: onionwright_missing: Run `co browser install-onion`
+```
+
+Good error. Names a command. So I ran the command:
+
+```
+Could not install Onionwright: pip could not install Onionwright (exit 1).
+```
+
+And that is where the trail went cold — except it hadn't, because sixteen lines
+above that, pip had explained itself perfectly:
+
+```
+error: externally-managed-environment
+× This environment is externally managed
+...
+You may restore the old behavior of pip by passing the '--break-system-packages'
+flag to pip ...
+Read more about this behavior here: <https://peps.python.org/pep-0668/>
+```
+
+pip had not failed. pip had **declined**, on purpose, for a reason it stated,
+and had named the flag that overrides it.
+
+## The last line is the one that gets read
+
+Our line was printed after all of that, and it said `exit 1`.
+
+This matters more than it looks. A human skims upward and finds pip's text. An
+agent does not: it reads the last line, or it reads the exception message, and
+both said an exit code. From there, `exit 1` on an install points at the
+download, the release feed, the credentials — every one of which was fine.
+
+And this is not an exotic setup. PEP 668 is the default for Homebrew Python and
+for the Python that ships with most Linux distributions. Anyone who did not
+build their own interpreter hits it. So the documented path to the paid engine —
+an error naming `install-onion`, and `install-onion` naming an exit code —
+dead-ends on the ordinary case.
+
+## Two things changed
+
+**pip's output is captured now, and printed back.** Captured, because an exit
+code alone cannot tell a refusal-by-policy from a genuine failure and we have to
+look at the text to know which one happened. Printed back, because the upstream
+text is the evidence — summarising it away would be trading one lost signal for
+another. The wheel is about 70 KB, so there is no progress bar worth watching;
+nothing is lost by not streaming.
+
+**A policy refusal says so, and names the interpreter:**
+
+```
+Could not install Onionwright: this Python is externally managed, so pip will not write to it.
+
+  This interpreter:  /usr/local/opt/python@3.13/bin/python3.13
+
+Install into it anyway — the right answer when `co` itself lives there, because
+Onionwright has to be importable by this same interpreter:
+  co browser install-onion --break-system-packages
+
+Or put both in a virtualenv, where nothing needs the flag:
+  python3 -m venv ~/.co/venv
+  ~/.co/venv/bin/pip install --pre connectonion
+```
+
+The interpreter path is there because that is the thing the reader has to make a
+decision about, and it is not guessable — `co` may be one of four Pythons on
+that machine.
+
+## Why we do not just pass the flag
+
+The obvious shortcut is to retry automatically with `--break-system-packages`.
+We don't, and the reason is in the name of the flag.
+
+PEP 668 exists because package managers and pip were both writing to the same
+site-packages and breaking each other. The marker file is a person or an OS
+saying *I manage this one*. Silently overriding it on someone's behalf, inside a
+command they ran for an unrelated reason, is the kind of helpfulness that shows
+up three weeks later as a broken `brew` and no memory of what did it.
+
+So the flag is opt-in, spelled exactly like pip's own, and the failure message
+is the only place it is advertised. The user overrides their own guard, knowingly,
+or they move to a virtualenv.
+
+One detail that is easy to miss: the flag is **not** re-offered when it was
+already used. If pip refuses with the override already on, suggesting the
+override is a loop — the same shape as an error that tells you to run the
+command it is refusing.
+
+## Verified where it was found
+
+The test suite proves the classification, but the check that mattered was on the
+machine that produced the original message: run it, read the new refusal, then
+run the command the refusal prints.
+
+```
+co browser install-onion --break-system-packages
+→ Installed Onionwright 0.0.14 from the signed OpenOnion release.
+```
+
+Printing a command is a promise that it works. The only way to keep that promise
+is to run it.
+
+## Postscript: the engine still would not start
+
+With Onionwright installed, the paid engine on that machine says:
+
+```
+BrowserEngineError: artifact_unavailable: Use system Chrome on this platform or revision.
+```
+
+Which is correct, and a different problem entirely: there is no `darwin-x86_64`
+object in the production release bucket. It was built and staged on 2026-09-04
+and never promoted, because the native gate failed that day — the same way the
+arm64 gate failed that day. arm64 was re-run on the 5th and passed. Intel was
+never re-run.
+
+Two unrelated faults, stacked, both presenting as "the paid browser doesn't work
+here". Only one of them was ours to fix in code.

--- a/tests/unit/test_install_onion_on_a_managed_python.py
+++ b/tests/unit/test_install_onion_on_a_managed_python.py
@@ -1,0 +1,106 @@
+"""pip refusing by policy is not the same failure as pip breaking.
+
+Measured on the Intel acceptance Mac, 2026-09-12, with `co` installed into
+Homebrew's python@3.13:
+
+    Could not install Onionwright: pip could not install Onionwright (exit 1).
+
+pip's own text above it said `externally-managed-environment` — a policy the OS
+applies to its own interpreter, which every Homebrew and system Python applies
+too. The line a reader ends on, and the only line an agent parses, named an exit
+code instead. So the next move looks like "the download is broken" when it is
+"this interpreter does not accept writes without an explicit override".
+
+`co` itself lives in that interpreter, and Onionwright has to be importable by
+the same one, so a virtualenv is a real answer only if `co` moves there too.
+Both routes are named; neither is chosen for the caller, because the flag
+overrides a guard somebody put there on purpose.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from connectonion.cli.commands import browser_commands
+from connectonion.cli.commands.onionwright_install import _install_failure_advice
+
+PIP_REFUSAL = """error: externally-managed-environment
+
+× This environment is externally managed
+╰─> To install Python packages system-wide, try brew install ...
+"""
+
+
+def _completed(stderr="", stdout="", returncode=1):
+    return subprocess.CompletedProcess(
+        args=["pip"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_a_policy_refusal_is_named_as_one():
+    advice = _install_failure_advice(_completed(stderr=PIP_REFUSAL), False)
+
+    assert "externally managed" in advice
+    assert "exit 1" not in advice, "the exit code is the least useful thing here"
+
+
+def test_it_names_the_interpreter_the_reader_has_to_decide_about():
+    advice = _install_failure_advice(_completed(stderr=PIP_REFUSAL), False)
+
+    assert sys.executable in advice
+
+
+def test_it_names_both_routes_and_picks_neither():
+    advice = _install_failure_advice(_completed(stderr=PIP_REFUSAL), False)
+
+    assert "co browser install-onion --break-system-packages" in advice
+    assert "venv" in advice
+
+
+def test_pips_own_words_are_kept():
+    """Never summarise away the upstream text; it is the evidence."""
+    advice = _install_failure_advice(_completed(stderr=PIP_REFUSAL), False)
+
+    assert "externally-managed-environment" in advice
+
+
+def test_an_ordinary_failure_still_reads_as_one():
+    advice = _install_failure_advice(_completed(stderr="No space left on device"), False)
+
+    assert "exit 1" in advice
+    assert "--break-system-packages" not in advice, "do not offer a flag that cannot help"
+    assert "No space left on device" in advice
+
+
+def test_the_flag_is_not_re_offered_after_it_was_already_used():
+    """If the override was on and pip still refused, repeating it is a loop."""
+    advice = _install_failure_advice(_completed(stderr=PIP_REFUSAL), True)
+
+    assert "--break-system-packages" not in advice
+
+
+@pytest.mark.parametrize(
+    "args,expected_override",
+    [(["install-onion"], False), (["install-onion", "--break-system-packages"], True)],
+)
+def test_the_cli_passes_the_choice_through(monkeypatch, args, expected_override):
+    seen = {}
+
+    class _Result:
+        version, already_installed = "0.0.14", False
+
+    monkeypatch.setattr(
+        "connectonion.cli.commands.onionwright_install.install_onionwright",
+        lambda **kw: seen.update(kw) or _Result(),
+    )
+
+    assert browser_commands.handle_browser(list(args)) == 0
+    assert seen == {"break_system_packages": expected_override}
+
+
+def test_an_unknown_flag_is_still_a_usage_error(capsys):
+    assert browser_commands.handle_browser(["install-onion", "--yolo"]) == 2
+
+    usage = capsys.readouterr().err
+    assert "--break-system-packages" in usage, "usage must list what IS accepted"

--- a/tests/unit/test_onionwright_install.py
+++ b/tests/unit/test_onionwright_install.py
@@ -94,12 +94,14 @@ def test_signed_wheel_is_verified_before_exact_current_python_pip(monkeypatch):
         lambda url, **kwargs: wheel_response,
     )
 
-    def run(command, check):
+    def run(command, check, capture_output=False, text=False):
         assert check is False
+        # Captured so a policy refusal can be told apart from a real failure.
+        assert capture_output is True and text is True
         wheel_path = command[-1]
         assert installer.Path(wheel_path).read_bytes() == wheel
         pip_calls.append(command)
-        return SimpleNamespace(returncode=0)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(installer.subprocess, "run", run)
 
@@ -230,7 +232,9 @@ def test_cli_install_returns_before_contacting_browser_daemon(monkeypatch, capsy
     monkeypatch.setattr(
         installer,
         "install_onionwright",
-        lambda: installer.InstallResult(version="0.0.14", already_installed=False),
+        lambda **kwargs: installer.InstallResult(
+            version="0.0.14", already_installed=False
+        ),
     )
 
     assert browser_commands.handle_browser(["install-onion"]) == 0
@@ -249,7 +253,7 @@ def test_cli_missing_credentials_fails_before_daemon(monkeypatch, capsys):
     monkeypatch.setattr(
         installer,
         "install_onionwright",
-        lambda: (_ for _ in ()).throw(MissingAmbientAPIKey()),
+        lambda **kwargs: (_ for _ in ()).throw(MissingAmbientAPIKey()),
     )
 
     assert browser_commands.handle_browser(["install-onion"]) == 1


### PR DESCRIPTION
Closes #1516.

## The trail

Found while checking why the paid browser engine would not run on the Intel
acceptance Mac. `co` said:

```
BrowserEngineError: onionwright_missing: Run `co browser install-onion`
```

Good error — it names a command. Running the command gave:

```
Could not install Onionwright: pip could not install Onionwright (exit 1).
```

Sixteen lines above that, pip had explained itself: `externally-managed-environment`,
PEP 668, and it had even named `--break-system-packages`. pip had not failed. It
had **declined**, on purpose, for a stated reason.

But the last line — the one a reader ends on and the only one an agent parses —
said an exit code. From there, `exit 1` on an install points at the download, the
release feed, or the credentials, all of which were fine. And PEP 668 is the
default for Homebrew Python and most distro Pythons, so this is the ordinary
case, not an exotic one.

## What changed

**pip's output is captured, and printed back.** Captured because an exit code
alone cannot tell a policy refusal from a real failure. Printed back because the
upstream text is the evidence and summarising it away trades one lost signal for
another. The wheel is ~70 KB, so there is no progress worth streaming.

**A policy refusal says so and names the interpreter:**

```
Could not install Onionwright: this Python is externally managed, so pip will not write to it.

  This interpreter:  /usr/local/opt/python@3.13/bin/python3.13

Install into it anyway — the right answer when `co` itself lives there, because
Onionwright has to be importable by this same interpreter:
  co browser install-onion --break-system-packages

Or put both in a virtualenv, where nothing needs the flag:
  python3 -m venv ~/.co/venv
  ~/.co/venv/bin/pip install --pre connectonion
```

The interpreter path is there because it is what the reader has to decide about,
and it is not guessable — `co` may be one of four Pythons on that machine.

## Why the flag is not passed automatically

PEP 668's marker is a person or an OS saying *I manage this one*. Overriding it
silently, inside a command someone ran for an unrelated reason, is the kind of
help that surfaces three weeks later as a broken `brew` with no memory of what
did it. So it is opt-in, spelled like pip's own, and the failure message is the
only place it is advertised.

It is also **not re-offered when it was already used** — suggesting a flag that
just failed is a loop, the same shape as an error telling you to run the command
it is refusing.

## Verified on the machine that produced the message

Not only in tests:

```
co browser install-onion
→ the new refusal above

co browser install-onion --break-system-packages
→ Installed Onionwright 0.0.14 from the signed OpenOnion release.
```

Printing a command is a promise it works; the only way to keep it is to run it.
The hand-patched files were reverted afterwards and that machine is back on
stock 1.8.5b3.

## Tests

`tests/unit/test_install_onion_on_a_managed_python.py` — 9 tests. Verified red
first: neutering the classification branch fails 3 of them, and the CLI
pass-through tests fail on `main` because the flag does not parse there.

`tests/unit/test_onionwright_install.py` — three test doubles updated for the new
call signature (they asserted the old positional shape of `subprocess.run` and a
zero-argument `install_onionwright`). No behaviour assertions changed.

1454 browser/onion/install unit tests pass.

## Not in this PR

The Intel machine has a second, unrelated blocker: there is no `darwin-x86_64`
object in the production release bucket, so the client correctly answers
`artifact_unavailable`. It was built and staged on 2026-09-04 and never promoted
because the native gate failed that day — the same way the arm64 gate failed that
day. arm64 was re-run on the 5th and passed 7/7; Intel was never re-run. That is
a release-operations task in the `browser` repo, not a code change here.

**Proposed target version:** 1.8.5b4
**Estimated release window:** today, 2026-09-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3VJDT8R3Sr69BzfEBxT6
