### PR TITLE
Release ConnectOnion 1.8.5b4: pip declined, and we said exit 1

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -58,7 +58,18 @@ See [1.8.4 notes](docs/releases/1.8.4.md) for migration and acceptance limits.
 The planned 1.8.4b1 was not published separately; its reviewed changes are included
 in 1.8.4. Publication is performed and verified by the immutable-tag workflow.
 
-## Release candidate: 1.8.5b3 (beta)
+## Release candidate: 1.8.5b4 (beta)
+
+`co browser install-onion` reported `pip could not install Onionwright (exit 1)`
+when pip had in fact declined by policy — PEP 668's externally-managed marker,
+the default on Homebrew and most distro Pythons — and had named the override
+itself. pip's output is now captured so a refusal can be told from a failure,
+printed back either way, and a policy refusal names the interpreter and both
+routes out. `--break-system-packages` is new and opt-in. Stable remains 1.8.4:
+the reconnect-gap gate in #1462 has not passed.
+See [1.8.5b4 notes](docs/releases/1.8.5b4.md).
+
+### Superseded: 1.8.5b3 (beta, published)
 
 Two fixes an unattended agent paid for before we found them. `co browser wait`
 takes seconds while every neighbouring knob is named in milliseconds, so
@@ -162,9 +173,16 @@ Stable remains 1.8.3; this does not authorize final 1.8.4 or cloud provisioning.
 See [1.8.4a2 notes](docs/releases/1.8.4a2.md) and the
 [local acceptance record](docs/acceptance/1.8.4-live-followup/README.md).
 
-## Current Version: 1.8.5b3
+## Current Version: 1.8.5b4
 
 ### Version History
+- 1.8.5b4 (**beta: pip declined, and we reported an exit code.**
+  `co browser install-onion` ended on `pip could not install Onionwright
+  (exit 1)` where pip had refused by PEP 668 policy and named the override
+  itself — the ordinary case on Homebrew and distro Pythons, and the documented
+  route to the paid engine. pip's output is captured and printed back; a policy
+  refusal names the interpreter and both ways past it. `--break-system-packages`
+  is opt-in and never re-offered after it was used. Stable remains 1.8.4.)
 - 1.8.5b3 (**beta: two ways a browser could waste an afternoon.** `wait` takes
   seconds while everything around it is named in milliseconds, so `wait 2500`
   held a tab for 41 minutes and every command behind it timed out while

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.8.5b3"
+__version__ = "1.8.5b4"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -22,7 +22,14 @@ co env
 
 ## Current preview
 
-Beta **1.8.5b3** fixes two ways the browser could waste an afternoon, both
+Beta **1.8.5b4** fixes what `b3` could not install. `co browser install-onion`
+reported `pip could not install Onionwright (exit 1)` when pip had declined by
+policy — PEP 668's externally-managed marker, the default on Homebrew and most
+distro Pythons — and had named the override itself. pip's output is captured now
+so a refusal can be told from a failure, and a policy refusal names the
+interpreter and both routes out. The new `--break-system-packages` is opt-in.
+
+It carries everything from `b3`, which fixes two ways the browser could waste an afternoon, both
 found by an unattended agent. `co browser wait` takes seconds while every
 neighbouring knob is named in milliseconds, so `wait 2500` meant forty-one
 minutes holding a tab's lock — every command behind it timed out while
@@ -40,14 +47,14 @@ It carries everything from `b2`: `co browser config`, the paid engine called
 It is a beta because the no-loss-across-a-reconnect gate has not passed: the
 repair is offline-tested and has not been run against a real group. The release
 notes list what else to decide before putting it on a machine other people use.
-See [1.8.5b3 release notes](releases/1.8.5b3.md).
+See [1.8.5b4 release notes](releases/1.8.5b4.md).
 
 ```bash
-python -m pip install --pre connectonion==1.8.5b3
+python -m pip install --pre connectonion==1.8.5b4
 co --version
 ```
 
-The 1.8.5a1, 1.8.5a2, 1.8.5b1 and 1.8.5b2 previews are superseded; 1.8.4a1 and 1.8.4a2
+The 1.8.5a1, 1.8.5a2, 1.8.5b1, 1.8.5b2 and 1.8.5b3 previews are superseded; 1.8.4a1 and 1.8.4a2
 are historical, and the planned 1.8.4b1 was folded into the stable release. The
 tag workflow builds and verifies the public package before documentation is
 deployed. Google authorization from 1.8.3 is retained; TikTok remains deferred.

--- a/docs/releases/1.8.5b4.md
+++ b/docs/releases/1.8.5b4.md
@@ -1,0 +1,79 @@
+# ConnectOnion 1.8.5b4 — beta
+
+Beta, 12 September 2026. One fix on top of `1.8.5b3`, found by installing the
+previous beta on an old Intel Mac and following its own instructions.
+
+Stable stays **1.8.4**. This is not Latest and needs an explicit pin or
+`--pre`:
+
+```bash
+python -m pip install --pre connectonion==1.8.5b4
+co --version
+```
+
+## Change
+
+**`co browser install-onion` says pip declined by policy, instead of reporting
+an exit code.** On a Mac with `co` in Homebrew's `python@3.13`, the documented
+route to the paid engine dead-ended:
+
+```
+BrowserEngineError: onionwright_missing: Run `co browser install-onion`
+→ Could not install Onionwright: pip could not install Onionwright (exit 1).
+```
+
+pip had not failed. It had **declined** — `externally-managed-environment`,
+PEP 668 — and had named the override itself, sixteen lines above our line. But
+the line a reader ends on, and the only line an agent parses, said `exit 1`,
+which points at the download, the release feed or the credentials. All were
+fine. PEP 668 is the default for Homebrew Python and most distro Pythons, so
+this is the ordinary case, not an exotic one.
+
+pip's output is now captured — an exit code alone cannot tell a policy refusal
+from a real failure — and printed back either way, because the upstream text is
+the evidence. On a policy refusal:
+
+```
+Could not install Onionwright: this Python is externally managed, so pip will not write to it.
+
+  This interpreter:  /usr/local/opt/python@3.13/bin/python3.13
+
+Install into it anyway — the right answer when `co` itself lives there, because
+Onionwright has to be importable by this same interpreter:
+  co browser install-onion --break-system-packages
+
+Or put both in a virtualenv, where nothing needs the flag:
+  python3 -m venv ~/.co/venv
+  ~/.co/venv/bin/pip install --pre connectonion
+```
+
+The interpreter path is named because it is what the reader has to decide about
+and it is not guessable — `co` may be one of four Pythons on a machine.
+
+`--break-system-packages` is new, opt-in, and spelled like pip's own. It is not
+passed automatically: PEP 668's marker is a person or an OS saying *I manage
+this one*, and overriding that silently inside an unrelated command is the kind
+of help that surfaces weeks later as a broken package manager. It is also not
+re-offered when it was already used — suggesting a flag that just failed is the
+same loop `b3` removed from the engine-pin refusal.
+
+## Known limits
+
+Unchanged from `b3`: the no-loss-across-a-reconnect gate in #1462 has not
+passed, which is why stable is still 1.8.4. A chat message can command the agent
+and there is no sender allowlist until 1.9. A browser that exits on its own
+takes the tab registry with it (#1513, targeted 1.8.6).
+
+**The paid engine does not run on macOS x86_64**, and that is not a client bug:
+there is no `darwin-x86_64` object in the production release bucket, so
+`co browser --engine wtf` correctly answers `artifact_unavailable` and points at
+system Chrome. A build exists, staged 2026-09-04 and never promoted because the
+native gate failed that day — identically for arm64, which was re-run on the 5th
+and passed. Release-operations work in the `browser` repo, not here.
+
+## Verification
+
+The fix was checked on the machine that produced the original message, not only
+in tests: run `install-onion`, read the new refusal, then run the command the
+refusal prints — Onionwright 0.0.14 installs. Printing a command is a promise it
+works, and the only way to keep it is to run it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.8.5b3"
+version = "1.8.5b4"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.8.5b3"
+version = "1.8.5b4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
One fix on top of `1.8.5b3` (#1516 / #1517), found by installing `b3` on the old
Intel Mac and following its own instructions.

## What ships

`co browser install-onion` reported `pip could not install Onionwright (exit 1)`
when pip had **declined by policy** — PEP 668's `externally-managed-environment`,
the default on Homebrew and most distro Pythons — and had named the override
itself sixteen lines earlier. pip's output is captured now (an exit code alone
cannot tell a policy refusal from a real failure) and printed back either way; a
policy refusal names the interpreter being decided about and both routes past it.
`--break-system-packages` is new, opt-in, and not re-offered once used.

## Version surface

`_version.py`, `pyproject.toml`, `VERSIONING.md` (candidate section + history),
`docs/releases.md`, `docs/releases/1.8.5b4.md`, `uv.lock`.

The Design Journal post for the fix shipped with #1517, so this PR carries no
new one — hence the `no-blog` label on a release that is only version surface.

## Known limits, newly recorded

The release notes now state plainly that **the paid engine does not run on
macOS x86_64**, and that this is not a client bug: there is no `darwin-x86_64`
object in the production release bucket, so `co browser --engine wtf` correctly
answers `artifact_unavailable`. A build exists, staged 2026-09-04, never
promoted because the native gate failed that day — identically for arm64, which
was re-run on the 5th and passed 7/7. Release-operations work in the `browser`
repo, not here.

Unchanged: the #1462 reconnect gate has not passed (stable stays 1.8.4), no
sender allowlist until 1.9, and #1513 (a browser that exits on its own takes the
tab registry with it) targets 1.8.6.

## Verification

`b3` itself was verified from PyPI against a live paid WTF Browser session
before this branch was cut. This fix was verified on the machine that produced
the original message: run `install-onion`, read the new refusal, run the command
it prints, get Onionwright 0.0.14. The hand-patched files were reverted and that
machine is back on stock.

58 version-consistency tests pass; 1454 browser/onion/install unit tests passed
on #1517.

**Proposed target version:** 1.8.5b4
**Estimated release window:** today, 2026-09-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3VJDT8R3Sr69BzfEBxT6
